### PR TITLE
[FLINK-29444][Connectors/AWS] Syncing parent pom to elasticsearch in prep for release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/releasing/shared"]
+	path = tools/releasing/shared
+	url = https://github.com/apache/flink-connector-shared-utils

--- a/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-dynamodb/pom.xml
@@ -25,9 +25,8 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-aws</artifactId>
+        <artifactId>flink-connector-aws-parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>flink-connector-dynamodb</artifactId>
@@ -80,13 +79,6 @@ under the License.
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils</artifactId>
-			<version>${flink.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${flink.version}</version>
 			<type>test-jar</type>
@@ -114,7 +106,5 @@ under the License.
 			<version>${flink.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
-
 </project>

--- a/flink-sql-connector-dynamodb/pom.xml
+++ b/flink-sql-connector-dynamodb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-connector-aws</artifactId>
+		<artifactId>flink-connector-aws-parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -18,145 +18,203 @@ specific language governing permissions and limitations
 under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-connectors</artifactId>
-		<version>1.15.2</version>
-		<relativePath/>
-	</parent>
+    <parent>
+        <groupId>io.github.zentol.flink</groupId>
+        <artifactId>flink-connector-parent</artifactId>
+        <version>1.0</version>
+    </parent>
 
-	<artifactId>flink-connector-aws</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+    <groupId>org.apache.flink</groupId>
+    <artifactId>flink-connector-aws-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
 
-	<name>Flink : Connectors : AWS : Parent</name>
-	<packaging>pom</packaging>
-	<url>https://flink.apache.org</url>
-	<inceptionYear>2022</inceptionYear>
+    <name>Flink : Connectors : AWS : Parent</name>
+    <packaging>pom</packaging>
+    <url>https://flink.apache.org</url>
+    <inceptionYear>2022</inceptionYear>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<scm>
-		<url>https://github.com/apache/flink-connector-aws</url>
-		<connection>git@github.com:apache/flink-connector-aws.git</connection>
-		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-aws.git</developerConnection>
-	</scm>
+    <scm>
+        <url>https://github.com/apache/flink-connector-aws</url>
+        <connection>git@github.com:apache/flink-connector-aws.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-aws.git</developerConnection>
+    </scm>
 
-	<pluginRepositories>
-		<pluginRepository>
-			<!-- Allows exec-maven-plugin to resolve snapshot plugin dependencies -->
-			<id>apache.snapshots.https</id>
-			<name>${distMgmtSnapshotsName}</name>
-			<url>${distMgmtSnapshotsUrl}</url>
-		</pluginRepository>
-	</pluginRepositories>
+    <properties>
+        <aws.sdk.version>2.17.247</aws.sdk.version>
+        <flink.version>1.15.2</flink.version>
+        <flink.shaded.version>15.0</flink.shaded.version>
 
-	<properties>
-		<aws.sdk.version>2.17.247</aws.sdk.version>
-		<flink.version>1.15.2</flink.version>
-	</properties>
+        <junit5.version>5.8.1</junit5.version>
+        <assertj.version>3.21.0</assertj.version>
+        <archunit.version>0.22.0</archunit.version>
+        <testcontainers.version>1.17.2</testcontainers.version>
+        <mockito.version>2.21.0</mockito.version>
+        <japicmp.skip>false</japicmp.skip>
+        <japicmp.referenceVersion>1.15.0</japicmp.referenceVersion>
 
-	<modules>
-		<module>flink-connector-dynamodb</module>
-		<module>flink-sql-connector-dynamodb</module>
-	</modules>
+        <flink.parent.artifactId>flink-connector-aws-parent</flink.parent.artifactId>
+    </properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>bom</artifactId>
-				<version>${aws.sdk.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
+    <modules>
+        <module>flink-connector-dynamodb</module>
+        <module>flink-sql-connector-dynamodb</module>
+    </modules>
 
-			<dependency>
-				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-test-utils-junit</artifactId>
-				<version>${project.parent.version}</version>
-				<scope>test</scope>
-			</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-force-shading</artifactId>
+            <version>${flink.shaded.version}</version>
+        </dependency>
 
-		</dependencies>
-	</dependencyManagement>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.1.0</version>
-				<inherited>false</inherited>
-				<executions>
-					<execution>
-						<id>check-license</id>
-						<!-- manually called -->
-						<phase>none</phase>
-						<goals>
-							<goal>java</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<mainClass>org.apache.flink.tools.ci.licensecheck.LicenseChecker</mainClass>
-					<includePluginDependencies>true</includePluginDependencies>
-					<includeProjectDependencies>false</includeProjectDependencies>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.flink</groupId>
-						<artifactId>flink-ci-tools</artifactId>
-						<version>1.16-SNAPSHOT</version>
-					</dependency>
-				</dependencies>
-			</plugin>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-			<plugin>
-				<!-- Override directory for parent project -->
-				<groupId>org.commonjava.maven.plugins</groupId>
-				<artifactId>directory-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>directories</id>
-						<goals>
-							<goal>directory-of</goal>
-						</goals>
-						<configuration>
-							<property>rootDir</property>
-							<project>
-								<groupId>org.apache.flink</groupId>
-								<artifactId>flink-connector-aws</artifactId>
-							</project>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>dependency-convergence</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<skip>false</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-test-utils-junit</artifactId>
+                <version>${flink.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit5.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <inherited>false</inherited>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.flink</groupId>
+                        <artifactId>flink-ci-tools</artifactId>
+                        <version>${flink.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <!-- activate API compatibility checks -->
+                <groupId>io.github.zentol.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <inherited>false</inherited>
+            </plugin>
+
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

Prep for connector release

## Brief change log

- Syncing parent pom to elasticsearch in prep for release
- Adding git submodule for connector release scripts

## Verifying this change

Build locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
