### PR TITLE
[FLINK-29900][Connectors/DynamoDB] Make configurations for DynamoDB T…

### DIFF
--- a/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConfiguration.java
+++ b/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConfiguration.java
@@ -20,6 +20,11 @@ package org.apache.flink.connector.dynamodb.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.aws.table.util.AsyncClientOptionsUtils;
+import org.apache.flink.connector.base.table.sink.options.AsyncSinkConfigurationValidator;
+
+import java.util.Map;
+import java.util.Properties;
 
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.FAIL_ON_ERROR;
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.TABLE_NAME;
@@ -28,17 +33,31 @@ import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions
 @Internal
 public class DynamoDbConfiguration {
 
-    private final ReadableConfig config;
+    private final Map<String, String> rawTableOptions;
+    private final ReadableConfig tableOptions;
+    private final AsyncSinkConfigurationValidator asyncSinkConfigurationValidator;
+    private final AsyncClientOptionsUtils asyncClientOptionsUtils;
 
-    public DynamoDbConfiguration(ReadableConfig config) {
-        this.config = config;
+    public DynamoDbConfiguration(Map<String, String> rawTableOptions, ReadableConfig tableOptions) {
+        this.rawTableOptions = rawTableOptions;
+        this.tableOptions = tableOptions;
+        this.asyncSinkConfigurationValidator = new AsyncSinkConfigurationValidator(tableOptions);
+        this.asyncClientOptionsUtils = new AsyncClientOptionsUtils(rawTableOptions);
     }
 
     public String getTableName() {
-        return config.get(TABLE_NAME);
+        return tableOptions.get(TABLE_NAME);
     }
 
     public boolean getFailOnError() {
-        return config.get(FAIL_ON_ERROR);
+        return tableOptions.get(FAIL_ON_ERROR);
+    }
+
+    public Properties getAsyncSinkProperties() {
+        return asyncSinkConfigurationValidator.getValidatedConfigurations();
+    }
+
+    public Properties getSinkClientProperties() {
+        return asyncClientOptionsUtils.getValidatedConfigurations();
     }
 }


### PR DESCRIPTION
…able API sink follow the standard AWS and HTTP client convention

## What is the purpose of the change
Update DynamoDB Table API table configurations to follow the same convention used by Kinesis connector and Firehose connector for AWS and HTTP client configs.

In particular:
- Table API's `aws.credentials.*` maps to `aws.credentials.provider.*`
- Table API's `sink.http-client.max-concurrency` maps to `aws.http-client.max-concurrency`
- Table API's `sink.http-client.read-timeout` maps to `aws.http-client.read-timeout`
- Table API's `sink.http-client.protocol.version` maps to `aws.http.protocol.version`

## Verifying this change
- Unit tests
- Manual tests
    - Built locally and verified that the configurations are passed into the `DynamoDbSink`

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
* The S3 file system connector: no

## Documentation
* Does this pull request introduce a new feature? no
* If yes, how is the feature documented? n/a

