### PR TITLE
[FLINK-29908] Externalize and configure E2E tests for Firehose/Kinesis connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       FLINK_URL: https://dlcdn.apache.org/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
       MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
     steps:
@@ -49,13 +50,30 @@ jobs:
         with:
           maven-version: 3.8.5
 
+      - name: Create cache dirs
+        run: mkdir -p ${{ env.FLINK_CACHE_DIR }}
+
+      - name: Cache Flink binary
+        if: ${{ inputs.cache_flink_binary == 'true' }}
+        uses: actions/cache@v3
+        id: cache-flink
+        with:
+          path: ${{ env.FLINK_CACHE_DIR }}
+          key: ${{ inputs.flink_url }}
+
+      - name: Download Flink binary
+        working-directory: ${{ env.FLINK_CACHE_DIR }}
+        if: steps.cache-flink.outputs.cache-hit != 'true'
+        run: wget -q -c ${{ inputs.flink_url }} -O - | tar -xz
+
       - name: Compile and test flink-connector-dynamodb
         run: |
           set -o pipefail
           
           mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
-            -Dflink.version=${{ matrix.flink }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+            -Dflink.version=${{ matrix.flink }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }} \
+            -Prun-end-to-end-tests -DdistDir=${{ env.FLINK_CACHE_DIR }}/flink-${{ matrix.flink }} \
 
       - name: Check licensing
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-name: Build flink-connector-dynamodb
+name: Build flink-connector-aws
 on: [push, pull_request]
 jobs:
   compile_and_test:
@@ -66,14 +66,27 @@ jobs:
         if: steps.cache-flink.outputs.cache-hit != 'true'
         run: wget -q -c ${{ env.FLINK_URL }} -O - | tar -xz
 
-      - name: Compile and test flink-connector-dynamodb
+      - name: Compile and test flink-connector-aws
         run: |
           set -o pipefail
           
           mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
-            -Dflink.version=${{ matrix.flink }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }} \
+            -Dflink.version=${{ matrix.flink }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }} 
+
+      - name: Run e2e tests
+        run: |
+          set -o pipefail
+          
+          cd flink-connector-aws-e2e-tests
+          
+          mvn clean verify ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
+            -Dflink.version=${{ matrix.flink }}  \
             -Prun-end-to-end-tests -DdistDir=${{ env.FLINK_CACHE_DIR }}/flink-${{ matrix.flink }} \
+            | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+          
+          mvn clean
 
       - name: Check licensing
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,12 @@ jobs:
         id: cache-flink
         with:
           path: ${{ env.FLINK_CACHE_DIR }}
-          key: ${{ inputs.flink_url }}
+          key: ${{ env.FLINK_URL }}
 
       - name: Download Flink binary
         working-directory: ${{ env.FLINK_CACHE_DIR }}
         if: steps.cache-flink.outputs.cache-hit != 'true'
-        run: wget -q -c ${{ inputs.flink_url }} -O - | tar -xz
+        run: wget -q -c ${{ env.FLINK_URL }} -O - | tar -xz
 
       - name: Compile and test flink-connector-dynamodb
         run: |

--- a/flink-connector-aws-e2e-tests/README.md
+++ b/flink-connector-aws-e2e-tests/README.md
@@ -1,0 +1,14 @@
+# Apache Flink AWS Connectors end-to-end tests
+
+To run the end-to-end tests you will need a `flink-dist`. You can build Flink from source or download 
+from https://dist.apache.org/repos/dist/release/flink. For example, download
+[flink-1.16.0-bin-scala_2.12.tgz](https://dist.apache.org/repos/dist/release/flink/flink-1.16.0/flink-1.16.0-bin-scala_2.12.tgz)
+and extract, then find `flink-dist-1.16.0.jar` in the `lib` folder.
+
+The end-to-end tests are disabled by default, to run them you can use the `run-end-to-end-tests` maven profile.
+
+Example command to run end-to-end tests:
+```
+mvn clean verify -Prun-end-to-end-tests -DdistDir=<path-to-dist>/flink-1.16.0/lib/flink-dist-1.16.0.jar 
+```
+

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
@@ -30,7 +30,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flink-connector-aws-kinesis-firehose-e2e-tests</artifactId>
-    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Firehose e2e tests</name>
+    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Firehose</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>4.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-aws-kinesis-firehose-e2e-tests</artifactId>
+    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Firehose e2e tests</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-aws-kinesis-firehose</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-aws-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-sql-connector-aws-kinesis-firehose</artifactId>
+                            <version>${project.version}</version>
+                            <destFileName>sql-kinesis-firehose.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+                        </artifactItem>
+                    </artifactItems>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Required for Kinesalite. -->
+                        <!-- Including shaded and non-shaded conf to support test running from Maven and IntelliJ -->
+                        <com.amazonaws.sdk.disableCbor>true</com.amazonaws.sdk.disableCbor>
+                        <com.amazonaws.sdk.disableCertChecking>true</com.amazonaws.sdk.disableCertChecking>
+                        <org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCbor>true
+                        </org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCbor>
+                        <org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCertChecking>true
+                        </org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCertChecking>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.firehose.table.test;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.aws.testutils.LocalstackContainer;
+import org.apache.flink.connector.testframe.container.FlinkContainers;
+import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.test.resources.ResourceTestUtils;
+import org.apache.flink.test.util.SQLJobSubmission;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createBucket;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createHttpClient;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createIAMRole;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createIamClient;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createS3Client;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.listBucketObjects;
+import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.readObjectsFromS3Bucket;
+import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehoseTestUtils.createDeliveryStream;
+import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehoseTestUtils.createFirehoseClient;
+
+/** End to End test for Kinesis Firehose Table sink API. */
+public class KinesisFirehoseTableITTest extends TestLogger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseTableITTest.class);
+
+    private static final String ROLE_NAME = "super-role";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/" + ROLE_NAME;
+    private static final String BUCKET_NAME = "s3-firehose";
+    private static final String STREAM_NAME = "s3-stream";
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
+
+    private final Path sqlConnectorFirehoseJar = ResourceTestUtils.getResource(".*firehose.jar");
+
+    private SdkHttpClient httpClient;
+    private S3Client s3Client;
+    private FirehoseClient firehoseClient;
+    private IamClient iamClient;
+
+    private static final int NUM_ELEMENTS = 5;
+    private static final Network network = Network.newNetwork();
+
+    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+
+    @ClassRule
+    public static LocalstackContainer mockFirehoseContainer =
+            new LocalstackContainer(DockerImageName.parse(DockerImageVersions.LOCALSTACK))
+                    .withNetwork(network)
+                    .withNetworkAliases("localstack");
+
+    public static final TestcontainersSettings TESTCONTAINERS_SETTINGS =
+            TestcontainersSettings.builder()
+                    .environmentVariable("AWS_CBOR_DISABLE", "1")
+                    .environmentVariable(
+                            "FLINK_ENV_JAVA_OPTS",
+                            "-Dorg.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCertChecking -Daws.cborEnabled=false")
+                    .network(network)
+                    .logger(LOG)
+                    .dependsOn(mockFirehoseContainer)
+                    .build();
+
+    public static final FlinkContainers FLINK =
+            FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
+
+    @Before
+    public void setup() {
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+
+        httpClient = createHttpClient();
+
+        s3Client = createS3Client(mockFirehoseContainer.getEndpoint(), httpClient);
+        firehoseClient = createFirehoseClient(mockFirehoseContainer.getEndpoint(), httpClient);
+        iamClient = createIamClient(mockFirehoseContainer.getEndpoint(), httpClient);
+
+        LOG.info("1 - Creating the bucket for Firehose to deliver into...");
+        createBucket(s3Client, BUCKET_NAME);
+
+        LOG.info("2 - Creating the IAM Role for Firehose to write into the s3 bucket...");
+        createIAMRole(iamClient, ROLE_NAME);
+
+        LOG.info("3 - Creating the Firehose delivery stream...");
+        createDeliveryStream(STREAM_NAME, BUCKET_NAME, ROLE_ARN, firehoseClient);
+
+        LOG.info("Done setting up the localstack.");
+    }
+
+    @BeforeClass
+    public static void setupFlink() throws Exception {
+        FLINK.start();
+    }
+
+    @AfterClass
+    public static void stopFlink() {
+        FLINK.stop();
+    }
+
+    @After
+    public void teardown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+
+        s3Client.close();
+        firehoseClient.close();
+        iamClient.close();
+        httpClient.close();
+    }
+
+    @Test
+    public void testTableApiSink() throws Exception {
+        List<Order> orderList = getTestOrders();
+
+        executeSqlStatements(readSqlFile("send-orders.sql"));
+        List<Order> orders = readFromS3();
+        Assertions.assertThat(orders).containsAll(orderList);
+    }
+
+    private List<Order> getTestOrders() {
+        return IntStream.range(1, NUM_ELEMENTS)
+                .mapToObj(this::getOrderWithOffset)
+                .collect(Collectors.toList());
+    }
+
+    private Order getOrderWithOffset(int offset) {
+        return new Order(String.valueOf((char) ('A' + offset - 1)), offset);
+    }
+
+    private void executeSqlStatements(final List<String> sqlLines) throws Exception {
+        FLINK.submitSQLJob(
+                new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+                        .addJars(sqlConnectorFirehoseJar)
+                        .build());
+    }
+
+    private List<String> readSqlFile(final String resourceName) throws Exception {
+        return Files.readAllLines(Paths.get(getClass().getResource("/" + resourceName).toURI()));
+    }
+
+    private List<Order> readFromS3() throws Exception {
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        List<S3Object> ordersObjects;
+        List<Order> orders;
+        do {
+            Thread.sleep(1000);
+            ordersObjects = listBucketObjects(s3Client, BUCKET_NAME);
+            orders =
+                    readObjectsFromS3Bucket(
+                            s3Client,
+                            ordersObjects,
+                            BUCKET_NAME,
+                            responseBytes ->
+                                    fromJson(
+                                            new String(responseBytes.asByteArrayUnsafe()),
+                                            Order.class));
+        } while (deadline.hasTimeLeft() && orders.size() < NUM_ELEMENTS);
+
+        return orders;
+    }
+
+    private <T> T fromJson(final String json, final Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(String.format("Failed to deserialize json: %s", json), e);
+        }
+    }
+
+    /** POJO model class for sending and receiving records on Kinesis during e2e test. */
+    public static class Order {
+        private final String code;
+        private final int quantity;
+
+        @JsonCreator
+        public Order(
+                @JsonProperty("code") final String code, @JsonProperty("quantity") int quantity) {
+            this.code = code;
+            this.quantity = quantity;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Order order = (Order) o;
+            return quantity == order.quantity && Objects.equals(code, order.code);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(code, quantity);
+        }
+
+        @Override
+        public String toString() {
+            return "Order{" + "code='" + code + '\'' + ", quantity=" + quantity + '}';
+        }
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/resources/send-orders.sql
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/resources/send-orders.sql
@@ -1,0 +1,36 @@
+--/*
+-- * Licensed to the Apache Software Foundation (ASF) under one
+-- * or more contributor license agreements.  See the NOTICE file
+-- * distributed with this work for additional information
+-- * regarding copyright ownership.  The ASF licenses this file
+-- * to you under the Apache License, Version 2.0 (the
+-- * "License"); you may not use this file except in compliance
+-- * with the License.  You may obtain a copy of the License at
+-- *
+-- *     http://www.apache.org/licenses/LICENSE-2.0
+-- *
+-- * Unless required by applicable law or agreed to in writing, software
+-- * distributed under the License is distributed on an "AS IS" BASIS,
+-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- * See the License for the specific language governing permissions and
+-- * limitations under the License.
+-- */
+
+CREATE TABLE orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'firehose',
+  'delivery-stream' = 's3-stream',
+  'aws.region' = 'ap-southeast-1',
+  'aws.endpoint' = 'https://localstack:4566',
+  'aws.credentials.provider' = 'BASIC',
+  'aws.credentials.basic.accesskeyid' = 'accessKeyId',
+  'aws.credentials.basic.secretkey' = 'secretAccessKey',
+  'aws.trust.all.certificates' = 'true',
+  'sink.http-client.protocol.version' = 'HTTP1_1',
+  'sink.batch.max-size' = '1',
+  'format' = 'json'
+);
+
+INSERT INTO orders VALUES ('A',1),('B',2),('C',3),('D',4),('E',5);

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
@@ -29,64 +29,53 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flink-connector-aws-kinesis-firehose-e2e-tests</artifactId>
-    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Firehose e2e tests</name>
+    <artifactId>flink-connector-aws-kinesis-streams-e2e-tests</artifactId>
+    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Streams e2e tests</name>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-aws-kinesis-firehose</artifactId>
-            <version>${project.version}</version>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
             <scope>test</scope>
-            <type>test-jar</type>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-base</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.typesafe.netty</groupId>
+                    <artifactId>netty-reactive-streams-http</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-            <version>${flink.version}</version>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.typesafe.netty</groupId>
+                    <artifactId>netty-reactive-streams-http</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>iam</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -105,9 +94,9 @@
                     <artifactItems>
                         <artifactItem>
                             <groupId>org.apache.flink</groupId>
-                            <artifactId>flink-sql-connector-aws-kinesis-firehose</artifactId>
+                            <artifactId>flink-sql-connector-aws-kinesis-streams</artifactId>
                             <version>${project.version}</version>
-                            <destFileName>sql-kinesis-firehose.jar</destFileName>
+                            <destFileName>sql-kinesis-streams.jar</destFileName>
                             <type>jar</type>
                             <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
                         </artifactItem>
@@ -124,10 +113,10 @@
                         <!-- Including shaded and non-shaded conf to support test running from Maven and IntelliJ -->
                         <com.amazonaws.sdk.disableCbor>true</com.amazonaws.sdk.disableCbor>
                         <com.amazonaws.sdk.disableCertChecking>true</com.amazonaws.sdk.disableCertChecking>
-                        <org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCbor>true
-                        </org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCbor>
-                        <org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCertChecking>true
-                        </org.apache.flink.kinesis-firehose.shaded.com.amazonaws.sdk.disableCertChecking>
+                        <org.apache.flink.kinesis-streams.shaded.com.amazonaws.sdk.disableCbor>true
+                        </org.apache.flink.kinesis-streams.shaded.com.amazonaws.sdk.disableCbor>
+                        <org.apache.flink.kinesis-streams.shaded.com.amazonaws.sdk.disableCertChecking>true
+                        </org.apache.flink.kinesis-streams.shaded.com.amazonaws.sdk.disableCertChecking>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/pom.xml
@@ -30,7 +30,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flink-connector-aws-kinesis-streams-e2e-tests</artifactId>
-    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Streams e2e tests</name>
+    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Streams v2</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.table.test;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.connector.testframe.container.FlinkContainers;
+import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.connectors.kinesis.testutils.KinesaliteContainer;
+import org.apache.flink.test.resources.ResourceTestUtils;
+import org.apache.flink.test.util.SQLJobSubmission;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+import software.amazon.awssdk.services.kinesis.model.StreamStatus;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/** End-to-end test for Kinesis Streams Table API Sink using Kinesalite. */
+public class KinesisStreamsTableApiIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KinesisStreamsTableApiIT.class);
+
+    private static final String ORDERS_STREAM = "orders";
+    private static final String INTER_CONTAINER_KINESALITE_ALIAS = "kinesalite";
+    private static final String DEFAULT_FIRST_SHARD_NAME = "shardId-000000000000";
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
+
+    private SdkHttpClient httpClient;
+    private KinesisClient kinesisClient;
+
+    private final Path sqlConnectorKinesisJar =
+            ResourceTestUtils.getResource(".*kinesis-streams.jar");
+    private static final Network network = Network.newNetwork();
+
+    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+
+    @ClassRule
+    public static final KinesaliteContainer KINESALITE =
+            new KinesaliteContainer(DockerImageName.parse(DockerImageVersions.KINESALITE))
+                    .withNetwork(network)
+                    .withNetworkAliases(INTER_CONTAINER_KINESALITE_ALIAS);
+
+    public static final TestcontainersSettings TESTCONTAINERS_SETTINGS =
+            TestcontainersSettings.builder()
+                    .environmentVariable("AWS_CBOR_DISABLE", "1")
+                    .environmentVariable(
+                            "FLINK_ENV_JAVA_OPTS",
+                            "-Dorg.apache.flink.kinesis-streams.shaded.com.amazonaws.sdk.disableCertChecking -Daws.cborEnabled=false")
+                    .network(network)
+                    .logger(LOGGER)
+                    .dependsOn(KINESALITE)
+                    .build();
+
+    public static final FlinkContainers FLINK =
+            FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
+
+    @BeforeClass
+    public static void setupFlink() throws Exception {
+        FLINK.start();
+    }
+
+    @AfterClass
+    public static void stopFlink() {
+        FLINK.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+        httpClient = AWSServicesTestUtils.createHttpClient();
+        kinesisClient = KINESALITE.createHostClient(httpClient);
+        prepareStream(ORDERS_STREAM);
+    }
+
+    @After
+    public void teardown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        AWSGeneralUtil.closeResources(httpClient, kinesisClient);
+    }
+
+    @Test
+    public void testTableApiSourceAndSink() throws Exception {
+        executeSqlStatements(readSqlFile("send-orders.sql"));
+        List<Order> expected =
+                ImmutableList.of(
+                        new Order("A", 10),
+                        new Order("B", 12),
+                        new Order("C", 14),
+                        new Order("D", 16),
+                        new Order("E", 18));
+        // result order is not guaranteed
+        List<Order> result = readAllOrdersFromKinesis();
+        Assertions.assertThat(result).containsAll(expected);
+    }
+
+    private void prepareStream(String streamName) throws Exception {
+        final RateLimiter rateLimiter =
+                RateLimiterBuilder.newBuilder()
+                        .withRate(1, SECONDS)
+                        .withConstantThroughput()
+                        .build();
+
+        kinesisClient.createStream(
+                CreateStreamRequest.builder().streamName(streamName).shardCount(1).build());
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        while (!rateLimiter.getWhenReady(() -> streamExists(streamName))) {
+            if (deadline.isOverdue()) {
+                throw new RuntimeException("Failed to create stream within time");
+            }
+        }
+    }
+
+    private boolean streamExists(final String streamName) {
+        try {
+            return kinesisClient
+                            .describeStream(
+                                    DescribeStreamRequest.builder().streamName(streamName).build())
+                            .streamDescription()
+                            .streamStatus()
+                    == StreamStatus.ACTIVE;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private List<Order> readAllOrdersFromKinesis() throws Exception {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
+        List<Order> orders;
+        do {
+            orders =
+                    readMessagesFromStream(
+                            recordBytes -> fromJson(new String(recordBytes), Order.class));
+
+        } while (deadline.hasTimeLeft() && orders.size() < 5);
+
+        return orders;
+    }
+
+    private void executeSqlStatements(final List<String> sqlLines) throws Exception {
+        FLINK.submitSQLJob(
+                new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+                        .addJars(sqlConnectorKinesisJar)
+                        .build());
+    }
+
+    private List<String> readSqlFile(final String resourceName) throws Exception {
+        return Files.readAllLines(Paths.get(getClass().getResource("/" + resourceName).toURI()));
+    }
+
+    private <T> T fromJson(final String json, final Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Test Failure.", e);
+        }
+    }
+
+    private <T> List<T> readMessagesFromStream(Function<byte[], T> deserialiser) throws Exception {
+        String shardIterator =
+                kinesisClient
+                        .getShardIterator(
+                                GetShardIteratorRequest.builder()
+                                        .shardId(DEFAULT_FIRST_SHARD_NAME)
+                                        .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                        .streamName(KinesisStreamsTableApiIT.ORDERS_STREAM)
+                                        .build())
+                        .shardIterator();
+
+        List<Record> records =
+                kinesisClient
+                        .getRecords(
+                                GetRecordsRequest.builder().shardIterator(shardIterator).build())
+                        .records();
+        List<T> messages = new ArrayList<>();
+        records.forEach(record -> messages.add(deserialiser.apply(record.data().asByteArray())));
+        return messages;
+    }
+
+    /** POJO class for orders used by e2e test. */
+    public static class Order {
+        private final String code;
+        private final int quantity;
+
+        public Order(
+                @JsonProperty("code") final String code, @JsonProperty("quantity") int quantity) {
+            this.code = code;
+            this.quantity = quantity;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Order order = (Order) o;
+            return quantity == order.quantity && Objects.equals(code, order.code);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(code, quantity);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Order{code: %s, quantity: %d}", code, quantity);
+        }
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/resources/send-orders.sql
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/resources/send-orders.sql
@@ -1,0 +1,36 @@
+--/*
+-- * Licensed to the Apache Software Foundation (ASF) under one
+-- * or more contributor license agreements.  See the NOTICE file
+-- * distributed with this work for additional information
+-- * regarding copyright ownership.  The ASF licenses this file
+-- * to you under the Apache License, Version 2.0 (the
+-- * "License"); you may not use this file except in compliance
+-- * with the License.  You may obtain a copy of the License at
+-- *
+-- *     http://www.apache.org/licenses/LICENSE-2.0
+-- *
+-- * Unless required by applicable law or agreed to in writing, software
+-- * distributed under the License is distributed on an "AS IS" BASIS,
+-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- * See the License for the specific language governing permissions and
+-- * limitations under the License.
+-- */
+
+CREATE TABLE orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'kinesis',
+  'stream' = 'orders',
+  'aws.region' = 'us-east-1',
+  'aws.endpoint' = 'https://kinesalite:4567',
+  'aws.credentials.provider' = 'BASIC',
+  'aws.credentials.basic.accesskeyid' = 'access key',
+  'aws.credentials.basic.secretkey' ='secret key',
+  'aws.trust.all.certificates' = 'true',
+  'sink.http-client.protocol.version' = 'HTTP1_1',
+  'sink.batch.max-size' = '1',
+  'format' = 'json'
+);
+
+INSERT INTO orders VALUES ('A', 10),('B', 12),('C', 14),('D', 16),('E', 18);

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>4.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-kinesis-e2e-tests</artifactId>
+    <name>Flink : Connectors : AWS : E2E Tests : Amazon Kinesis Streams</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!--		<dependency>-->
+        <!--			<groupId>org.apache.flink</groupId>-->
+        <!--			<artifactId>flink-streaming-kafka-test-base</artifactId>-->
+        <!--			<version>${flink.version}</version>-->
+        <!--		</dependency>-->
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kinesis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kinesis</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-aws-base</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils-junit</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Use the shade plugin to build a fat jar for the Kinesis connector test -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fat-jar-kinesis-example</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.apache.flink.streaming.kinesis.test.KinesisExample</mainClass>
+                                </transformer>
+                            </transformers>
+                            <finalName>KinesisExample</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-sql-connector-kinesis</artifactId>
+                            <version>${project.version}</version>
+                            <destFileName>sql-kinesis.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+                        </artifactItem>
+                    </artifactItems>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Required for Kinesalite. -->
+                        <!-- Including shaded and non-shaded conf to support test running from Maven and IntelliJ -->
+                        <com.amazonaws.sdk.disableCbor>true</com.amazonaws.sdk.disableCbor>
+                        <com.amazonaws.sdk.disableCertChecking>true</com.amazonaws.sdk.disableCertChecking>
+                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>true
+                        </org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>
+                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>true
+                        </org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
+            <!-- Skip dependency convergence check because of guava version -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency-convergence</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/CustomWatermarkExtractor.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/CustomWatermarkExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+import javax.annotation.Nullable;
+
+/**
+ * A custom {@link AssignerWithPeriodicWatermarks}, that simply assumes that the input stream
+ * records are strictly ascending.
+ *
+ * <p>Flink also ships some built-in convenience assigners, such as the {@link
+ * BoundedOutOfOrdernessTimestampExtractor} and {@link AscendingTimestampExtractor}
+ */
+public class CustomWatermarkExtractor implements AssignerWithPeriodicWatermarks<Event> {
+
+    private static final long serialVersionUID = -742759155861320823L;
+
+    private long currentTimestamp = Long.MIN_VALUE;
+
+    @Override
+    public long extractTimestamp(Event event, long previousElementTimestamp) {
+        // the inputs are assumed to be of format (message,timestamp)
+        this.currentTimestamp = event.getTimestamp();
+        return event.getTimestamp();
+    }
+
+    @Nullable
+    @Override
+    public Watermark getCurrentWatermark() {
+        return new Watermark(
+                currentTimestamp == Long.MIN_VALUE ? Long.MIN_VALUE : currentTimestamp - 1);
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/Event.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/Event.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+/**
+ * This is a Java POJO, which Flink recognizes and will allow "by-name" field referencing when
+ * keying a {@link org.apache.flink.streaming.api.datastream.DataStream} of such a type.
+ */
+public class Event {
+
+    private String word;
+    private int frequency;
+    private long timestamp;
+
+    public Event() {}
+
+    public Event(String word, int frequency, long timestamp) {
+        this.word = word;
+        this.frequency = frequency;
+        this.timestamp = timestamp;
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    public int getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(int frequency) {
+        this.frequency = frequency;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public static Event fromString(String eventStr) {
+        String[] split = eventStr.split(",");
+        return new Event(split[0], Integer.valueOf(split[1]), Long.valueOf(split[2]));
+    }
+
+    @Override
+    public String toString() {
+        return word + "," + frequency + "," + timestamp;
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/EventSchema.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/EventSchema.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import java.io.IOException;
+
+/**
+ * The serialization schema for the {@link Event} type. This class defines how to transform a Kafka
+ * record's bytes to a {@link Event}, and vice-versa.
+ */
+public class EventSchema implements DeserializationSchema<Event>, SerializationSchema<Event> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public byte[] serialize(Event event) {
+        return event.toString().getBytes();
+    }
+
+    @Override
+    public Event deserialize(byte[] message) throws IOException {
+        return Event.fromString(new String(message));
+    }
+
+    @Override
+    public boolean isEndOfStream(Event nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<Event> getProducedType() {
+        return TypeInformation.of(Event.class);
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExample.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExample.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer;
+import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+
+import java.net.URL;
+import java.util.Properties;
+
+/**
+ * A simple example that shows how to read from and write to Kinesis. This will read String messages
+ * from the input topic, parse them into a POJO type {@link Event}, group by some key, and finally
+ * perform a rolling addition on each key for which the results are written back to another topic.
+ *
+ * <p>This example also demonstrates using a watermark assigner to generate per-partition watermarks
+ * directly in the Flink Kinesis consumer. For demonstration purposes, it is assumed that the String
+ * messages formatted as a (word,frequency,timestamp) tuple.
+ *
+ * <p>Example usage: --input-stream test-input --output-stream test-output --aws.endpoint
+ * https://localhost:4567 --flink.stream.initpos TRIM_HORIZON
+ */
+public class KinesisExample {
+    public static void main(String[] args) throws Exception {
+        // parse input arguments
+        final ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+        if (parameterTool.getNumberOfParameters() < 5) {
+            System.out.println(
+                    "Missing parameters!\n"
+                            + "Usage: Kafka --input-topic <topic> --output-topic <topic> "
+                            + "--bootstrap.servers <kafka brokers> "
+                            + "--group.id <some id>");
+            throw new Exception(
+                    "Missing parameters!\n"
+                            + "Usage: Kafka --input-topic <topic> --output-topic <topic> "
+                            + "--bootstrap.servers <kafka brokers> "
+                            + "--group.id <some id>");
+        }
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
+        env.enableCheckpointing(5000); // create a checkpoint every 5 seconds
+        env.getConfig()
+                .setGlobalJobParameters(
+                        parameterTool); // make parameters available in the web interface
+
+        String inputStream = parameterTool.getRequired("input-stream");
+        String outputStream = parameterTool.getRequired("output-stream");
+
+        FlinkKinesisConsumer<Event> consumer =
+                new FlinkKinesisConsumer<>(
+                        inputStream, new EventSchema(), parameterTool.getProperties());
+        consumer.setPeriodicWatermarkAssigner(new CustomWatermarkExtractor());
+
+        Properties producerProperties = new Properties(parameterTool.getProperties());
+        // producer needs region even when URL is specified
+        producerProperties.putIfAbsent(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+        // test driver does not deaggregate
+        producerProperties.putIfAbsent("AggregationEnabled", String.valueOf(false));
+
+        // KPL does not recognize endpoint URL..
+        String kinesisUrl = producerProperties.getProperty(ConsumerConfigConstants.AWS_ENDPOINT);
+        if (kinesisUrl != null) {
+            URL url = new URL(kinesisUrl);
+            producerProperties.put("KinesisEndpoint", url.getHost());
+            producerProperties.put("KinesisPort", Integer.toString(url.getPort()));
+            producerProperties.put("VerifyCertificate", "false");
+        }
+
+        FlinkKinesisProducer<Event> producer =
+                new FlinkKinesisProducer<>(new EventSchema(), producerProperties);
+        producer.setDefaultStream(outputStream);
+        producer.setDefaultPartition("fakePartition");
+
+        DataStream<Event> input =
+                env.addSource(consumer).keyBy("word").map(new RollingAdditionMapper());
+
+        input.addSink(producer);
+        env.execute();
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExampleTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExampleTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Test driver for {@link KinesisExample#main}. */
+public class KinesisExampleTest {
+    private static final Logger LOG = LoggerFactory.getLogger(KinesisExampleTest.class);
+
+    public static void main(String[] args) throws Exception {
+        LOG.info("System properties: {}", System.getProperties());
+        final ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+        String inputStream = parameterTool.getRequired("input-stream");
+        String outputStream = parameterTool.getRequired("output-stream");
+
+        KinesisPubsubClient pubsub = new KinesisPubsubClient(parameterTool.getProperties());
+        pubsub.createTopic(inputStream, 2, parameterTool.getProperties());
+        pubsub.createTopic(outputStream, 2, parameterTool.getProperties());
+
+        // The example job needs to start after streams are created and run in parallel to the
+        // validation logic.
+        // The thread that runs the job won't terminate, we don't have a job reference to cancel it.
+        // Once results are validated, the driver main thread will exit; job/cluster will be
+        // terminated from script.
+        final AtomicReference<Exception> executeException = new AtomicReference<>();
+        Thread executeThread =
+                new Thread(
+                        () -> {
+                            try {
+                                KinesisExample.main(args);
+                                // this message won't appear in the log,
+                                // job is terminated when shutting down cluster
+                                LOG.info("executed program");
+                            } catch (Exception e) {
+                                executeException.set(e);
+                            }
+                        });
+        executeThread.start();
+
+        // generate input
+        String[] messages = {
+            "elephant,5,45218",
+            "squirrel,12,46213",
+            "bee,3,51348",
+            "squirrel,22,52444",
+            "bee,10,53412",
+            "elephant,9,54867"
+        };
+        for (String msg : messages) {
+            pubsub.sendMessage(inputStream, msg);
+        }
+        LOG.info("generated records");
+
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(60));
+        List<String> results = pubsub.readAllMessages(outputStream);
+        while (deadline.hasTimeLeft()
+                && executeException.get() == null
+                && results.size() < messages.length) {
+            LOG.info("waiting for results..");
+            Thread.sleep(1000);
+            results = pubsub.readAllMessages(outputStream);
+        }
+
+        if (executeException.get() != null) {
+            throw executeException.get();
+        }
+
+        LOG.info("results: {}", results);
+
+        //        Validate.isTrue(
+        //                results.size() == messages.length,
+        //                "Expecting results to equal " + results.size() + " , but was " +
+        // messages.length);
+
+        String[] expectedResults = {
+            "elephant,5,45218",
+            "elephant,14,54867",
+            "squirrel,12,46213",
+            "squirrel,34,52444",
+            "bee,3,51348",
+            "bee,13,53412"
+        };
+
+        for (String expectedResult : expectedResults) {
+            //            Validate.isTrue(
+            //                    results.contains(expectedResult), "Expecting to receive " +
+            // expectedResult);
+        }
+
+        // TODO: main thread needs to create job or CLI fails with:
+        // "The program didn't contain a Flink job. Perhaps you forgot to call execute() on the
+        // execution environment."
+        System.out.println("test finished");
+        System.exit(0);
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/RollingAdditionMapper.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/main/java/org/apache/flink/streaming/kinesis/test/RollingAdditionMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * A {@link RichMapFunction} that continuously outputs the current total frequency count of a key.
+ * The current total count is keyed state managed by Flink.
+ */
+public class RollingAdditionMapper extends RichMapFunction<Event, Event> {
+
+    private static final long serialVersionUID = 1180234853172462378L;
+
+    private transient ValueState<Integer> currentTotalCount;
+
+    @Override
+    public Event map(Event event) throws Exception {
+        Integer totalCount = currentTotalCount.value();
+
+        if (totalCount == null) {
+            totalCount = 0;
+        }
+        totalCount += event.getFrequency();
+
+        currentTotalCount.update(totalCount);
+
+        return new Event(event.getWord(), totalCount, event.getTimestamp());
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        currentTotalCount =
+                getRuntimeContext()
+                        .getState(new ValueStateDescriptor<>("currentTotalCount", Integer.class));
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.testframe.container.FlinkContainers;
+import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.connectors.kinesis.testutils.KinesaliteContainer;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+import org.apache.flink.streaming.kinesis.test.model.Order;
+import org.apache.flink.test.resources.ResourceTestUtils;
+import org.apache.flink.test.util.SQLJobSubmission;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkSystemSetting;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** End-to-end test for Kinesis Table API using Kinesalite. */
+public class KinesisTableApiITCase extends TestLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KinesisTableApiITCase.class);
+
+    private static final String ORDERS_STREAM = "orders";
+    private static final String LARGE_ORDERS_STREAM = "large_orders";
+    private static final String INTER_CONTAINER_KINESALITE_ALIAS = "kinesalite";
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
+
+    private final Path sqlConnectorKinesisJar = ResourceTestUtils.getResource(".*kinesis.jar");
+    private static final Network network = Network.newNetwork();
+
+    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+
+    @ClassRule
+    public static final KinesaliteContainer KINESALITE =
+            new KinesaliteContainer(DockerImageName.parse(DockerImageVersions.KINESALITE))
+                    .withNetwork(network)
+                    .withNetworkAliases(INTER_CONTAINER_KINESALITE_ALIAS);
+
+    private KinesisPubsubClient kinesisClient;
+
+    public static final TestcontainersSettings TESTCONTAINERS_SETTINGS =
+            TestcontainersSettings.builder()
+                    .environmentVariable("AWS_CBOR_DISABLE", "1")
+                    .environmentVariable(
+                            "FLINK_ENV_JAVA_OPTS",
+                            "-Dorg.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking -Daws.cborEnabled=false")
+                    .network(network)
+                    .logger(LOGGER)
+                    .dependsOn(KINESALITE)
+                    .build();
+
+    public static final FlinkContainers FLINK =
+            FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
+
+    @BeforeClass
+    public static void setupFlink() throws Exception {
+        FLINK.start();
+    }
+
+    @AfterClass
+    public static void stopFlink() {
+        FLINK.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Properties properties = KINESALITE.getContainerProperties();
+
+        kinesisClient = new KinesisPubsubClient(properties);
+        kinesisClient.createTopic(ORDERS_STREAM, 1, properties);
+        kinesisClient.createTopic(LARGE_ORDERS_STREAM, 1, properties);
+
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+    }
+
+    @After
+    public void teardown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+    }
+
+    @Test
+    public void testTableApiSourceAndSink() throws Exception {
+        List<Order> smallOrders = ImmutableList.of(new Order("A", 5), new Order("B", 10));
+
+        // filter-large-orders.sql is supposed to preserve orders with quantity > 10
+        List<Order> expected =
+                ImmutableList.of(new Order("C", 15), new Order("D", 20), new Order("E", 25));
+
+        smallOrders.forEach(order -> kinesisClient.sendMessage(ORDERS_STREAM, toJson(order)));
+        expected.forEach(order -> kinesisClient.sendMessage(ORDERS_STREAM, toJson(order)));
+
+        executeSqlStatements(readSqlFile("filter-large-orders.sql"));
+
+        // result order is not guaranteed
+        List<Order> result = readAllOrdersFromKinesis(kinesisClient);
+        assertThat(result).contains(expected.toArray(new Order[0]));
+    }
+
+    private List<Order> readAllOrdersFromKinesis(final KinesisPubsubClient client)
+            throws Exception {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(5));
+        List<Order> orders;
+        do {
+            Thread.sleep(1000);
+            orders =
+                    client.readAllMessages(LARGE_ORDERS_STREAM).stream()
+                            .map(order -> fromJson(order, Order.class))
+                            .collect(Collectors.toList());
+        } while (deadline.hasTimeLeft() && orders.size() < 3);
+
+        return orders;
+    }
+
+    private List<String> readSqlFile(final String resourceName) throws Exception {
+        return Files.readAllLines(Paths.get(getClass().getResource("/" + resourceName).toURI()));
+    }
+
+    private void executeSqlStatements(final List<String> sqlLines) throws Exception {
+        FLINK.submitSQLJob(
+                new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+                        .addJars(sqlConnectorKinesisJar)
+                        .build());
+    }
+
+    private <T> String toJson(final T object) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Test Failure.", e);
+        }
+    }
+
+    private <T> T fromJson(final String json, final Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Test Failure.", e);
+        }
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/java/org/apache/flink/streaming/kinesis/test/model/Order.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/java/org/apache/flink/streaming/kinesis/test/model/Order.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test.model;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/** POJO model class for sending and receiving records on Kinesis during e2e test. */
+public class Order {
+    private final String code;
+    private final int quantity;
+
+    public Order(@JsonProperty("code") final String code, @JsonProperty("quantity") int quantity) {
+        this.code = code;
+        this.quantity = quantity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Order order = (Order) o;
+        return quantity == order.quantity && Objects.equals(code, order.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, quantity);
+    }
+
+    @Override
+    public String toString() {
+        return "Order{" + "code='" + code + '\'' + ", quantity=" + quantity + '}';
+    }
+}

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/resources/filter-large-orders.sql
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/resources/filter-large-orders.sql
@@ -1,0 +1,52 @@
+--/*
+-- * Licensed to the Apache Software Foundation (ASF) under one
+-- * or more contributor license agreements.  See the NOTICE file
+-- * distributed with this work for additional information
+-- * regarding copyright ownership.  The ASF licenses this file
+-- * to you under the Apache License, Version 2.0 (the
+-- * "License"); you may not use this file except in compliance
+-- * with the License.  You may obtain a copy of the License at
+-- *
+-- *     http://www.apache.org/licenses/LICENSE-2.0
+-- *
+-- * Unless required by applicable law or agreed to in writing, software
+-- * distributed under the License is distributed on an "AS IS" BASIS,
+-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- * See the License for the specific language governing permissions and
+-- * limitations under the License.
+-- */
+
+CREATE TABLE orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'kinesis',
+  'stream' = 'orders',
+  'aws.endpoint' = 'https://kinesalite:4567',
+  'aws.credentials.provider'='BASIC',
+  'aws.credentials.basic.accesskeyid' = 'access key',
+  'aws.credentials.basic.secretkey' ='secret key',
+  'scan.stream.initpos' = 'TRIM_HORIZON',
+  'scan.shard.discovery.intervalmillis' = '1000',
+  'scan.shard.adaptivereads' = 'true',
+  'format' = 'json'
+);
+
+CREATE TABLE large_orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'kinesis',
+  'stream' = 'large_orders',
+  'aws.region' = 'us-east-1',
+  'aws.endpoint' = 'https://kinesalite:4567',
+  'aws.credentials.provider' = 'BASIC',
+  'aws.credentials.basic.accesskeyid' = 'access key',
+  'aws.credentials.basic.secretkey' ='secret key',
+  'aws.trust.all.certificates' = 'true',
+  'sink.http-client.protocol.version' = 'HTTP1_1',
+  'sink.batch.max-size' = '1',
+  'format' = 'json'
+);
+
+INSERT INTO large_orders SELECT * FROM orders WHERE quantity > 10;

--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connector-aws-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/pom.xml
@@ -41,6 +41,7 @@ under the License.
     <modules>
         <module>flink-connector-aws-kinesis-firehose-e2e-tests</module>
         <module>flink-connector-aws-kinesis-streams-e2e-tests</module>
+        <module>flink-connector-kinesis-e2e-tests</module>
     </modules>
 
     <dependencies>

--- a/flink-connector-aws-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-connector-aws-parent</artifactId>
+        <version>4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-connector-aws-e2e-tests-parent</artifactId>
+    <version>4.0-SNAPSHOT</version>
+    <name>Flink : Connectors : AWS : E2E Tests : Parent</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <scala.binary.version>2.12</scala.binary.version>
+    </properties>
+
+    <modules>
+        <module>flink-connector-aws-kinesis-firehose-e2e-tests</module>
+    </modules>
+
+    <dependencyManagement>
+        <!-- For dependency convergence -->
+        <dependencies>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>2.12.7</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>run-end-to-end-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>end-to-end-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/*.*</include>
+                                    </includes>
+                                    <!-- E2E tests must not access flink-dist concurrently. -->
+                                    <forkCount>1</forkCount>
+                                    <systemPropertyVariables>
+                                        <moduleDir>${project.basedir}</moduleDir>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>integration-tests</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-connector-aws-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/pom.xml
@@ -40,8 +40,17 @@ under the License.
 
     <modules>
         <module>flink-connector-aws-kinesis-firehose-e2e-tests</module>
+        <module>flink-connector-aws-kinesis-streams-e2e-tests</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <dependencyManagement>
         <!-- For dependency convergence -->
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@ under the License.
         <module>flink-sql-connector-aws-kinesis-firehose</module>
         <module>flink-sql-connector-aws-kinesis-streams</module>
         <module>flink-sql-connector-kinesis</module>
+
+        <module>flink-connector-aws-e2e-tests</module>
     </modules>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>


### PR DESCRIPTION
Externalized the following modules from Flink:
- [flink-end-to-end-tests-aws-kinesis-firehose](https://github.com/apache/flink/tree/master/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose)
- [flink-end-to-end-tests-aws-kinesis-streams](https://github.com/apache/flink/tree/master/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams)
- [flink-streaming-kinesis-test](https://github.com/apache/flink/tree/master/flink-end-to-end-tests/flink-streaming-kinesis-test)

Update CI to run e2e tests in a separate phase.

Added an e2e tests parent for common config