### PR TITLE
[FLINK-30098] Migrate DynamoDb unit tests to JUnit5

### DIFF
--- a/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/util/PrimaryKeyBuilder.java
+++ b/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/util/PrimaryKeyBuilder.java
@@ -57,11 +57,7 @@ public class PrimaryKeyBuilder {
 
             if (keyAttribute == null) {
                 throw new InvalidRequestException(
-                        "Request "
-                                + request.toString()
-                                + " does not contain partition key "
-                                + keyName
-                                + ".");
+                        "Request " + request + " does not contain partition key " + keyName + ".");
             }
 
             String keyValue = getKeyValue(keyAttribute);
@@ -69,7 +65,7 @@ public class PrimaryKeyBuilder {
             if (StringUtils.isBlank(keyValue)) {
                 throw new InvalidRequestException(
                         "Partition key or sort key attributes require non-empty values. Request "
-                                + request.toString()
+                                + request
                                 + " contains empty key "
                                 + keyName
                                 + ".");
@@ -109,19 +105,17 @@ public class PrimaryKeyBuilder {
                 return request.putRequest().item();
             } else {
                 throw new InvalidRequestException(
-                        "PutItemRequest " + request.toString() + " does not contain request items");
+                        "PutItemRequest " + request + " does not contain request items.");
             }
         } else if (request.deleteRequest() != null) {
             if (request.deleteRequest().hasKey()) {
                 return request.deleteRequest().key();
             } else {
                 throw new InvalidRequestException(
-                        "DeleteItemRequest "
-                                + request.toString()
-                                + " does not contain request key");
+                        "DeleteItemRequest " + request + " does not contain request key.");
             }
         } else {
-            throw new InvalidRequestException("Empty write request" + request.toString());
+            throw new InvalidRequestException("Empty write request" + request);
         }
     }
 }

--- a/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtilTest.java
+++ b/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtilTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.connector.dynamodb.sink.DynamoDbWriteRequestType;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 


### PR DESCRIPTION
## What is the purpose of the change
Migrate DynamoDb unit tests to JUnit5

## Verifying this change
Ran unit tests locally and verified all passed.

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
* The S3 file system connector: no

## Documentation
* Does this pull request introduce a new feature? no
* If yes, how is the feature documented? n/a

