### PR TITLE
[FLINK-30578][build] Publish SBOM for externalized connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,20 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## What is the purpose of the change
The original PR which modified the flink-parent: #https://github.com/apache/flink/pull/21606

This PR aims to publish SBOM artifacts.

- Here is an article to give some context: [article](https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/)

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

## Brief change log
- Add `cyclonedx-maven-plugin plugin`

## Verifying this change
Each jar file will have two corresponding files: `xxx-cyclonedx.xml` and `xxx-cyclonedx.json`

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): Yes, but it's plugin dependency.
- The public API, i.e., is any changed class annotated with @Public(Evolving): No
- The serializers: No
- The runtime per-record code paths (performance sensitive): No
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
- The S3 file system connector: No

## Documentation
- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A