### PR TITLE
[FLINK-30762][ci] Add nightly build workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,22 +16,42 @@
 # limitations under the License.
 ################################################################################
 
-name: Build flink-connector-aws
-on: [push, pull_request]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  workflow_call:
+    inputs:
+      flink_url:
+        description: "Url to Flink binary."
+        required: true
+        type: string
+      flink_version:
+        description: "Flink version to test against."
+        required: true
+        type: string
+      cache_flink_binary:
+        description: "Whether to cache the Flink binary. Should be false for SNAPSHOT URLs, true otherwise."
+        required: true
+        type: boolean
+      timeout_global:
+        description: "The timeout in minutes for the entire workflow."
+        required: false
+        type: number
+        default: 60
+      timeout_test:
+        description: "The timeout in minutes for the compile and test step."
+        required: false
+        type: number
+        default: 50
+
 jobs:
   compile_and_test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         jdk: [ 8, 11 ]
-        flink: [ 1.16.0 ]
+    timeout-minutes: ${{ inputs.timeout_global }}
     env:
-      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-      FLINK_URL: https://dlcdn.apache.org/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
       MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
@@ -39,17 +59,17 @@ jobs:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Set Maven 3.8.5
-        uses: stCarolas/setup-maven@v4.2
+        uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.5
 
@@ -57,25 +77,26 @@ jobs:
         run: mkdir -p ${{ env.FLINK_CACHE_DIR }}
 
       - name: Cache Flink binary
-        if: ${{ inputs.cache_flink_binary == 'true' }}
+        if: ${{ inputs.cache_flink_binary }}
         uses: actions/cache@v3
         id: cache-flink
         with:
           path: ${{ env.FLINK_CACHE_DIR }}
-          key: ${{ env.FLINK_URL }}
+          key: ${{ inputs.flink_url }}
 
       - name: Download Flink binary
         working-directory: ${{ env.FLINK_CACHE_DIR }}
         if: steps.cache-flink.outputs.cache-hit != 'true'
-        run: wget -q -c ${{ env.FLINK_URL }} -O - | tar -xz
+        run: wget -q -c ${{ inputs.flink_url }} -O - | tar -xz
 
       - name: Compile and test flink-connector-aws
+        timeout-minutes: ${{ inputs.timeout_test }}
         run: |
           set -o pipefail
           
           mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
-            -Dflink.version=${{ matrix.flink }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }} 
+            -Dflink.version=${{ inputs.flink_version }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
 
       - name: Run e2e tests
         run: |
@@ -85,8 +106,8 @@ jobs:
           
           mvn clean verify ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
-            -Dflink.version=${{ matrix.flink }}  \
-            -Prun-end-to-end-tests -DdistDir=${{ env.FLINK_CACHE_DIR }}/flink-${{ matrix.flink }} \
+            -Dflink.version=${{ inputs.flink_version }}  \
+            -Prun-end-to-end-tests -DdistDir=${{ env.FLINK_CACHE_DIR }}/flink-${{ inputs.flink_version }} \
             | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
           
           mvn clean

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,33 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: "flink-connector-aws: nightly build"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  compile_and_test:
+    if: github.repository_owner == 'apache'
+    strategy:
+      matrix:
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+    uses: ./.github/workflows/common.yml
+    with:
+      flink_version: ${{ matrix.flink }}
+      flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      cache_flink_binary: false

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -1,0 +1,33 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: "flink-connector-aws: build on pull request"
+on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  compile_and_test:
+    uses: ./.github/workflows/common.yml
+    strategy:
+      matrix:
+        flink: [1.16.0]
+    with:
+      flink_version: ${{ matrix.flink }}
+      flink_url: https://dist.apache.org/repos/dist/release/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      cache_flink_binary: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites:
 
 * Unix-like environment (we use Linux, Mac OS X)
 * Git
-* Maven (we recommend version 3.8.6)
+* Maven (we recommend version 3.8.5)
 * Java 11
 
 ```


### PR DESCRIPTION
- Extracted existing build logic into common reusable workflow
- Added nightly build against SNAPSHOT versions of Flink
- Update actions to address Node 12 actions deprecation notice:
  - `actions/checkout` to `v3`
  - `actions/setup-java` to `v3`
  - `stCarolas/setup-maven` to `v4.5`