### PR TITLE
[FLINK-29896] hotfix for build failure due to yaml literal typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,10 @@ jobs:
           maven-version: 3.8.5
 
       - name: Compile and test flink-connector-dynamodb
-        run: mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
-          -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
-          | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+        run: |
+          mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
+            | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
 
       - name: Check licensing
         run: |


### PR DESCRIPTION
This is a hotfix for build failure caused by typo in yaml multiline literal.