### PR TITLE
[FLINK-29905][Connectors/AWS] Migrate DynamoDB parent pom 

### DIFF
--- a/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-dynamodb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-dynamodb-parent</artifactId>
+        <artifactId>flink-connector-aws</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/flink-sql-connector-dynamodb/pom.xml
+++ b/flink-sql-connector-dynamodb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-connector-dynamodb-parent</artifactId>
+		<artifactId>flink-connector-aws</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@ under the License.
 		<relativePath/>
 	</parent>
 
-	<artifactId>flink-connector-dynamodb-parent</artifactId>
+	<artifactId>flink-connector-aws</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 
-	<name>Flink : Connectors : Amazon DynamoDB Parent</name>
+	<name>Flink : Connectors : AWS : Parent</name>
 	<packaging>pom</packaging>
 	<url>https://flink.apache.org</url>
 	<inceptionYear>2022</inceptionYear>
@@ -47,9 +47,9 @@ under the License.
 	</licenses>
 
 	<scm>
-		<url>https://github.com/apache/flink-connector-dynamodb</url>
-		<connection>git@github.com:apache/flink-connector-dynamodb.git</connection>
-		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-dynamodb.git</developerConnection>
+		<url>https://github.com/apache/flink-connector-aws</url>
+		<connection>git@github.com:apache/flink-connector-aws.git</connection>
+		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-aws.git</developerConnection>
 	</scm>
 
 	<pluginRepositories>
@@ -136,7 +136,7 @@ under the License.
 							<property>rootDir</property>
 							<project>
 								<groupId>org.apache.flink</groupId>
-								<artifactId>flink-connector-dynamodb-parent</artifactId>
+								<artifactId>flink-connector-aws</artifactId>
 							</project>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

Migrate DynamoDB parent pom to AWS connectors

## Brief change log

* Rename module name and SCM references

## Verifying this change

Full build locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
