### PR TITLE
[FLINK-24438] Add Kinesis connector using FLIP-27

### DIFF
--- a/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSClientUtil.java
+++ b/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSClientUtil.java
@@ -170,7 +170,7 @@ public class AWSClientUtil extends AWSGeneralUtil {
      *
      * @param configProps configuration properties
      * @param httpClient the underlying HTTP client used to talk to AWS
-     * @param clientBuilder httpClientBuilder to build the underlying HTTP client
+     * @param clientBuilder the builder for the AWS SDK client
      * @param awsUserAgentPrefixFormat user agent prefix for Flink
      * @param awsClientUserAgentPrefix user agent prefix for kinesis client
      * @return a new AWS Sync Client

--- a/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws-kinesis-streams/pom.xml
@@ -30,7 +30,7 @@ under the License.
     </parent>
 
     <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-    <name>Flink : Connectors : AWS : Amazon Kinesis Data Streams Sink v2</name>
+    <name>Flink : Connectors : AWS : Amazon Kinesis Data Streams Connector v2</name>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -80,12 +80,25 @@ under the License.
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-base</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>3.14.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.connector.aws.util.AWSClientUtil;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsConfigConstants;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumerator;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumeratorState;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumeratorStateSerializer;
+import org.apache.flink.connector.kinesis.source.proxy.KinesisStreamProxy;
+import org.apache.flink.connector.kinesis.source.reader.KinesisStreamsRecordEmitter;
+import org.apache.flink.connector.kinesis.source.reader.KinesisStreamsSourceReader;
+import org.apache.flink.connector.kinesis.source.reader.PollingKinesisShardSplitReader;
+import org.apache.flink.connector.kinesis.source.serialization.KinesisDeserializationSchema;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.utils.AttributeMap;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+/**
+ * The {@link KinesisStreamsSource} is an exactly-once parallel streaming data source that
+ * subscribes to a single AWS Kinesis data stream. It is able to handle resharding of streams, and
+ * stores its current progress in Flink checkpoints. The source will read in data from the Kinesis
+ * Data stream, deserialize it using the provided {@link DeserializationSchema}, and emit the record
+ * into the Flink job graph.
+ *
+ * <p>Exactly-once semantics. To leverage Flink's checkpointing mechanics for exactly-once stream
+ * processing, the Kinesis Source is implemented with the AWS Java SDK, instead of the officially
+ * recommended AWS Kinesis Client Library. The source will store its current progress in Flink
+ * checkpoint/savepoint, and will pick up from where it left off upon restore from the
+ * checkpoint/savepoint.
+ *
+ * <p>Initial starting points. The Kinesis Streams Source supports reads starting from TRIM_HORIZON,
+ * LATEST, and AT_TIMESTAMP.
+ *
+ * @param <T> the data type emitted by the source
+ */
+@Experimental
+public class KinesisStreamsSource<T>
+        implements Source<T, KinesisShardSplit, KinesisStreamsSourceEnumeratorState> {
+
+    private final String streamArn;
+    private final Properties consumerConfig;
+    private final KinesisDeserializationSchema<T> deserializationSchema;
+    private final KinesisShardAssigner kinesisShardAssigner;
+
+    KinesisStreamsSource(
+            String streamArn,
+            Properties consumerConfig,
+            KinesisDeserializationSchema<T> deserializationSchema,
+            KinesisShardAssigner kinesisShardAssigner) {
+        Preconditions.checkNotNull(streamArn);
+        Preconditions.checkArgument(!streamArn.isEmpty(), "stream ARN cannot be empty string");
+        Preconditions.checkNotNull(consumerConfig);
+        Preconditions.checkNotNull(deserializationSchema);
+        Preconditions.checkNotNull(kinesisShardAssigner);
+        this.streamArn = streamArn;
+        this.consumerConfig = consumerConfig;
+        this.deserializationSchema = deserializationSchema;
+        this.kinesisShardAssigner = kinesisShardAssigner;
+    }
+
+    /**
+     * Create a {@link KinesisStreamsSourceBuilder} to allow the fluent construction of a new {@link
+     * KinesisStreamsSource}.
+     *
+     * @param <T> type of records being read
+     * @return {@link KinesisStreamsSourceBuilder}
+     */
+    public static <T> KinesisStreamsSourceBuilder<T> builder() {
+        return new KinesisStreamsSourceBuilder<>();
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<T, KinesisShardSplit> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        setUpDeserializationSchema(readerContext);
+
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue =
+                new FutureCompletingBlockingQueue<>();
+        // We create a new stream proxy for each split reader since they have their own independent
+        // lifecycle.
+        Supplier<PollingKinesisShardSplitReader> splitReaderSupplier =
+                () -> new PollingKinesisShardSplitReader(createKinesisStreamProxy(consumerConfig));
+        KinesisStreamsRecordEmitter<T> recordEmitter =
+                new KinesisStreamsRecordEmitter<>(deserializationSchema);
+
+        return new KinesisStreamsSourceReader<>(
+                elementsQueue,
+                new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                recordEmitter,
+                ConfigurationUtils.createConfiguration(consumerConfig),
+                readerContext);
+    }
+
+    @Override
+    public SplitEnumerator<KinesisShardSplit, KinesisStreamsSourceEnumeratorState> createEnumerator(
+            SplitEnumeratorContext<KinesisShardSplit> enumContext) throws Exception {
+        return restoreEnumerator(enumContext, null);
+    }
+
+    @Override
+    public SplitEnumerator<KinesisShardSplit, KinesisStreamsSourceEnumeratorState>
+            restoreEnumerator(
+                    SplitEnumeratorContext<KinesisShardSplit> enumContext,
+                    KinesisStreamsSourceEnumeratorState checkpoint)
+                    throws Exception {
+        return new KinesisStreamsSourceEnumerator(
+                enumContext,
+                streamArn,
+                consumerConfig,
+                createKinesisStreamProxy(consumerConfig),
+                kinesisShardAssigner,
+                checkpoint);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<KinesisShardSplit> getSplitSerializer() {
+        return new KinesisShardSplitSerializer();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<KinesisStreamsSourceEnumeratorState>
+            getEnumeratorCheckpointSerializer() {
+        return new KinesisStreamsSourceEnumeratorStateSerializer(new KinesisShardSplitSerializer());
+    }
+
+    private KinesisStreamProxy createKinesisStreamProxy(Properties consumerConfig) {
+        SdkHttpClient httpClient =
+                AWSGeneralUtil.createSyncHttpClient(
+                        AttributeMap.builder().build(), ApacheHttpClient.builder());
+
+        AWSGeneralUtil.validateAwsCredentials(consumerConfig);
+        KinesisClient kinesisClient =
+                AWSClientUtil.createAwsSyncClient(
+                        consumerConfig,
+                        httpClient,
+                        KinesisClient.builder(),
+                        KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX);
+        return new KinesisStreamProxy(kinesisClient, httpClient);
+    }
+
+    private void setUpDeserializationSchema(SourceReaderContext sourceReaderContext)
+            throws Exception {
+        deserializationSchema.open(
+                new DeserializationSchema.InitializationContext() {
+                    @Override
+                    public MetricGroup getMetricGroup() {
+                        return sourceReaderContext.metricGroup().addGroup("deserializer");
+                    }
+
+                    @Override
+                    public UserCodeClassLoader getUserCodeClassLoader() {
+                        return sourceReaderContext.getUserCodeClassLoader();
+                    }
+                });
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceBuilder.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
+import org.apache.flink.connector.kinesis.source.enumerator.assigner.ShardAssignerFactory;
+import org.apache.flink.connector.kinesis.source.enumerator.assigner.UniformShardAssigner;
+import org.apache.flink.connector.kinesis.source.serialization.KinesisDeserializationSchema;
+
+import java.util.Properties;
+
+/**
+ * Builder to construct the {@link KinesisStreamsSource}.
+ *
+ * <p>The following example shows the minimum setup to create a {@link KinesisStreamsSource} that
+ * reads String values from a Kinesis Data Streams stream with ARN of
+ * arn:aws:kinesis:us-east-1:012345678901:stream/your_stream_name.
+ *
+ * <pre>{@code
+ * KinesisStreamsSource<String> kdsSource =
+ *                 KinesisStreamsSource.<String>builder()
+ *                         .setStreamArn("arn:aws:kinesis:us-east-1:012345678901:stream/your_stream_name")
+ *                         .setDeserializationSchema(new SimpleStringSchema())
+ *                         .build();
+ * }</pre>
+ *
+ * <p>If the following parameters are not set in this builder, the following defaults will be used:
+ *
+ * <ul>
+ *   <li>{@code kinesisShardAssigner} will be {@link UniformShardAssigner}
+ * </ul>
+ *
+ * @param <T> type of elements that should be read from the source stream
+ */
+@Experimental
+public class KinesisStreamsSourceBuilder<T> {
+    private String streamArn;
+    private Properties consumerConfig;
+    private KinesisDeserializationSchema<T> deserializationSchema;
+    private KinesisShardAssigner kinesisShardAssigner = ShardAssignerFactory.uniformShardAssigner();
+
+    public KinesisStreamsSourceBuilder<T> setStreamArn(String streamArn) {
+        this.streamArn = streamArn;
+        return this;
+    }
+
+    public KinesisStreamsSourceBuilder<T> setConsumerConfig(Properties consumerConfig) {
+        this.consumerConfig = consumerConfig;
+        return this;
+    }
+
+    public KinesisStreamsSourceBuilder<T> setDeserializationSchema(
+            KinesisDeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+        return this;
+    }
+
+    public KinesisStreamsSourceBuilder<T> setDeserializationSchema(
+            DeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = KinesisDeserializationSchema.of(deserializationSchema);
+        return this;
+    }
+
+    public KinesisStreamsSourceBuilder<T> setKinesisShardAssigner(
+            KinesisShardAssigner kinesisShardAssigner) {
+        this.kinesisShardAssigner = kinesisShardAssigner;
+        return this;
+    }
+
+    public KinesisStreamsSource<T> build() {
+        return new KinesisStreamsSource<>(
+                streamArn, consumerConfig, deserializationSchema, kinesisShardAssigner);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigConstants.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigConstants.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.config;
+
+import org.apache.flink.annotation.Experimental;
+
+/** Constants to be used with the KinesisStreamsSource. */
+@Experimental
+public class KinesisStreamsSourceConfigConstants {
+    /** Marks the initial position to use when reading from the Kinesis stream. */
+    public enum InitialPosition {
+        LATEST,
+        TRIM_HORIZON,
+        AT_TIMESTAMP
+    }
+
+    /** The initial position to start reading Kinesis streams from. */
+    public static final String STREAM_INITIAL_POSITION = "flink.stream.initpos";
+
+    public static final String DEFAULT_STREAM_INITIAL_POSITION = InitialPosition.LATEST.toString();
+
+    /**
+     * The initial timestamp to start reading Kinesis stream from (when AT_TIMESTAMP is set for
+     * STREAM_INITIAL_POSITION).
+     */
+    public static final String STREAM_INITIAL_TIMESTAMP = "flink.stream.initpos.timestamp";
+
+    /**
+     * The date format of initial timestamp to start reading Kinesis stream from (when AT_TIMESTAMP
+     * is set for STREAM_INITIAL_POSITION).
+     */
+    public static final String STREAM_TIMESTAMP_DATE_FORMAT =
+            "flink.stream.initpos.timestamp.format";
+
+    public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT =
+            "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+    /** The interval between each attempt to discover new shards. */
+    public static final String SHARD_DISCOVERY_INTERVAL_MILLIS =
+            "flink.shard.discovery.intervalmillis";
+
+    public static final long DEFAULT_SHARD_DISCOVERY_INTERVAL_MILLIS = 10000L;
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigUtil.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.config;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.STREAM_INITIAL_TIMESTAMP;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
+
+/** Utility functions to use with {@link KinesisStreamsSourceConfigConstants}. */
+@Internal
+public class KinesisStreamsSourceConfigUtil {
+
+    private KinesisStreamsSourceConfigUtil() {
+        // private constructor to prevent initialization of utility class.
+    }
+
+    /**
+     * Parses the timestamp in which to start consuming from the stream, from the given properties.
+     *
+     * @param consumerConfig the properties to parse timestamp from
+     * @return the timestamp
+     */
+    public static Date parseStreamTimestampStartingPosition(final Properties consumerConfig) {
+        Preconditions.checkNotNull(consumerConfig);
+        String timestamp = consumerConfig.getProperty(STREAM_INITIAL_TIMESTAMP);
+
+        try {
+            String format =
+                    consumerConfig.getProperty(
+                            STREAM_TIMESTAMP_DATE_FORMAT, DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT);
+            SimpleDateFormat customDateFormat = new SimpleDateFormat(format);
+            return customDateFormat.parse(timestamp);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new IllegalArgumentException(exception);
+        } catch (ParseException exception) {
+            return new Date((long) (Double.parseDouble(timestamp) * 1000));
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisShardAssigner.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisShardAssigner.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Interface that controls the mapping of the split to a given subtask. */
+@Experimental
+public interface KinesisShardAssigner extends Serializable {
+
+    /**
+     * Controls the assignment of a given split to a specific subtask. The {@link Context} object
+     * provides immutable information for the current status of the Flink cluster (e.g. number of
+     * registered readers, current split assignments).
+     *
+     * @param split the split to assign
+     * @param context immutable information about the Flink cluster
+     * @return subtaskId to assign given split
+     */
+    int assign(final KinesisShardSplit split, final Context context);
+
+    /**
+     * Immutable information about the Flink cluster useful for deciding which subtask to assign a
+     * given split.
+     */
+    @Experimental
+    interface Context {
+        /**
+         * Provides the current split distribution between subtasks.
+         *
+         * @return current assignment of splits. Key is subtaskId, value is the currently assigned
+         *     splits.
+         */
+        Map<Integer, Set<KinesisShardSplit>> getCurrentSplitAssignment();
+
+        /**
+         * Provides the pending split assignments in the current batch of splits.
+         *
+         * @return pending split assignments. Key is subtaskId, value is the currently assigned
+         *     splits.
+         */
+        Map<Integer, List<KinesisShardSplit>> getPendingSplitAssignments();
+
+        /**
+         * Provides information about the currently registered readers on the Flink cluster.
+         *
+         * @return currently registered readers in the Flink cluster. Key is subtaskId, value is
+         *     information about the registered reader.
+         */
+        Map<Integer, ReaderInfo> getRegisteredReaders();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumerator.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumerator.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.InitialPosition;
+import org.apache.flink.connector.kinesis.source.exception.KinesisStreamsSourceException;
+import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.DEFAULT_SHARD_DISCOVERY_INTERVAL_MILLIS;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.DEFAULT_STREAM_INITIAL_POSITION;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.STREAM_INITIAL_POSITION;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition;
+
+/**
+ * This class is used to discover and assign Kinesis splits to subtasks on the Flink cluster. This
+ * runs on the JobManager.
+ */
+@Internal
+public class KinesisStreamsSourceEnumerator
+        implements SplitEnumerator<KinesisShardSplit, KinesisStreamsSourceEnumeratorState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KinesisStreamsSourceEnumerator.class);
+
+    private final SplitEnumeratorContext<KinesisShardSplit> context;
+    private final String streamArn;
+    private final Properties consumerConfig;
+    private final StreamProxy streamProxy;
+    private final KinesisShardAssigner shardAssigner;
+    private final ShardAssignerContext shardAssignerContext;
+
+    private final Map<Integer, Set<KinesisShardSplit>> splitAssignment = new HashMap<>();
+    private final Set<String> assignedSplitIds = new HashSet<>();
+    private final Set<KinesisShardSplit> unassignedSplits;
+
+    private String lastSeenShardId;
+
+    public KinesisStreamsSourceEnumerator(
+            SplitEnumeratorContext<KinesisShardSplit> context,
+            String streamArn,
+            Properties consumerConfig,
+            StreamProxy streamProxy,
+            KinesisShardAssigner shardAssigner,
+            KinesisStreamsSourceEnumeratorState state) {
+        this.context = context;
+        this.streamArn = streamArn;
+        this.consumerConfig = consumerConfig;
+        this.streamProxy = streamProxy;
+        this.shardAssigner = shardAssigner;
+        this.shardAssignerContext = new ShardAssignerContext(splitAssignment, context);
+        if (state == null) {
+            this.lastSeenShardId = null;
+            this.unassignedSplits = new HashSet<>();
+        } else {
+            this.lastSeenShardId = state.getLastSeenShardId();
+            this.unassignedSplits = state.getUnassignedSplits();
+        }
+    }
+
+    @Override
+    public void start() {
+        if (lastSeenShardId == null) {
+            context.callAsync(this::initialDiscoverSplits, this::assignSplits);
+        }
+
+        final long shardDiscoveryInterval =
+                Long.parseLong(
+                        consumerConfig.getProperty(
+                                SHARD_DISCOVERY_INTERVAL_MILLIS,
+                                String.valueOf(DEFAULT_SHARD_DISCOVERY_INTERVAL_MILLIS)));
+        context.callAsync(
+                this::periodicallyDiscoverSplits,
+                this::assignSplits,
+                shardDiscoveryInterval,
+                shardDiscoveryInterval);
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        // Do nothing, since we assign splits eagerly
+    }
+
+    @Override
+    public void addSplitsBack(List<KinesisShardSplit> splits, int subtaskId) {
+        if (!splitAssignment.containsKey(subtaskId)) {
+            LOG.warn(
+                    "Unable to add splits back for subtask {} since it is not assigned any splits. Splits: {}",
+                    subtaskId,
+                    splits);
+            return;
+        }
+
+        for (KinesisShardSplit split : splits) {
+            splitAssignment.get(subtaskId).remove(split);
+            assignedSplitIds.remove(split.splitId());
+            unassignedSplits.add(split);
+        }
+
+        // Assign the unassignedSplits
+        // We did not discover any new splits, so we put in an empty list
+        assignSplits(Collections.emptyList(), null);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        splitAssignment.putIfAbsent(subtaskId, new HashSet<>());
+    }
+
+    @Override
+    public KinesisStreamsSourceEnumeratorState snapshotState(long checkpointId) throws Exception {
+        return new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+    }
+
+    @Override
+    public void close() throws IOException {
+        streamProxy.close();
+    }
+
+    private List<KinesisShardSplit> initialDiscoverSplits() {
+        List<Shard> shards = streamProxy.listShards(streamArn, lastSeenShardId);
+        return mapToSplits(
+                shards,
+                InitialPosition.valueOf(
+                        consumerConfig
+                                .getOrDefault(
+                                        STREAM_INITIAL_POSITION, DEFAULT_STREAM_INITIAL_POSITION)
+                                .toString()));
+    }
+
+    /**
+     * This method is used to discover Kinesis splits the job can subscribe to. It can be run in
+     * parallel, is important to not mutate any shared state.
+     *
+     * @return list of discovered splits
+     */
+    private List<KinesisShardSplit> periodicallyDiscoverSplits() {
+        List<Shard> shards = streamProxy.listShards(streamArn, lastSeenShardId);
+        // Any shard discovered after the initial startup should be read from the start, since they
+        // come from resharding
+        return mapToSplits(shards, InitialPosition.TRIM_HORIZON);
+    }
+
+    private List<KinesisShardSplit> mapToSplits(
+            List<Shard> shards, InitialPosition initialPosition) {
+        StartingPosition startingPosition;
+        switch (initialPosition) {
+            case LATEST:
+                // If LATEST is requested, we still set the starting position to the time of
+                // startup. This way, the job starts reading from a deterministic timestamp
+                // (i.e. time of job submission), even if it enters a restart loop immediately
+                // after submission.
+                startingPosition = StartingPosition.fromTimestamp(Instant.now());
+                break;
+            case AT_TIMESTAMP:
+                startingPosition =
+                        StartingPosition.fromTimestamp(
+                                parseStreamTimestampStartingPosition(consumerConfig).toInstant());
+                break;
+            case TRIM_HORIZON:
+            default:
+                startingPosition = StartingPosition.fromStart();
+        }
+
+        List<KinesisShardSplit> splits = new ArrayList<>();
+        for (Shard shard : shards) {
+            splits.add(new KinesisShardSplit(streamArn, shard.shardId(), startingPosition));
+        }
+
+        return splits;
+    }
+
+    /**
+     * This method assigns a given set of Kinesis splits to the readers currently registered on the
+     * cluster. This assignment is done via a side-effect on the {@link SplitEnumeratorContext}
+     * object.
+     *
+     * @param discoveredSplits list of discovered splits
+     * @param throwable thrown when discovering splits. Will be null if no throwable thrown.
+     */
+    private void assignSplits(List<KinesisShardSplit> discoveredSplits, Throwable throwable) {
+        if (throwable != null) {
+            throw new KinesisStreamsSourceException("Failed to list shards.", throwable);
+        }
+
+        if (context.registeredReaders().size() < context.currentParallelism()) {
+            LOG.info(
+                    "Insufficient registered readers, skipping assignment of discovered splits until all readers are registered. Required number of readers: {}, Registered readers: {}",
+                    context.currentParallelism(),
+                    context.registeredReaders().size());
+            unassignedSplits.addAll(discoveredSplits);
+            return;
+        }
+
+        Map<Integer, List<KinesisShardSplit>> newSplitAssignments = new HashMap<>();
+        for (KinesisShardSplit split : unassignedSplits) {
+            assignSplitToSubtask(split, newSplitAssignments);
+        }
+        unassignedSplits.clear();
+        for (KinesisShardSplit split : discoveredSplits) {
+            assignSplitToSubtask(split, newSplitAssignments);
+        }
+
+        updateLastSeenShardId(discoveredSplits);
+        updateSplitAssignment(newSplitAssignments);
+        context.assignSplits(new SplitsAssignment<>(newSplitAssignments));
+    }
+
+    private void assignSplitToSubtask(
+            KinesisShardSplit split, Map<Integer, List<KinesisShardSplit>> newSplitAssignments) {
+        if (assignedSplitIds.contains(split.splitId())) {
+            LOG.info(
+                    "Skipping assignment of shard {} from stream {} because it is already assigned.",
+                    split.getShardId(),
+                    split.getStreamArn());
+            return;
+        }
+
+        int selectedSubtask =
+                shardAssigner.assign(
+                        split,
+                        shardAssignerContext.withPendingSplitAssignments(newSplitAssignments));
+        LOG.info(
+                "Assigning shard {} from stream {} to subtask {}.",
+                split.getShardId(),
+                split.getStreamArn(),
+                selectedSubtask);
+
+        if (newSplitAssignments.containsKey(selectedSubtask)) {
+            newSplitAssignments.get(selectedSubtask).add(split);
+        } else {
+            List<KinesisShardSplit> subtaskList = new ArrayList<>();
+            subtaskList.add(split);
+            newSplitAssignments.put(selectedSubtask, subtaskList);
+        }
+        assignedSplitIds.add(split.splitId());
+    }
+
+    private void updateLastSeenShardId(List<KinesisShardSplit> discoveredSplits) {
+        if (!discoveredSplits.isEmpty()) {
+            KinesisShardSplit lastSplit = discoveredSplits.get(discoveredSplits.size() - 1);
+            lastSeenShardId = lastSplit.getShardId();
+        }
+    }
+
+    private void updateSplitAssignment(Map<Integer, List<KinesisShardSplit>> newSplitsAssignment) {
+        newSplitsAssignment.forEach(
+                (subtaskId, newSplits) -> {
+                    if (splitAssignment.containsKey(subtaskId)) {
+                        splitAssignment.get(subtaskId).addAll(newSplits);
+                    } else {
+                        splitAssignment.put(subtaskId, new HashSet<>(newSplits));
+                    }
+                });
+    }
+
+    @Internal
+    private static class ShardAssignerContext implements KinesisShardAssigner.Context {
+
+        private final Map<Integer, Set<KinesisShardSplit>> splitAssignment;
+        private final SplitEnumeratorContext<KinesisShardSplit> splitEnumeratorContext;
+        private Map<Integer, List<KinesisShardSplit>> pendingSplitAssignments =
+                Collections.emptyMap();
+
+        private ShardAssignerContext(
+                Map<Integer, Set<KinesisShardSplit>> splitAssignment,
+                SplitEnumeratorContext<KinesisShardSplit> splitEnumeratorContext) {
+            this.splitAssignment = splitAssignment;
+            this.splitEnumeratorContext = splitEnumeratorContext;
+        }
+
+        private ShardAssignerContext withPendingSplitAssignments(
+                Map<Integer, List<KinesisShardSplit>> pendingSplitAssignments) {
+            ImmutableMap.Builder<Integer, List<KinesisShardSplit>> mapBuilder =
+                    ImmutableMap.builder();
+            for (Entry<Integer, List<KinesisShardSplit>> entry :
+                    pendingSplitAssignments.entrySet()) {
+                mapBuilder.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+            }
+            this.pendingSplitAssignments = mapBuilder.build();
+            return this;
+        }
+
+        @Override
+        public Map<Integer, Set<KinesisShardSplit>> getCurrentSplitAssignment() {
+            ImmutableMap.Builder<Integer, Set<KinesisShardSplit>> mapBuilder =
+                    ImmutableMap.builder();
+            for (Entry<Integer, Set<KinesisShardSplit>> entry : splitAssignment.entrySet()) {
+                mapBuilder.put(entry.getKey(), ImmutableSet.copyOf(entry.getValue()));
+            }
+            return mapBuilder.build();
+        }
+
+        @Override
+        public Map<Integer, List<KinesisShardSplit>> getPendingSplitAssignments() {
+            return pendingSplitAssignments;
+        }
+
+        @Override
+        public Map<Integer, ReaderInfo> getRegisteredReaders() {
+            // the split enumerator context already returns an unmodifiable map.
+            return splitEnumeratorContext.registeredReaders();
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorState.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorState.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.Set;
+
+/**
+ * State for the {@link KinesisStreamsSourceEnumerator}. This class is stored in state, so any
+ * changes need to be backwards compatible
+ */
+@Internal
+public class KinesisStreamsSourceEnumeratorState {
+    private final Set<KinesisShardSplit> unassignedSplits;
+    @Nullable private final String lastSeenShardId;
+
+    public KinesisStreamsSourceEnumeratorState(
+            Set<KinesisShardSplit> unassignedSplits, String lastSeenShardId) {
+        this.unassignedSplits = unassignedSplits;
+        this.lastSeenShardId = lastSeenShardId;
+    }
+
+    public String getLastSeenShardId() {
+        return lastSeenShardId;
+    }
+
+    public Set<KinesisShardSplit> getUnassignedSplits() {
+        return unassignedSplits;
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializer.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializer.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.io.VersionMismatchException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Used to serialize and deserialize the {@link KinesisStreamsSourceEnumeratorState}. */
+@Internal
+public class KinesisStreamsSourceEnumeratorStateSerializer
+        implements SimpleVersionedSerializer<KinesisStreamsSourceEnumeratorState> {
+
+    private static final int CURRENT_VERSION = 0;
+
+    private final KinesisShardSplitSerializer splitSerializer;
+
+    public KinesisStreamsSourceEnumeratorStateSerializer(
+            KinesisShardSplitSerializer splitSerializer) {
+        this.splitSerializer = splitSerializer;
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(KinesisStreamsSourceEnumeratorState kinesisStreamsSourceEnumeratorState)
+            throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+
+            boolean hasLastSeenShardId =
+                    kinesisStreamsSourceEnumeratorState.getLastSeenShardId() != null;
+            out.writeBoolean(hasLastSeenShardId);
+            if (hasLastSeenShardId) {
+                out.writeUTF(kinesisStreamsSourceEnumeratorState.getLastSeenShardId());
+            }
+
+            out.writeInt(kinesisStreamsSourceEnumeratorState.getUnassignedSplits().size());
+            out.writeInt(splitSerializer.getVersion());
+            for (KinesisShardSplit split :
+                    kinesisStreamsSourceEnumeratorState.getUnassignedSplits()) {
+                byte[] serializedSplit = splitSerializer.serialize(split);
+                out.writeInt(serializedSplit.length);
+                out.write(serializedSplit);
+            }
+
+            out.flush();
+
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public KinesisStreamsSourceEnumeratorState deserialize(
+            int version, byte[] serializedEnumeratorState) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serializedEnumeratorState);
+                DataInputStream in = new DataInputStream(bais)) {
+
+            if (version != getVersion()) {
+                throw new VersionMismatchException(
+                        "Trying to deserialize KinesisStreamsSourceEnumeratorState serialized with unsupported version "
+                                + version
+                                + ". Serializer version is "
+                                + getVersion());
+            }
+
+            String lastSeenShardId = null;
+
+            final boolean hasLastSeenShardId = in.readBoolean();
+            if (hasLastSeenShardId) {
+                lastSeenShardId = in.readUTF();
+            }
+
+            final int numUnassignedSplits = in.readInt();
+            final int splitSerializerVersion = in.readInt();
+            if (splitSerializerVersion != splitSerializer.getVersion()) {
+                throw new VersionMismatchException(
+                        "Trying to deserialize KinesisShardSplit serialized with unsupported version "
+                                + splitSerializerVersion
+                                + ". Serializer version is "
+                                + splitSerializer.getVersion());
+            }
+            Set<KinesisShardSplit> unassignedSplits = new HashSet<>(numUnassignedSplits);
+            for (int i = 0; i < numUnassignedSplits; i++) {
+                int serializedLength = in.readInt();
+                byte[] serializedSplit = new byte[serializedLength];
+                if (in.read(serializedSplit) != -1) {
+                    unassignedSplits.add(
+                            splitSerializer.deserialize(splitSerializerVersion, serializedSplit));
+                } else {
+                    throw new IOException(
+                            "Unexpectedly reading more bytes than is present in stream.");
+                }
+            }
+
+            if (in.available() > 0) {
+                throw new IOException("Unexpected trailing bytes when deserializing.");
+            }
+
+            return new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/ShardAssignerFactory.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/ShardAssignerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator.assigner;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
+
+/**
+ * Factory that provides an instance of {@link KinesisShardAssigner} pre-packaged with the
+ * connector.
+ */
+@Experimental
+public class ShardAssignerFactory {
+    private ShardAssignerFactory() {
+        // No-op private constructor to prevent instantiation of class
+    }
+
+    public static KinesisShardAssigner uniformShardAssigner() {
+        return new UniformShardAssigner();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssigner.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssigner.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator.assigner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** An implementation of the {@link KinesisShardAssigner} that assigns splits uniformly. */
+@Internal
+public class UniformShardAssigner implements KinesisShardAssigner {
+    @Override
+    public int assign(KinesisShardSplit split, Context context) {
+        int selectedSubtask = -1;
+        int curMinAssignment = Integer.MAX_VALUE;
+        Map<Integer, Set<KinesisShardSplit>> splitAssignment = context.getCurrentSplitAssignment();
+        Map<Integer, List<KinesisShardSplit>> pendingSplitAssignments =
+                context.getPendingSplitAssignments();
+
+        for (int subtaskId : context.getRegisteredReaders().keySet()) {
+            int subtaskAssignmentSize =
+                    splitAssignment.getOrDefault(subtaskId, Collections.emptySet()).size()
+                            + pendingSplitAssignments
+                                    .getOrDefault(subtaskId, Collections.emptyList())
+                                    .size();
+            if (subtaskAssignmentSize < curMinAssignment) {
+                curMinAssignment = subtaskAssignmentSize;
+                selectedSubtask = subtaskId;
+            }
+        }
+
+        Preconditions.checkArgument(
+                selectedSubtask != -1,
+                "Expected at least one registered reader. Unable to assign split.");
+        return selectedSubtask;
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/exception/KinesisStreamsSourceException.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/exception/KinesisStreamsSourceException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.exception;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.FlinkRuntimeException;
+
+/**
+ * Exception to indicate that there is some issue resulting from the code of the {@link
+ * org.apache.flink.connector.kinesis.source.KinesisStreamsSource}.
+ */
+@Internal
+public class KinesisStreamsSourceException extends FlinkRuntimeException {
+    public KinesisStreamsSourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxy.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxy.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.proxy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Implementation of the {@link StreamProxy} for Kinesis data streams. */
+@Internal
+public class KinesisStreamProxy implements StreamProxy {
+
+    private final KinesisClient kinesisClient;
+    private final SdkHttpClient httpClient;
+    private final Map<String, String> shardIdToIteratorStore;
+
+    public KinesisStreamProxy(KinesisClient kinesisClient, SdkHttpClient httpClient) {
+        this.kinesisClient = kinesisClient;
+        this.httpClient = httpClient;
+        this.shardIdToIteratorStore = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public List<Shard> listShards(String streamArn, @Nullable String lastSeenShardId) {
+        List<Shard> shards = new ArrayList<>();
+
+        ListShardsResponse listShardsResponse;
+        String nextToken = null;
+        do {
+            listShardsResponse =
+                    kinesisClient.listShards(
+                            ListShardsRequest.builder()
+                                    .streamARN(streamArn)
+                                    .exclusiveStartShardId(
+                                            nextToken == null ? lastSeenShardId : null)
+                                    .nextToken(nextToken)
+                                    .build());
+
+            shards.addAll(listShardsResponse.shards());
+            nextToken = listShardsResponse.nextToken();
+        } while (nextToken != null);
+
+        return shards;
+    }
+
+    @Override
+    public GetRecordsResponse getRecords(
+            String streamArn, String shardId, StartingPosition startingPosition) {
+        String shardIterator =
+                shardIdToIteratorStore.computeIfAbsent(
+                        shardId, (s) -> getShardIterator(streamArn, s, startingPosition));
+
+        try {
+            GetRecordsResponse getRecordsResponse = getRecords(streamArn, shardIterator);
+            if (getRecordsResponse.nextShardIterator() != null) {
+                shardIdToIteratorStore.put(shardId, getRecordsResponse.nextShardIterator());
+            }
+            return getRecordsResponse;
+        } catch (ExpiredIteratorException e) {
+            // Eagerly retry getRecords() if the iterator is expired
+            shardIterator = getShardIterator(streamArn, shardId, startingPosition);
+            GetRecordsResponse getRecordsResponse = getRecords(streamArn, shardIterator);
+            if (getRecordsResponse.nextShardIterator() != null) {
+                shardIdToIteratorStore.put(shardId, getRecordsResponse.nextShardIterator());
+            }
+            return getRecordsResponse;
+        }
+    }
+
+    private String getShardIterator(
+            String streamArn, String shardId, StartingPosition startingPosition) {
+        GetShardIteratorRequest.Builder requestBuilder =
+                GetShardIteratorRequest.builder()
+                        .streamARN(streamArn)
+                        .shardId(shardId)
+                        .shardIteratorType(startingPosition.getShardIteratorType());
+
+        switch (startingPosition.getShardIteratorType()) {
+            case TRIM_HORIZON:
+            case LATEST:
+                break;
+            case AT_TIMESTAMP:
+                if (startingPosition.getStartingMarker() instanceof Instant) {
+                    requestBuilder =
+                            requestBuilder.timestamp(
+                                    (Instant) startingPosition.getStartingMarker());
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid object given for GetShardIteratorRequest() when ShardIteratorType is AT_TIMESTAMP. Must be a Date object.");
+                }
+                break;
+            case AT_SEQUENCE_NUMBER:
+            case AFTER_SEQUENCE_NUMBER:
+                if (startingPosition.getStartingMarker() instanceof String) {
+                    requestBuilder =
+                            requestBuilder.startingSequenceNumber(
+                                    (String) startingPosition.getStartingMarker());
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid object given for GetShardIteratorRequest() when ShardIteratorType is AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER. Must be a String.");
+                }
+        }
+
+        return kinesisClient.getShardIterator(requestBuilder.build()).shardIterator();
+    }
+
+    private GetRecordsResponse getRecords(String streamArn, String shardIterator) {
+        return kinesisClient.getRecords(
+                GetRecordsRequest.builder()
+                        .streamARN(streamArn)
+                        .shardIterator(shardIterator)
+                        .build());
+    }
+
+    @Override
+    public void close() throws IOException {
+        kinesisClient.close();
+        httpClient.close();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/StreamProxy.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/StreamProxy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.proxy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.util.List;
+
+/** Interface for a StreamProxy to interact with Streams service in a given region. */
+@Internal
+public interface StreamProxy extends Closeable {
+
+    /**
+     * Obtains the shards associated with a given stream.
+     *
+     * @param streamArn the ARN of the stream
+     * @param lastSeenShardId the last seen shard Id. Used for reducing the number of results
+     *     returned.
+     * @return shard list
+     */
+    List<Shard> listShards(String streamArn, @Nullable String lastSeenShardId);
+
+    /**
+     * Retrieves records from the stream.
+     *
+     * @param streamArn the ARN of the stream
+     * @param shardId the shard to subscribe from
+     * @param startingPosition the starting position to read from
+     * @return the response with records. Includes both the returned records and the subsequent
+     *     shard iterator to use.
+     */
+    GetRecordsResponse getRecords(
+            String streamArn, String shardId, StartingPosition startingPosition);
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitter.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.kinesis.source.serialization.KinesisDeserializationSchema;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+import org.apache.flink.util.Collector;
+
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+/**
+ * Emits record from the source into the Flink job graph. This serves as the interface between the
+ * source and the Flink job.
+ *
+ * @param <T> the data type being emitted into the Flink job graph
+ */
+@Internal
+public class KinesisStreamsRecordEmitter<T>
+        implements RecordEmitter<Record, T, KinesisShardSplitState> {
+
+    private final KinesisDeserializationSchema<T> deserializationSchema;
+    private final SourceOutputWrapper<T> sourceOutputWrapper = new SourceOutputWrapper<>();
+
+    public KinesisStreamsRecordEmitter(KinesisDeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @Override
+    public void emitRecord(
+            Record element, SourceOutput<T> output, KinesisShardSplitState splitState)
+            throws Exception {
+        sourceOutputWrapper.setSourceOutput(output);
+        sourceOutputWrapper.setTimestamp(element.approximateArrivalTimestamp().toEpochMilli());
+        deserializationSchema.deserialize(
+                element, splitState.getStreamArn(), splitState.getShardId(), sourceOutputWrapper);
+        splitState.setNextStartingPosition(
+                StartingPosition.continueFromSequenceNumber(element.sequenceNumber()));
+    }
+
+    private static class SourceOutputWrapper<T> implements Collector<T> {
+        private SourceOutput<T> sourceOutput;
+        private long timestamp;
+
+        @Override
+        public void collect(T record) {
+            sourceOutput.collect(record, timestamp);
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+
+        private void setSourceOutput(SourceOutput<T> sourceOutput) {
+            this.sourceOutput = sourceOutput;
+        }
+
+        private void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.util.Map;
+
+/**
+ * Coordinates the reading from assigned splits. Runs on the TaskManager.
+ *
+ * @param <T> the data type emitted by the Kinesis stream source
+ */
+@Internal
+public class KinesisStreamsSourceReader<T>
+        extends SingleThreadMultiplexSourceReaderBase<
+                Record, T, KinesisShardSplit, KinesisShardSplitState> {
+
+    public KinesisStreamsSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue,
+            SingleThreadFetcherManager<Record, KinesisShardSplit> splitFetcherManager,
+            RecordEmitter<Record, T, KinesisShardSplitState> recordEmitter,
+            Configuration config,
+            SourceReaderContext context) {
+        super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, KinesisShardSplitState> finishedSplitIds) {
+        // no-op. We don't need to do anything on finished split now
+    }
+
+    @Override
+    protected KinesisShardSplitState initializedState(KinesisShardSplit split) {
+        return new KinesisShardSplitState(split);
+    }
+
+    @Override
+    protected KinesisShardSplit toSplitType(String splitId, KinesisShardSplitState splitState) {
+        return splitState.getKinesisShardSplit();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReader.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReader.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * An implementation of the SplitReader that periodically polls the Kinesis stream to retrieve
+ * records.
+ */
+@Internal
+public class PollingKinesisShardSplitReader implements SplitReader<Record, KinesisShardSplit> {
+
+    private static final RecordsWithSplitIds<Record> INCOMPLETE_SHARD_EMPTY_RECORDS =
+            new KinesisRecordsWithSplitIds(Collections.emptyIterator(), null, false);
+
+    private final StreamProxy kinesis;
+    private final Deque<KinesisShardSplitState> assignedSplits = new ArrayDeque<>();
+
+    public PollingKinesisShardSplitReader(StreamProxy kinesisProxy) {
+        this.kinesis = kinesisProxy;
+    }
+
+    @Override
+    public RecordsWithSplitIds<Record> fetch() throws IOException {
+        KinesisShardSplitState splitState = assignedSplits.poll();
+        if (splitState == null) {
+            return INCOMPLETE_SHARD_EMPTY_RECORDS;
+        }
+
+        GetRecordsResponse getRecordsResponse =
+                kinesis.getRecords(
+                        splitState.getStreamArn(),
+                        splitState.getShardId(),
+                        splitState.getNextStartingPosition());
+        boolean isComplete = getRecordsResponse.nextShardIterator() == null;
+
+        if (hasNoRecords(getRecordsResponse)) {
+            if (isComplete) {
+                return new KinesisRecordsWithSplitIds(
+                        Collections.emptyIterator(), splitState.getSplitId(), true);
+            } else {
+                assignedSplits.add(splitState);
+                return INCOMPLETE_SHARD_EMPTY_RECORDS;
+            }
+        }
+
+        splitState.setNextStartingPosition(
+                StartingPosition.continueFromSequenceNumber(
+                        getRecordsResponse
+                                .records()
+                                .get(getRecordsResponse.records().size() - 1)
+                                .sequenceNumber()));
+
+        assignedSplits.add(splitState);
+        return new KinesisRecordsWithSplitIds(
+                getRecordsResponse.records().iterator(), splitState.getSplitId(), isComplete);
+    }
+
+    private boolean hasNoRecords(GetRecordsResponse getRecordsResponse) {
+        return !getRecordsResponse.hasRecords() || getRecordsResponse.records().isEmpty();
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<KinesisShardSplit> splitsChanges) {
+        for (KinesisShardSplit split : splitsChanges.splits()) {
+            assignedSplits.add(new KinesisShardSplitState(split));
+        }
+    }
+
+    @Override
+    public void wakeUp() {
+        // Do nothing because we don't have any sleep mechanism
+    }
+
+    @Override
+    public void close() throws Exception {
+        kinesis.close();
+    }
+
+    private static class KinesisRecordsWithSplitIds implements RecordsWithSplitIds<Record> {
+
+        private final Iterator<Record> recordsIterator;
+        private final String splitId;
+        private final boolean isComplete;
+
+        public KinesisRecordsWithSplitIds(
+                Iterator<Record> recordsIterator, String splitId, boolean isComplete) {
+            this.recordsIterator = recordsIterator;
+            this.splitId = splitId;
+            this.isComplete = isComplete;
+        }
+
+        @Nullable
+        @Override
+        public String nextSplit() {
+            return recordsIterator.hasNext() ? splitId : null;
+        }
+
+        @Nullable
+        @Override
+        public Record nextRecordFromSplit() {
+            return recordsIterator.hasNext() ? recordsIterator.next() : null;
+        }
+
+        @Override
+        public Set<String> finishedSplits() {
+            if (splitId == null) {
+                return Collections.emptySet();
+            }
+            if (recordsIterator.hasNext()) {
+                return Collections.emptySet();
+            }
+            return isComplete ? ImmutableSet.of(splitId) : Collections.emptySet();
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchema.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchema.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.serialization;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.util.Collector;
+
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * This is a deserialization schema specific for the {@link KinesisStreamsSource}. Different from
+ * the basic {@link DeserializationSchema}, this schema offers additional Kinesis-specific
+ * information about the record that may be useful to the user application.
+ *
+ * @param <T> The type created by the deserialization schema.
+ */
+@PublicEvolving
+public interface KinesisDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /**
+     * Initialization method for the schema. It is called before the actual working methods {@link
+     * #deserialize} and thus suitable for one time setup work.
+     *
+     * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access
+     * additional features such as e.g. registering user metrics.
+     *
+     * @param context Contextual information that can be used during initialization.
+     */
+    default void open(DeserializationSchema.InitializationContext context) throws Exception {}
+
+    /**
+     * Deserializes a Kinesis record. If the record cannot be deserialized, {@code null} may be
+     * returned. This informs the Flink Kinesis Consumer to process the Kinesis record without
+     * producing any output for it, i.e. effectively "skipping" the record.
+     *
+     * @param record the Kinesis record to deserialize
+     * @param stream the ARN of the Kinesis stream that this record was sent to
+     * @param shardId the identifier of the shard the record was sent to
+     * @param output the identifier of the shard the record was sent to
+     * @throws IOException exception when deserializing record
+     */
+    void deserialize(Record record, String stream, String shardId, Collector<T> output)
+            throws IOException;
+
+    static <T> KinesisDeserializationSchema<T> of(DeserializationSchema<T> deserializationSchema) {
+        return new KinesisDeserializationSchemaWrapper<>(deserializationSchema);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchemaWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.serialization;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.io.IOException;
+
+/**
+ * A simple wrapper for using the {@link DeserializationSchema} with the {@link
+ * KinesisDeserializationSchema} interface.
+ *
+ * @param <T> The type created by the deserialization schema.
+ */
+@Internal
+class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializationSchema<T> {
+    private static final long serialVersionUID = 9143148962928375886L;
+
+    private final DeserializationSchema<T> deserializationSchema;
+
+    KinesisDeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @Override
+    public void open(DeserializationSchema.InitializationContext context) throws Exception {
+        this.deserializationSchema.open(context);
+    }
+
+    @Override
+    public void deserialize(Record record, String stream, String shardId, Collector<T> output)
+            throws IOException {
+        deserializationSchema.deserialize(record.data().asByteArray(), output);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplit.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplit.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumerator;
+
+import org.apache.flink.shaded.curator5.org.apache.curator.shaded.com.google.common.base.Preconditions;
+
+import java.util.Objects;
+
+/**
+ * Contains information about the kinesis stream and shard. Serves as a communication mechanism
+ * between the {@link KinesisStreamsSourceEnumerator} and the {@link SplitReader}. Information
+ * provided here should be immutable. This class is stored in state, so any changes need to be
+ * backwards compatible.
+ */
+@Internal
+public final class KinesisShardSplit implements SourceSplit {
+
+    private final String streamArn;
+    private final String shardId;
+    private final StartingPosition startingPosition;
+
+    public KinesisShardSplit(String streamArn, String shardId, StartingPosition startingPosition) {
+        Preconditions.checkNotNull(streamArn, "streamArn cannot be null");
+        Preconditions.checkNotNull(shardId, "shardId cannot be null");
+        Preconditions.checkNotNull(startingPosition, "startingPosition cannot be null");
+
+        this.streamArn = streamArn;
+        this.shardId = shardId;
+        this.startingPosition = startingPosition;
+    }
+
+    @Override
+    public String splitId() {
+        return shardId;
+    }
+
+    public String getStreamArn() {
+        return streamArn;
+    }
+
+    public String getShardId() {
+        return shardId;
+    }
+
+    public StartingPosition getStartingPosition() {
+        return startingPosition;
+    }
+
+    @Override
+    public String toString() {
+        return "KinesisShardSplit{"
+                + "streamArn='"
+                + streamArn
+                + '\''
+                + ", shardId='"
+                + shardId
+                + '\''
+                + ", startingPosition="
+                + startingPosition
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KinesisShardSplit that = (KinesisShardSplit) o;
+        return Objects.equals(streamArn, that.streamArn)
+                && Objects.equals(shardId, that.shardId)
+                && Objects.equals(startingPosition, that.startingPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(streamArn, shardId, startingPosition);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializer.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializer.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.io.VersionMismatchException;
+
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * Serializes and deserializes the {@link KinesisShardSplit}. This class needs to handle
+ * deserializing splits from older versions.
+ */
+@Internal
+public class KinesisShardSplitSerializer implements SimpleVersionedSerializer<KinesisShardSplit> {
+
+    private static final int CURRENT_VERSION = 0;
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(KinesisShardSplit split) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+
+            out.writeUTF(split.getStreamArn());
+            out.writeUTF(split.getShardId());
+            out.writeUTF(split.getStartingPosition().getShardIteratorType().toString());
+            if (split.getStartingPosition().getStartingMarker() == null) {
+                out.writeBoolean(false);
+            } else {
+                out.writeBoolean(true);
+                Object startingMarker = split.getStartingPosition().getStartingMarker();
+                out.writeBoolean(startingMarker instanceof Instant);
+                if (startingMarker instanceof Instant) {
+                    out.writeLong(((Instant) startingMarker).toEpochMilli());
+                }
+                out.writeBoolean(startingMarker instanceof String);
+                if (startingMarker instanceof String) {
+                    out.writeUTF((String) startingMarker);
+                }
+            }
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public KinesisShardSplit deserialize(int version, byte[] serialized) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            if (version != getVersion()) {
+                throw new VersionMismatchException(
+                        "Trying to deserialize KinesisShardSplit serialized with unsupported version "
+                                + version
+                                + ". Version of serializer is "
+                                + getVersion());
+            }
+
+            final String streamArn = in.readUTF();
+            final String shardId = in.readUTF();
+            final ShardIteratorType shardIteratorType = ShardIteratorType.fromValue(in.readUTF());
+            Object startingMarker = null;
+
+            final boolean hasStartingMarker = in.readBoolean();
+            if (hasStartingMarker) {
+                if (in.readBoolean()) {
+                    startingMarker = Instant.ofEpochMilli(in.readLong());
+                }
+                if (in.readBoolean()) {
+                    startingMarker = in.readUTF();
+                }
+            }
+
+            return new KinesisShardSplit(
+                    streamArn, shardId, new StartingPosition(shardIteratorType, startingMarker));
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitState.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitState.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Stores the metadata around a given {@link KinesisShardSplit}. This class is stored in state, and
+ * any changes should be backwards compatible.
+ */
+@Internal
+public class KinesisShardSplitState {
+    private final KinesisShardSplit kinesisShardSplit;
+    private StartingPosition nextStartingPosition;
+    private String nextShardIterator;
+
+    public KinesisShardSplitState(KinesisShardSplit kinesisShardSplit) {
+        this.kinesisShardSplit = kinesisShardSplit;
+        this.nextStartingPosition = kinesisShardSplit.getStartingPosition();
+    }
+
+    public KinesisShardSplit getKinesisShardSplit() {
+        return new KinesisShardSplit(
+                kinesisShardSplit.getStreamArn(),
+                kinesisShardSplit.getShardId(),
+                nextStartingPosition);
+    }
+
+    public String getSplitId() {
+        return kinesisShardSplit.splitId();
+    }
+
+    public String getStreamArn() {
+        return kinesisShardSplit.getStreamArn();
+    }
+
+    public String getShardId() {
+        return kinesisShardSplit.getShardId();
+    }
+
+    public StartingPosition getNextStartingPosition() {
+        return nextStartingPosition;
+    }
+
+    public void setNextStartingPosition(StartingPosition nextStartingPosition) {
+        this.nextStartingPosition = nextStartingPosition;
+    }
+
+    public String getNextShardIterator() {
+        return nextShardIterator;
+    }
+
+    public void setNextShardIterator(String nextShardIterator) {
+        this.nextShardIterator = nextShardIterator;
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/StartingPosition.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/StartingPosition.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.apache.flink.annotation.Internal;
+
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import javax.annotation.Nullable;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.AFTER_SEQUENCE_NUMBER;
+import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
+import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.TRIM_HORIZON;
+
+/** Data class indicating the starting position for reading a given shard. */
+@Internal
+public final class StartingPosition {
+
+    private final ShardIteratorType shardIteratorType;
+    private final Object startingMarker;
+
+    StartingPosition(ShardIteratorType shardIteratorType, Object startingMarker) {
+        this.shardIteratorType = shardIteratorType;
+        this.startingMarker = startingMarker;
+    }
+
+    public ShardIteratorType getShardIteratorType() {
+        return shardIteratorType;
+    }
+
+    @Nullable
+    public Object getStartingMarker() {
+        return startingMarker;
+    }
+
+    public static StartingPosition fromTimestamp(final Instant timestamp) {
+        return new StartingPosition(AT_TIMESTAMP, timestamp);
+    }
+
+    public static StartingPosition continueFromSequenceNumber(final String sequenceNumber) {
+        return new StartingPosition(AFTER_SEQUENCE_NUMBER, sequenceNumber);
+    }
+
+    public static StartingPosition fromStart() {
+        return new StartingPosition(TRIM_HORIZON, null);
+    }
+
+    @Override
+    public String toString() {
+        return "StartingPosition{"
+                + "shardIteratorType="
+                + shardIteratorType
+                + ", startingMarker="
+                + startingMarker
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StartingPosition that = (StartingPosition) o;
+        return shardIteratorType == that.shardIteratorType
+                && Objects.equals(startingMarker, that.startingMarker);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shardIteratorType, startingMarker);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.kinesis.source.enumerator.assigner.ShardAssignerFactory;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.STREAM_ARN;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class KinesisStreamsSourceTest {
+
+    @Test
+    void testSupportsContinuousUnboundedOnly() throws Exception {
+        final Properties sourceConfig = new Properties();
+        final KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(STREAM_ARN)
+                        .setConsumerConfig(sourceConfig)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .setKinesisShardAssigner(ShardAssignerFactory.uniformShardAssigner())
+                        .build();
+
+        assertThat(source.getBoundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigUtilTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/config/KinesisStreamsSourceConfigUtilTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.STREAM_INITIAL_TIMESTAMP;
+import static org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class KinesisStreamsSourceConfigUtilTest {
+
+    @Test
+    void testParseStreamTimestampUsingDefaultFormat() throws Exception {
+        String timestamp = "2023-04-13T09:18:00.0+01:00";
+        Date expectedTimestamp =
+                new SimpleDateFormat(DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT).parse(timestamp);
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, timestamp);
+
+        assertThat(
+                        KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition(
+                                consumerProperties))
+                .isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    void testParseStreamTimestampUsingCustomFormat() throws Exception {
+        String format = "yyyy-MM-dd'T'HH:mm";
+        String timestamp = "2023-04-13T09:23";
+        Date expectedTimestamp = new SimpleDateFormat(format).parse(timestamp);
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, timestamp);
+        consumerProperties.setProperty(STREAM_TIMESTAMP_DATE_FORMAT, format);
+
+        assertThat(
+                        KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition(
+                                consumerProperties))
+                .isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    void testParseStreamTimestampEpoch() {
+        long epoch = 1681910583L;
+        Date expectedTimestamp = new Date(epoch * 1000);
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, String.valueOf(epoch));
+
+        assertThat(
+                        KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition(
+                                consumerProperties))
+                .isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    void testParseStreamTimestampParseError() {
+        String badTimestamp = "badTimestamp";
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, badTimestamp);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(
+                        () ->
+                                KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition(
+                                        consumerProperties));
+    }
+
+    @Test
+    void testParseStreamTimestampTimestampNotSpecified() {
+        Properties consumerProperties = new Properties();
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                KinesisStreamsSourceConfigUtil.parseStreamTimestampStartingPosition(
+                                        consumerProperties));
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
+import org.apache.flink.core.io.VersionMismatchException;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static java.util.Arrays.copyOf;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class KinesisStreamsSourceEnumeratorStateSerializerTest {
+
+    @Test
+    void testSerializeAndDeserializeEverythingSpecified() throws Exception {
+        Set<String> completedShardIds =
+                ImmutableSet.of(
+                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+        Set<KinesisShardSplit> unassignedSplits =
+                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+        String lastSeenShardId = "shardId-000000000002";
+        KinesisStreamsSourceEnumeratorState initialState =
+                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+
+        KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer serializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(splitSerializer);
+
+        byte[] serialized = serializer.serialize(initialState);
+        KinesisStreamsSourceEnumeratorState deserializedState =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserializedState).usingRecursiveComparison().isEqualTo(initialState);
+    }
+
+    @Test
+    void testDeserializeWithWrongVersionStateSerializer() throws Exception {
+        Set<String> completedShardIds =
+                ImmutableSet.of(
+                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+        Set<KinesisShardSplit> unassignedSplits =
+                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+        String lastSeenShardId = "shardId-000000000002";
+        KinesisStreamsSourceEnumeratorState initialState =
+                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+
+        KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer serializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(splitSerializer);
+        KinesisStreamsSourceEnumeratorStateSerializer wrongVersionStateSerializer =
+                new WrongVersionStateSerializer(splitSerializer);
+
+        byte[] serialized = wrongVersionStateSerializer.serialize(initialState);
+
+        assertThatExceptionOfType(VersionMismatchException.class)
+                .isThrownBy(
+                        () ->
+                                serializer.deserialize(
+                                        wrongVersionStateSerializer.getVersion(), serialized))
+                .withMessageContaining(
+                        "Trying to deserialize KinesisStreamsSourceEnumeratorState serialized with unsupported version")
+                .withMessageContaining(String.valueOf(serializer.getVersion()))
+                .withMessageContaining(String.valueOf(wrongVersionStateSerializer.getVersion()));
+    }
+
+    @Test
+    void testDeserializeWithWrongVersionSplitSerializer() throws Exception {
+        Set<String> completedShardIds =
+                ImmutableSet.of(
+                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+        Set<KinesisShardSplit> unassignedSplits =
+                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+        String lastSeenShardId = "shardId-000000000002";
+        KinesisStreamsSourceEnumeratorState initialState =
+                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+
+        KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer serializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(splitSerializer);
+        KinesisShardSplitSerializer wrongVersionSplitSerializer = new WrongVersionSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer wrongVersionStateSerializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(wrongVersionSplitSerializer);
+
+        byte[] serialized = wrongVersionStateSerializer.serialize(initialState);
+
+        assertThatExceptionOfType(VersionMismatchException.class)
+                .isThrownBy(() -> serializer.deserialize(serializer.getVersion(), serialized))
+                .withMessageContaining(
+                        "Trying to deserialize KinesisShardSplit serialized with unsupported version")
+                .withMessageContaining(String.valueOf(serializer.getVersion()))
+                .withMessageContaining(String.valueOf(wrongVersionStateSerializer.getVersion()));
+    }
+
+    @Test
+    void testSerializeWithTrailingBytes() throws Exception {
+        Set<String> completedShardIds =
+                ImmutableSet.of(
+                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+        Set<KinesisShardSplit> unassignedSplits =
+                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+        String lastSeenShardId = "shardId-000000000002";
+        KinesisStreamsSourceEnumeratorState initialState =
+                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+
+        KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer serializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(splitSerializer);
+
+        byte[] serialized = serializer.serialize(initialState);
+        byte[] extraBytesSerialized = copyOf(serialized, serialized.length + 1);
+
+        assertThatExceptionOfType(IOException.class)
+                .isThrownBy(
+                        () -> serializer.deserialize(serializer.getVersion(), extraBytesSerialized))
+                .withMessageContaining("Unexpected trailing bytes when deserializing.");
+    }
+
+    private static class WrongVersionStateSerializer
+            extends KinesisStreamsSourceEnumeratorStateSerializer {
+
+        public WrongVersionStateSerializer(KinesisShardSplitSerializer splitSerializer) {
+            super(splitSerializer);
+        }
+
+        @Override
+        public int getVersion() {
+            return -1;
+        }
+    }
+
+    private static class WrongVersionSplitSerializer extends KinesisShardSplitSerializer {
+
+        @Override
+        public int getVersion() {
+            return -1;
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorTest.java
@@ -1,0 +1,678 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants;
+import org.apache.flink.connector.kinesis.source.config.KinesisStreamsSourceConfigConstants.InitialPosition;
+import org.apache.flink.connector.kinesis.source.enumerator.assigner.ShardAssignerFactory;
+import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.util.TestUtil;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.TestKinesisStreamProxy;
+import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class KinesisStreamsSourceEnumeratorTest {
+
+    private static final int NUM_SUBTASKS = 1;
+    private static final String STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:123456789012:stream/keenesesStream";
+
+    @ParameterizedTest
+    @MethodSource("provideInitialPositions")
+    void testStartWithoutStateDiscoversAndAssignsShards(
+            InitialPosition initialPosition,
+            String initialTimestamp,
+            ShardIteratorType expectedShardIteratorType)
+            throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            consumerConfig.setProperty(
+                    KinesisStreamsSourceConfigConstants.STREAM_INITIAL_POSITION,
+                    initialPosition.name());
+            consumerConfig.setProperty(
+                    KinesisStreamsSourceConfigConstants.STREAM_INITIAL_TIMESTAMP, initialTimestamp);
+
+            // Given enumerator is initialized with no state
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            // When enumerator starts
+            enumerator.start();
+            // Then initial discovery scheduled, with periodic discovery after
+            assertThat(context.getOneTimeCallables()).hasSize(1);
+            assertThat(context.getPeriodicCallables()).hasSize(1);
+
+            // Given there is one registered reader, with 4 shards in stream
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+            // When first discovery runs
+            context.runNextOneTimeCallable();
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+            // Then all 4 shards discovered on startup with configured INITIAL_POSITION
+            assertThat(initialSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(shardIds);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getStartingPosition))
+                    .allSatisfy(
+                            s ->
+                                    assertThat(s.getShardIteratorType())
+                                            .isEqualTo(expectedShardIteratorType));
+
+            // Given no resharding occurs (list of shards remains the same)
+            // When first periodic discovery runs
+            context.runPeriodicCallable(0);
+            // Then no additional splits are assigned
+            SplitsAssignment<KinesisShardSplit> noUpdateSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(1);
+            assertThat(noUpdateSplitAssignment.assignment()).isEmpty();
+
+            // Given resharding occurs
+            String[] additionalShards = new String[] {generateShardId(4), generateShardId(5)};
+            streamProxy.addShards(additionalShards);
+            // When periodic discovery runs
+            context.runPeriodicCallable(0);
+            // Then only additional shards are assigned to read from TRIM_HORIZON
+            SplitsAssignment<KinesisShardSplit> afterReshardingSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(2);
+            assertThat(afterReshardingSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            afterReshardingSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(additionalShards);
+            assertThat(
+                            afterReshardingSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getStartingPosition))
+                    .allSatisfy(
+                            s ->
+                                    assertThat(s.getShardIteratorType())
+                                            .isEqualTo(ShardIteratorType.TRIM_HORIZON));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInitialPositions")
+    void testStartWithStateDoesNotAssignCompletedShards(
+            InitialPosition initialPosition,
+            String initialTimestamp,
+            ShardIteratorType expectedShardIteratorType)
+            throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final String completedShard = generateShardId(0);
+            final String lastSeenShard = generateShardId(1);
+            final Set<String> completedShardIds = ImmutableSet.of(completedShard);
+
+            KinesisStreamsSourceEnumeratorState state =
+                    new KinesisStreamsSourceEnumeratorState(Collections.emptySet(), lastSeenShard);
+
+            final Properties consumerConfig = new Properties();
+            consumerConfig.setProperty(
+                    KinesisStreamsSourceConfigConstants.STREAM_INITIAL_POSITION,
+                    initialPosition.name());
+            consumerConfig.setProperty(
+                    KinesisStreamsSourceConfigConstants.STREAM_INITIAL_TIMESTAMP, initialTimestamp);
+
+            // Given enumerator is initialised with state
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            state);
+            // When enumerator starts
+            enumerator.start();
+            // Then no initial discovery is scheduled, but a periodic discovery is scheduled
+            assertThat(context.getOneTimeCallables()).isEmpty();
+            assertThat(context.getPeriodicCallables()).hasSize(1);
+
+            // Given there is one registered reader, with 4 shards in stream
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        completedShard, lastSeenShard, generateShardId(2), generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+            // When first periodic discovery of shards
+            context.runPeriodicCallable(0);
+            // Then newer shards will be discovered and read from TRIM_HORIZON, independent of
+            // configured starting position
+            SplitsAssignment<KinesisShardSplit> firstUpdateSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+            assertThat(firstUpdateSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            firstUpdateSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(generateShardId(2), generateShardId(3));
+            assertThat(
+                            firstUpdateSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getStartingPosition))
+                    .allSatisfy(
+                            s ->
+                                    assertThat(s.getShardIteratorType())
+                                            .isEqualTo(ShardIteratorType.TRIM_HORIZON));
+        }
+    }
+
+    @Test
+    void testReturnedSplitsWillBeReassigned() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            KinesisStreamsSourceEnumerator enumerator =
+                    getSimpleEnumeratorWithNoState(context, streamProxy);
+
+            // Given enumerator is initialised with one registered reader, with 4 shards in stream
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+
+            // When first discovery runs
+            context.runNextOneTimeCallable();
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+
+            // Then all 4 shards discovered on startup
+            assertThat(initialSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(shardIds);
+
+            // Given one shard split is returned
+            KinesisShardSplit returnedSplit =
+                    initialSplitAssignment.assignment().get(subtaskId).get(0);
+            enumerator.addSplitsBack(ImmutableList.of(returnedSplit), subtaskId);
+
+            // When first periodic discovery runs
+            context.runPeriodicCallable(0);
+            // Then returned split will be assigned
+            SplitsAssignment<KinesisShardSplit> firstReturnedSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(1);
+            assertThat(firstReturnedSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(firstReturnedSplitAssignment.assignment().get(subtaskId))
+                    .containsExactly(returnedSplit);
+        }
+    }
+
+    @Test
+    void testAddSplitsBackWithoutSplitIsNoOp() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            KinesisStreamsSourceEnumerator enumerator =
+                    getSimpleEnumeratorWithNoState(context, streamProxy);
+            List<KinesisShardSplit> splits = ImmutableList.of(getTestSplit());
+
+            // Given enumerator has no assigned splits
+            // When we add splits back
+            // Then handled gracefully with no exception thrown
+            assertThatNoException().isThrownBy(() -> enumerator.addSplitsBack(splits, 1));
+        }
+    }
+
+    @Test
+    void testAddSplitsBackAssignsUnassignedSplits() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            KinesisStreamsSourceEnumerator enumerator =
+                    getSimpleEnumeratorWithNoState(context, streamProxy);
+
+            // Given enumerator has assigned splits
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+            context.runNextOneTimeCallable();
+
+            // Ensure that there are splits assigned
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+            assertThat(initialSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(shardIds);
+
+            // When we add splits back
+            KinesisShardSplit returnedSplit =
+                    initialSplitAssignment.assignment().get(subtaskId).get(0);
+            enumerator.addSplitsBack(ImmutableList.of(returnedSplit), 1);
+
+            // Then splits are reassigned
+            assertThat(context.getSplitsAssignmentSequence()).hasSizeGreaterThan(1);
+            SplitsAssignment<KinesisShardSplit> secondSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(1);
+            assertThat(secondSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(secondSplitAssignment.assignment().get(subtaskId))
+                    .containsExactly(returnedSplit);
+        }
+    }
+
+    @Test
+    void testHandleSplitRequestIsNoOp() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            KinesisStreamsSourceEnumerator enumerator =
+                    getSimpleEnumeratorWithNoState(context, streamProxy);
+
+            // Given enumerator has no assigned splits
+            // When we add splits back
+            // Then handled gracefully with no exception thrown
+            assertThatNoException()
+                    .isThrownBy(() -> enumerator.handleSplitRequest(1, "some-hostname"));
+        }
+    }
+
+    @Test
+    void testAssignSplitsSurfacesThrowableIfUnableToListShards() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            // Given List Shard request throws an Exception
+            streamProxy.setListShardsExceptionSupplier(
+                    () -> AwsServiceException.create("Internal Service Error", null));
+
+            // When first discovery runs
+            // Then runtime exception is thrown
+            assertThatExceptionOfType(FlinkRuntimeException.class)
+                    .isThrownBy(context::runNextOneTimeCallable)
+                    .withMessage("Failed to list shards.")
+                    .withStackTraceContaining("Internal Service Error");
+        }
+    }
+
+    @Test
+    void testAssignSplitsHandlesRepeatSplitsGracefully() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            // Given enumerator is initialised with one registered reader, with 4 shards in stream
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+
+            // When first discovery runs
+            context.runNextOneTimeCallable();
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+
+            // Then all 4 shards discovered on startup
+            assertThat(initialSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactly(shardIds);
+
+            // Given ListShards doesn't respect lastSeenShardId, and returns already assigned shards
+            streamProxy.setShouldRespectLastSeenShardId(false);
+
+            // When first periodic discovery runs
+            // Then handled gracefully
+            assertThatNoException().isThrownBy(() -> context.runPeriodicCallable(0));
+            SplitsAssignment<KinesisShardSplit> secondReturnedSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(1);
+            assertThat(secondReturnedSplitAssignment.assignment()).isEmpty();
+        }
+    }
+
+    @Test
+    void testAssignSplitWithoutRegisteredReaders() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            // Given enumerator is initialised without a reader
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+
+            // When first discovery runs
+            context.runNextOneTimeCallable();
+
+            // Then nothing is assigned
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+
+            // Given a reader is now registered
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+
+            // When next periodic discovery is run
+            context.runPeriodicCallable(0);
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+
+            // Then shards are assigned, still respecting original configuration
+            assertThat(initialSplitAssignment.assignment()).containsOnlyKeys(subtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactlyInAnyOrder(shardIds);
+            assertThat(
+                            initialSplitAssignment.assignment().get(subtaskId).stream()
+                                    .map(KinesisShardSplit::getStartingPosition))
+                    .allSatisfy(
+                            s ->
+                                    assertThat(s.getShardIteratorType())
+                                            .isEqualTo(ShardIteratorType.AT_TIMESTAMP));
+        }
+    }
+
+    @Test
+    void testAssignSplitWithInsufficientRegisteredReaders() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(2)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            // Given enumerator is initialised without only one reader
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+
+            // When first discovery runs
+            context.runNextOneTimeCallable();
+
+            // Then nothing is assigned
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+
+            // Given a reader is now registered
+            final int secondSubtaskId = 2;
+            context.registerReader(TestUtil.getTestReaderInfo(secondSubtaskId));
+            enumerator.addReader(secondSubtaskId);
+
+            // When next periodic discovery is run
+            context.runPeriodicCallable(0);
+            SplitsAssignment<KinesisShardSplit> initialSplitAssignment =
+                    context.getSplitsAssignmentSequence().get(0);
+
+            // Then shards are assigned, still respecting original configuration
+            assertThat(initialSplitAssignment.assignment())
+                    .containsOnlyKeys(subtaskId, secondSubtaskId);
+            assertThat(
+                            initialSplitAssignment.assignment().values().stream()
+                                    .flatMap(Collection::stream)
+                                    .map(KinesisShardSplit::getShardId))
+                    .containsExactlyInAnyOrder(shardIds);
+            assertThat(
+                            initialSplitAssignment.assignment().values().stream()
+                                    .flatMap(Collection::stream)
+                                    .map(KinesisShardSplit::getStartingPosition))
+                    .allSatisfy(
+                            s ->
+                                    assertThat(s.getShardIteratorType())
+                                            .isEqualTo(ShardIteratorType.AT_TIMESTAMP));
+        }
+    }
+
+    @Test
+    void testRestoreFromStateRemembersLastSeenShardId() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                MockSplitEnumeratorContext<KinesisShardSplit> restoredContext =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            // Given enumerator is initialised with one registered reader, with 4 shards in stream
+            final int subtaskId = 1;
+            context.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            enumerator.addReader(subtaskId);
+            String[] shardIds =
+                    new String[] {
+                        generateShardId(0),
+                        generateShardId(1),
+                        generateShardId(2),
+                        generateShardId(3)
+                    };
+            streamProxy.addShards(shardIds);
+            // Given enumerator has run discovery
+            context.runNextOneTimeCallable();
+
+            // When restored from state
+            KinesisStreamsSourceEnumeratorState snapshottedState = enumerator.snapshotState(1);
+            KinesisStreamsSourceEnumerator restoredEnumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            restoredContext,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            snapshottedState);
+            restoredEnumerator.start();
+            // Given enumerator is initialised with one registered reader, with 4 shards in stream
+            restoredContext.registerReader(TestUtil.getTestReaderInfo(subtaskId));
+            restoredEnumerator.addReader(subtaskId);
+            restoredContext.runPeriodicCallable(0);
+
+            // Then ListShards receives a ListShards call with the lastSeenShardId
+            assertThat(streamProxy.getLastProvidedLastSeenShardId())
+                    .isEqualTo(shardIds[shardIds.length - 1]);
+        }
+    }
+
+    @Test
+    void testHandleUnrecognisedSourceEventIsNoOp() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+
+            assertThatNoException()
+                    .isThrownBy(() -> enumerator.handleSourceEvent(1, new SourceEvent() {}));
+        }
+    }
+
+    @Test
+    void testCloseClosesStreamProxy() throws Throwable {
+        try (MockSplitEnumeratorContext<KinesisShardSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS)) {
+            TestKinesisStreamProxy streamProxy = getTestStreamProxy();
+            final Properties consumerConfig = new Properties();
+            KinesisStreamsSourceEnumerator enumerator =
+                    new KinesisStreamsSourceEnumerator(
+                            context,
+                            STREAM_ARN,
+                            consumerConfig,
+                            streamProxy,
+                            ShardAssignerFactory.uniformShardAssigner(),
+                            null);
+            enumerator.start();
+
+            assertThatNoException().isThrownBy(enumerator::close);
+            assertThat(streamProxy.isClosed()).isTrue();
+        }
+    }
+
+    private KinesisStreamsSourceEnumerator getSimpleEnumeratorWithNoState(
+            MockSplitEnumeratorContext<KinesisShardSplit> context, StreamProxy streamProxy) {
+        final Properties consumerConfig = new Properties();
+        KinesisStreamsSourceEnumerator enumerator =
+                new KinesisStreamsSourceEnumerator(
+                        context,
+                        STREAM_ARN,
+                        consumerConfig,
+                        streamProxy,
+                        ShardAssignerFactory.uniformShardAssigner(),
+                        null);
+        enumerator.start();
+        assertThat(context.getOneTimeCallables()).hasSize(1);
+        assertThat(context.getPeriodicCallables()).hasSize(1);
+        return enumerator;
+    }
+
+    private static Stream<Arguments> provideInitialPositions() {
+        return Stream.of(
+                Arguments.of(InitialPosition.LATEST, "", ShardIteratorType.AT_TIMESTAMP),
+                Arguments.of(InitialPosition.TRIM_HORIZON, "", ShardIteratorType.TRIM_HORIZON),
+                Arguments.of(
+                        InitialPosition.AT_TIMESTAMP,
+                        "2023-04-13T09:18:00.0+01:00",
+                        ShardIteratorType.AT_TIMESTAMP));
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssignerTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssignerTest.java
@@ -1,0 +1,147 @@
+package org.apache.flink.connector.kinesis.source.enumerator.assigner;
+
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestReaderInfo;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class UniformShardAssignerTest {
+
+    @Test
+    void testAssignedToLeastBusySubtask() {
+        final KinesisShardSplit split = getTestSplit();
+        final TestShardAssignerContext assignerContext = new TestShardAssignerContext();
+
+        // Given a distribution of subtasks with varying busyness
+        createReaderWithAssignedSplits(assignerContext, 1, 3);
+        createReaderWithAssignedSplits(assignerContext, 2, 2);
+        createReaderWithAssignedSplits(assignerContext, 3, 1);
+
+        // When assigned a subtask
+        KinesisShardAssigner assigner = new UniformShardAssigner();
+
+        // Then least busy subtask is chosen
+        assertThat(assigner.assign(split, assignerContext)).isEqualTo(3);
+    }
+
+    @Test
+    void testAssignedToLeastBusySubtaskConsideringPendingAssignments() {
+        final KinesisShardSplit split = getTestSplit();
+        final TestShardAssignerContext assignerContext = new TestShardAssignerContext();
+
+        // Given a distribution of subtasks with same busyness
+        createReaderWithAssignedSplits(assignerContext, 1, 1);
+        createReaderWithAssignedSplits(assignerContext, 2, 1);
+        createReaderWithAssignedSplits(assignerContext, 3, 1);
+        // Given a pending distribution of subtasks with varying busyness
+        addPendingSplits(assignerContext, 1, 3);
+        addPendingSplits(assignerContext, 2, 1);
+        addPendingSplits(assignerContext, 3, 3);
+
+        // When assigned a subtask
+        KinesisShardAssigner assigner = new UniformShardAssigner();
+
+        // Then least busy subtask is chosen
+        assertThat(assigner.assign(split, assignerContext)).isEqualTo(2);
+    }
+
+    @Test
+    void testOnlyRegisteredReaders() {
+        final KinesisShardSplit split = getTestSplit();
+        final TestShardAssignerContext assignerContext = new TestShardAssignerContext();
+
+        // Given a few registered readers
+        assignerContext.registeredReaders.put(1, getTestReaderInfo(1));
+        assignerContext.registeredReaders.put(2, getTestReaderInfo(2));
+        assignerContext.registeredReaders.put(3, getTestReaderInfo(3));
+
+        // When assigned a subtask
+        KinesisShardAssigner assigner = new UniformShardAssigner();
+        // Then Exception is thrown
+        assertThat(assigner.assign(split, assignerContext)).isIn(1, 2, 3);
+    }
+
+    @Test
+    void testNoRegisteredReaders() {
+        final KinesisShardSplit split = getTestSplit();
+        final TestShardAssignerContext assignerContext = new TestShardAssignerContext();
+
+        // Given no registered readers
+
+        // When assigned a subtask
+        KinesisShardAssigner assigner = new UniformShardAssigner();
+
+        // Then Exception is thrown
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> assigner.assign(split, assignerContext))
+                .withMessageContaining(
+                        "Expected at least one registered reader. Unable to assign split.");
+    }
+
+    private void createReaderWithAssignedSplits(
+            TestShardAssignerContext testShardAssignerContext,
+            int subtaskId,
+            int numAssignedSplits) {
+        testShardAssignerContext.registeredReaders.put(subtaskId, getTestReaderInfo(subtaskId));
+
+        if (!testShardAssignerContext.splitAssignment.containsKey(subtaskId)) {
+            testShardAssignerContext.splitAssignment.put(subtaskId, new HashSet<>());
+        }
+        for (int i = 0; i < numAssignedSplits; i++) {
+            testShardAssignerContext
+                    .splitAssignment
+                    .get(subtaskId)
+                    .add(getTestSplit(String.valueOf(i)));
+        }
+    }
+
+    private void addPendingSplits(
+            TestShardAssignerContext testShardAssignerContext,
+            int subtaskId,
+            int numAssignedSplits) {
+        if (!testShardAssignerContext.pendingSplitAssignments.containsKey(subtaskId)) {
+            testShardAssignerContext.pendingSplitAssignments.put(subtaskId, new ArrayList<>());
+        }
+        for (int i = 0; i < numAssignedSplits; i++) {
+            testShardAssignerContext
+                    .pendingSplitAssignments
+                    .get(subtaskId)
+                    .add(getTestSplit(String.valueOf(i)));
+        }
+    }
+
+    private static class TestShardAssignerContext implements KinesisShardAssigner.Context {
+        private final Map<Integer, Set<KinesisShardSplit>> splitAssignment = new HashMap<>();
+        private final Map<Integer, List<KinesisShardSplit>> pendingSplitAssignments =
+                new HashMap<>();
+        private final Map<Integer, ReaderInfo> registeredReaders = new HashMap<>();
+
+        @Override
+        public Map<Integer, Set<KinesisShardSplit>> getCurrentSplitAssignment() {
+            return splitAssignment;
+        }
+
+        @Override
+        public Map<Integer, ReaderInfo> getRegisteredReaders() {
+            return registeredReaders;
+        }
+
+        @Override
+        public Map<Integer, List<KinesisShardSplit>> getPendingSplitAssignments() {
+            return pendingSplitAssignments;
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/examples/SourceFromKinesis.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/examples/SourceFromKinesis.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.examples;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.aws.config.AWSConfigConstants;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.connector.kinesis.source.enumerator.assigner.ShardAssignerFactory;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.Properties;
+
+/**
+ * An example application demonstrating how to use the {@link KinesisStreamsSource} to read from
+ * KDS.
+ */
+public class SourceFromKinesis {
+
+    public static void main(String[] args) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(10_000);
+        env.setParallelism(2);
+
+        Properties consumerConfig = new Properties();
+        consumerConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+        KinesisStreamsSource<String> kdsSource =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(
+                                "arn:aws:kinesis:us-east-1:290038087681:stream/LoadTestBeta_Input_35")
+                        .setConsumerConfig(consumerConfig)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .setKinesisShardAssigner(ShardAssignerFactory.uniformShardAssigner())
+                        .build();
+        env.fromSource(kdsSource, WatermarkStrategy.noWatermarks(), "Kinesis source")
+                .returns(TypeInformation.of(String.class))
+                .print();
+
+        env.execute("KinesisSource Example Program");
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/model/TestData.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/model/TestData.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.model;
+
+/** Data class for use in testing Kinesis Source. */
+public class TestData {
+    private final String stringData;
+    private final int intData;
+
+    private TestData(String stringData, int intData) {
+        this.stringData = stringData;
+        this.intData = intData;
+    }
+
+    public String getStringData() {
+        return stringData;
+    }
+
+    public int getIntData() {
+        return intData;
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxyTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxyTest.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.proxy;
+
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+import org.apache.flink.connector.kinesis.source.util.KinesisClientProvider.ListShardItem;
+import org.apache.flink.connector.kinesis.source.util.KinesisClientProvider.TestingKinesisClient;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.KinesisRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+
+class KinesisStreamProxyTest {
+    private static final SdkHttpClient HTTP_CLIENT = ApacheHttpClient.builder().build();
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"shardId-000000000002"})
+    void testListShardsSingleCall(String lastSeenShardId) {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final List<Shard> expectedShards = getTestShards(0, 3);
+
+        List<ListShardItem> listShardItems =
+                ImmutableList.of(
+                        ListShardItem.builder()
+                                .validation(
+                                        getListShardRequestValidation(
+                                                streamArn, lastSeenShardId, null))
+                                .shards(expectedShards)
+                                .nextToken(null)
+                                .build());
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setListShardsResponses(listShardItems);
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThat(kinesisStreamProxy.listShards(streamArn, lastSeenShardId))
+                .isEqualTo(expectedShards);
+    }
+
+    @Test
+    void testListShardsMultipleCalls() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String lastSeenShardId = "shardId-000000000000";
+        final List<Shard> expectedShards = getTestShards(0, 3);
+
+        List<ListShardItem> listShardItems =
+                ImmutableList.of(
+                        ListShardItem.builder()
+                                .validation(
+                                        getListShardRequestValidation(
+                                                streamArn, lastSeenShardId, null))
+                                .shards(expectedShards.subList(0, 1))
+                                .nextToken("next-token-1")
+                                .build(),
+                        ListShardItem.builder()
+                                .validation(
+                                        getListShardRequestValidation(
+                                                streamArn, null, "next-token-1"))
+                                .shards(expectedShards.subList(1, 2))
+                                .nextToken("next-token-2")
+                                .build(),
+                        ListShardItem.builder()
+                                .validation(
+                                        getListShardRequestValidation(
+                                                streamArn, null, "next-token-2"))
+                                .shards(expectedShards.subList(2, 4))
+                                .nextToken(null)
+                                .build());
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setListShardsResponses(listShardItems);
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThat(kinesisStreamProxy.listShards(streamArn, lastSeenShardId))
+                .isEqualTo(expectedShards);
+    }
+
+    @Test
+    void testGetRecordsInitialReadFromTrimHorizon() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final StartingPosition startingPosition = StartingPosition.fromStart();
+
+        final String expectedShardIterator = "some-shard-iterator";
+        final GetRecordsResponse expectedGetRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator("next-iterator")
+                        .build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setNextShardIterator(expectedShardIterator);
+        testKinesisClient.setShardIteratorValidation(
+                validateEqual(
+                        GetShardIteratorRequest.builder()
+                                .streamARN(streamArn)
+                                .shardId(shardId)
+                                .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                .build()));
+        testKinesisClient.setGetRecordsResponse(expectedGetRecordsResponse);
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(expectedShardIterator)
+                                .build()));
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(expectedGetRecordsResponse);
+    }
+
+    @Test
+    void testGetRecordsInitialReadFromTimestamp() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final Instant timestamp = Instant.now();
+        final StartingPosition startingPosition = StartingPosition.fromTimestamp(timestamp);
+
+        final String expectedShardIterator = "some-shard-iterator";
+        final GetRecordsResponse expectedGetRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator("next-iterator")
+                        .build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setNextShardIterator(expectedShardIterator);
+        testKinesisClient.setShardIteratorValidation(
+                validateEqual(
+                        GetShardIteratorRequest.builder()
+                                .streamARN(streamArn)
+                                .shardId(shardId)
+                                .shardIteratorType(ShardIteratorType.AT_TIMESTAMP)
+                                .timestamp(timestamp)
+                                .build()));
+        testKinesisClient.setGetRecordsResponse(expectedGetRecordsResponse);
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(expectedShardIterator)
+                                .build()));
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(expectedGetRecordsResponse);
+    }
+
+    @Test
+    void testGetRecordsInitialReadFromSequenceNumber() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final String sequenceNumber = "some-sequence-number";
+        final StartingPosition startingPosition =
+                StartingPosition.continueFromSequenceNumber(sequenceNumber);
+
+        final String expectedShardIterator = "some-shard-iterator";
+        final GetRecordsResponse expectedGetRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator("next-iterator")
+                        .build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setNextShardIterator(expectedShardIterator);
+        testKinesisClient.setShardIteratorValidation(
+                validateEqual(
+                        GetShardIteratorRequest.builder()
+                                .streamARN(streamArn)
+                                .shardId(shardId)
+                                .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+                                .startingSequenceNumber(sequenceNumber)
+                                .build()));
+        testKinesisClient.setGetRecordsResponse(expectedGetRecordsResponse);
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(expectedShardIterator)
+                                .build()));
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(expectedGetRecordsResponse);
+    }
+
+    @Test
+    void testConsecutiveGetRecordsUsesShardIteratorFromResponse() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final StartingPosition startingPosition = StartingPosition.fromStart();
+
+        final String firstShardIterator = "first-shard-iterator";
+        final String secondShardIterator = "second-shard-iterator";
+        final GetRecordsResponse firstGetRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator(secondShardIterator)
+                        .build();
+        final GetRecordsResponse secondGetRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator("third-shard-iterator")
+                        .build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        // When read for the first time
+        testKinesisClient.setNextShardIterator(firstShardIterator);
+        // Then getShardIterator called
+        testKinesisClient.setShardIteratorValidation(
+                validateEqual(
+                        GetShardIteratorRequest.builder()
+                                .streamARN(streamArn)
+                                .shardId(shardId)
+                                .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                .build()));
+        testKinesisClient.setGetRecordsResponse(firstGetRecordsResponse);
+        // Then getRecords called with returned shard iterator
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(firstShardIterator)
+                                .build()));
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(firstGetRecordsResponse);
+
+        // When read for the second time
+        // Then getShardsIterator() not called
+        testKinesisClient.setShardIteratorValidation(
+                (request) -> {
+                    throw new RuntimeException(
+                            "Call to GetShardIterator not expected on subsequent get records call");
+                });
+        testKinesisClient.setGetRecordsResponse(secondGetRecordsResponse);
+        // Then getRecords() called with shardIterator from previous response
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(secondShardIterator)
+                                .build()));
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(secondGetRecordsResponse);
+    }
+
+    @Test
+    void testGetRecordsEagerlyRetriesExpiredIterators() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final StartingPosition startingPosition = StartingPosition.fromStart();
+
+        final String firstShardIterator = "first-shard-iterator";
+        final String secondShardIterator = "second-shard-iterator";
+        final GetRecordsResponse getRecordsResponse =
+                GetRecordsResponse.builder()
+                        .records(Record.builder().build())
+                        .nextShardIterator(secondShardIterator)
+                        .build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        // When expired shard iterator is thrown on the first GetRecords() call
+        AtomicBoolean firstGetRecordsCall = new AtomicBoolean(true);
+        testKinesisClient.setNextShardIterator(firstShardIterator);
+        testKinesisClient.setShardIteratorValidation(ignored -> {});
+        testKinesisClient.setNextShardIterator(secondShardIterator);
+        testKinesisClient.setGetRecordsResponse(getRecordsResponse);
+        testKinesisClient.setGetRecordsValidation(
+                request -> {
+                    if (firstGetRecordsCall.get()) {
+                        firstGetRecordsCall.set(false);
+                        throw ExpiredIteratorException.builder().build();
+                    }
+                    // Then getRecords called with second shard iterator
+                    validateEqual(
+                            GetRecordsRequest.builder()
+                                    .streamARN(streamArn)
+                                    .shardIterator(secondShardIterator)
+                                    .build());
+                });
+
+        // Then getRecords called with second shard iterator
+        assertThat(kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition))
+                .isEqualTo(getRecordsResponse);
+        assertThat(firstGetRecordsCall.get()).isFalse();
+    }
+
+    @Test
+    void testGetRecordsHandlesCompletedShard() {
+        final String streamArn =
+                "arn:aws:kinesis:us-east-1:123456789012:stream/LoadTestBeta_Input_0";
+        final String shardId = "shardId-000000000002";
+        final String sequenceNumber = "some-sequence-number";
+        final StartingPosition startingPosition =
+                StartingPosition.continueFromSequenceNumber(sequenceNumber);
+        final String expectedShardIterator = "some-shard-iterator";
+
+        // When completed shard has null nextShardIterator
+        final GetRecordsResponse expectedGetRecordsResponse =
+                GetRecordsResponse.builder().records(Record.builder().build()).build();
+
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+        testKinesisClient.setNextShardIterator(expectedShardIterator);
+        testKinesisClient.setShardIteratorValidation(
+                validateEqual(
+                        GetShardIteratorRequest.builder()
+                                .streamARN(streamArn)
+                                .shardId(shardId)
+                                .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+                                .startingSequenceNumber(sequenceNumber)
+                                .build()));
+        testKinesisClient.setGetRecordsResponse(expectedGetRecordsResponse);
+        testKinesisClient.setGetRecordsValidation(
+                validateEqual(
+                        GetRecordsRequest.builder()
+                                .streamARN(streamArn)
+                                .shardIterator(expectedShardIterator)
+                                .build()));
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThatNoException()
+                .isThrownBy(
+                        () -> kinesisStreamProxy.getRecords(streamArn, shardId, startingPosition));
+    }
+
+    @Test
+    void testCloseClosesKinesisClient() {
+        TestingKinesisClient testKinesisClient = new TestingKinesisClient();
+
+        KinesisStreamProxy kinesisStreamProxy =
+                new KinesisStreamProxy(testKinesisClient, HTTP_CLIENT);
+
+        assertThatNoException().isThrownBy(kinesisStreamProxy::close);
+        assertThat(testKinesisClient.isClosed()).isTrue();
+    }
+
+    private List<Shard> getTestShards(final int startShardId, final int endShardId) {
+        List<Shard> shards = new ArrayList<>();
+        for (int i = startShardId; i <= endShardId; i++) {
+            shards.add(Shard.builder().shardId(generateShardId(i)).build());
+        }
+        return shards;
+    }
+
+    private Consumer<ListShardsRequest> getListShardRequestValidation(
+            final String streamArn, final String startShardId, final String nextToken) {
+        return req -> {
+            ListShardsRequest expectedReq =
+                    ListShardsRequest.builder()
+                            .streamARN(streamArn)
+                            .exclusiveStartShardId(startShardId)
+                            .nextToken(nextToken)
+                            .build();
+            assertThat(req).isEqualTo(expectedReq);
+        };
+    }
+
+    private <R extends KinesisRequest> Consumer<R> validateEqual(final R request) {
+        return req -> assertThat(req).isEqualTo(request);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitterTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitterTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.kinesis.source.serialization.KinesisDeserializationSchema;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplitState;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class KinesisStreamsRecordEmitterTest {
+
+    private static final SimpleStringSchema STRING_SCHEMA = new SimpleStringSchema();
+
+    @Test
+    void testEmitRecord() throws Exception {
+        final Instant startTime = Instant.now();
+        List<Record> inputRecords =
+                ImmutableList.of(
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
+                                .approximateArrivalTimestamp(startTime)
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
+                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
+                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                .sequenceNumber("some-sequence-number")
+                                .build());
+        final StartingPosition expectedStartingPosition =
+                StartingPosition.continueFromSequenceNumber("some-sequence-number");
+        final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
+        final KinesisShardSplitState splitState = getTestSplitState();
+
+        KinesisStreamsRecordEmitter<String> emitter =
+                new KinesisStreamsRecordEmitter<>(KinesisDeserializationSchema.of(STRING_SCHEMA));
+        for (Record record : inputRecords) {
+            emitter.emitRecord(record, output, splitState);
+        }
+
+        assertThat(output.getEmittedRecords()).containsExactly("data-1", "data-2", "data-3");
+        assertThat(output.getEmittedTimestamps())
+                .containsExactly(
+                        startTime.toEpochMilli(),
+                        startTime.plusSeconds(10).toEpochMilli(),
+                        startTime.plusSeconds(20).toEpochMilli());
+        assertThat(splitState.getNextStartingPosition())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedStartingPosition);
+    }
+
+    @Test
+    void testEmitRecordBasedOnSequenceNumber() throws Exception {
+        final Instant startTime = Instant.now();
+        List<Record> inputRecords =
+                ImmutableList.of(
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
+                                .sequenceNumber("emit")
+                                .approximateArrivalTimestamp(startTime)
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
+                                .sequenceNumber("emit")
+                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
+                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                .sequenceNumber("do-not-emit")
+                                .build());
+        final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
+        final KinesisShardSplitState splitState = getTestSplitState();
+
+        KinesisStreamsRecordEmitter<String> emitter =
+                new KinesisStreamsRecordEmitter<>(new SequenceNumberBasedDeserializationSchema());
+        for (Record record : inputRecords) {
+            emitter.emitRecord(record, output, splitState);
+        }
+
+        assertThat(output.getEmittedRecords()).containsExactly("data-1", "data-2");
+        assertThat(output.getEmittedTimestamps())
+                .containsExactly(
+                        startTime.toEpochMilli(), startTime.plusSeconds(10).toEpochMilli());
+    }
+
+    @Test
+    void testEmitRecordWithMetadata() throws Exception {
+        final Instant startTime = Instant.now();
+        List<Record> inputRecords =
+                ImmutableList.of(
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
+                                .approximateArrivalTimestamp(startTime)
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
+                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                .build(),
+                        Record.builder()
+                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
+                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                .sequenceNumber("some-sequence-number")
+                                .build());
+        final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
+        final KinesisShardSplitState splitState = getTestSplitState();
+
+        KinesisStreamsRecordEmitter<String> emitter =
+                new KinesisStreamsRecordEmitter<>(
+                        new AssertRecordMetadataDeserializationSchema(
+                                splitState.getStreamArn(), splitState.getShardId()));
+        for (Record record : inputRecords) {
+            emitter.emitRecord(record, output, splitState);
+        }
+
+        assertThat(output.getEmittedRecords()).containsExactly("data-1", "data-2", "data-3");
+        assertThat(output.getEmittedTimestamps())
+                .containsExactly(
+                        startTime.toEpochMilli(),
+                        startTime.plusSeconds(10).toEpochMilli(),
+                        startTime.plusSeconds(20).toEpochMilli());
+    }
+
+    private static class CapturingSourceOutput<T> implements SourceOutput<T> {
+
+        private final List<T> emittedRecords = new ArrayList<>();
+        private final List<Long> emittedTimestamps = new ArrayList<>();
+
+        @Override
+        public void collect(T record) {
+            emittedRecords.add(record);
+        }
+
+        @Override
+        public void collect(T record, long timestamp) {
+            emittedRecords.add(record);
+            emittedTimestamps.add(timestamp);
+        }
+
+        @Override
+        public void emitWatermark(Watermark watermark) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void markIdle() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void markActive() {
+            throw new UnsupportedOperationException();
+        }
+
+        public List<T> getEmittedRecords() {
+            return emittedRecords;
+        }
+
+        public List<Long> getEmittedTimestamps() {
+            return emittedTimestamps;
+        }
+    }
+
+    private static class SequenceNumberBasedDeserializationSchema
+            implements KinesisDeserializationSchema<String> {
+
+        @Override
+        public void deserialize(
+                Record record, String stream, String shardId, Collector<String> output)
+                throws IOException {
+            if (Objects.equals(record.sequenceNumber(), "emit")) {
+                STRING_SCHEMA.deserialize(record.data().asByteArray(), output);
+            }
+        }
+
+        @Override
+        public TypeInformation<String> getProducedType() {
+            return Types.STRING;
+        }
+    }
+
+    private static class AssertRecordMetadataDeserializationSchema
+            implements KinesisDeserializationSchema<String> {
+        private final String expectedStreamArn;
+        private final String expectedShardId;
+
+        private AssertRecordMetadataDeserializationSchema(
+                String expectedStreamArn, String expectedShardId) {
+            this.expectedStreamArn = expectedStreamArn;
+            this.expectedShardId = expectedShardId;
+        }
+
+        @Override
+        public void deserialize(
+                Record record, String stream, String shardId, Collector<String> output)
+                throws IOException {
+            assertThat(stream).isEqualTo(expectedStreamArn);
+            assertThat(shardId).isEqualTo(expectedShardId);
+            STRING_SCHEMA.deserialize(record.data().asByteArray(), output);
+        }
+
+        @Override
+        public TypeInformation<String> getProducedType() {
+            return Types.STRING;
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kinesis.source.model.TestData;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplitState;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class KinesisStreamsSourceReaderTest {
+
+    @Test
+    void testInitializedState() throws Exception {
+        KinesisStreamsSourceReader<TestData> sourceReader =
+                new KinesisStreamsSourceReader<>(
+                        null, null, null, new Configuration(), new TestingReaderContext());
+        KinesisShardSplit split = getTestSplit();
+        assertThat(sourceReader.initializedState(split))
+                .usingRecursiveComparison()
+                .isEqualTo(new KinesisShardSplitState(split));
+    }
+
+    @Test
+    void testToSplitType() throws Exception {
+        KinesisStreamsSourceReader<TestData> sourceReader =
+                new KinesisStreamsSourceReader<>(
+                        null, null, null, new Configuration(), new TestingReaderContext());
+        KinesisShardSplitState splitState = getTestSplitState();
+        String splitId = splitState.getSplitId();
+        assertThat(sourceReader.toSplitType(splitId, splitState))
+                .usingRecursiveComparison()
+                .isEqualTo(splitState.getKinesisShardSplit());
+    }
+
+    @Test
+    void testOnSplitFinishedIsNoOp() throws Exception {
+        KinesisStreamsSourceReader<TestData> sourceReader =
+                new KinesisStreamsSourceReader<>(
+                        null, null, null, new Configuration(), new TestingReaderContext());
+        assertThatNoException()
+                .isThrownBy(() -> sourceReader.onSplitFinished(Collections.emptyMap()));
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.TestKinesisStreamProxy;
+import org.apache.flink.connector.kinesis.source.util.TestUtil;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestRecord;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class PollingKinesisShardSplitReaderTest {
+    @Test
+    void testNoAssignedSplitsHandledGracefully() throws Exception {
+        StreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+
+        assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
+        assertThat(retrievedRecords.nextSplit()).isNull();
+        assertThat(retrievedRecords.finishedSplits()).isEmpty();
+    }
+
+    @Test
+    void testAssignedSplitHasNoRecordsHandledGracefully() throws Exception {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        // Given assigned split with no records
+        String shardId = generateShardId(1);
+        testStreamProxy.addShards(shardId);
+        splitReader.handleSplitsChanges(
+                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+
+        // When fetching records
+        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+
+        // Then retrieve no records
+        assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
+        assertThat(retrievedRecords.nextSplit()).isNull();
+        assertThat(retrievedRecords.finishedSplits()).isEmpty();
+    }
+
+    @Test
+    void testSingleAssignedSplitAllConsumed() throws Exception {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        // Given assigned split with records
+        String shardId = generateShardId(1);
+        testStreamProxy.addShards(shardId);
+        List<Record> expectedRecords =
+                ImmutableList.of(
+                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(0)));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(1)));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(2)));
+        splitReader.handleSplitsChanges(
+                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+
+        // When fetching records
+        List<Record> records = new ArrayList<>();
+        for (int i = 0; i < expectedRecords.size(); i++) {
+            RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+            records.addAll(readAllRecords(retrievedRecords));
+        }
+
+        assertThat(records).containsExactlyInAnyOrderElementsOf(expectedRecords);
+    }
+
+    @Test
+    void testMultipleAssignedSplitsAllConsumed() throws Exception {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        // Given assigned split with records
+        String shardId = generateShardId(1);
+        testStreamProxy.addShards(shardId);
+        List<Record> expectedRecords =
+                ImmutableList.of(
+                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(0)));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(1)));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(2)));
+        splitReader.handleSplitsChanges(
+                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+
+        // When records are fetched
+        List<Record> fetchedRecords = new ArrayList<>();
+        for (int i = 0; i < expectedRecords.size(); i++) {
+            RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+            fetchedRecords.addAll(readAllRecords(retrievedRecords));
+        }
+
+        // Then all records are fetched
+        assertThat(fetchedRecords).containsExactlyInAnyOrderElementsOf(expectedRecords);
+    }
+
+    @Test
+    void testHandleEmptyCompletedShard() throws Exception {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        // Given assigned split with no records, and the shard is complete
+        String shardId = generateShardId(1);
+        testStreamProxy.addShards(shardId);
+        testStreamProxy.addRecords(TestUtil.STREAM_ARN, shardId, Collections.emptyList());
+        KinesisShardSplit split = getTestSplit(shardId);
+        splitReader.handleSplitsChanges(new SplitsAddition<>(ImmutableList.of(split)));
+        testStreamProxy.setShouldCompleteNextShard(true);
+
+        // When fetching records
+        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+
+        // Returns completed split with no records
+        assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
+        assertThat(retrievedRecords.nextSplit()).isNull();
+        assertThat(retrievedRecords.finishedSplits()).contains(split.splitId());
+    }
+
+    @Test
+    void testFinishedSplitsReturned() throws Exception {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        // Given assigned split with records from completed shard
+        String shardId = generateShardId(1);
+        testStreamProxy.addShards(shardId);
+        List<Record> expectedRecords =
+                ImmutableList.of(
+                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+        testStreamProxy.addRecords(TestUtil.STREAM_ARN, shardId, expectedRecords);
+        KinesisShardSplit split = getTestSplit(shardId);
+        splitReader.handleSplitsChanges(new SplitsAddition<>(ImmutableList.of(split)));
+
+        // When fetching records
+        List<Record> fetchedRecords = new ArrayList<>();
+        testStreamProxy.setShouldCompleteNextShard(true);
+        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+
+        // Then records can be read successfully, with finishedSplit returned once all records are
+        // completed
+        for (int i = 0; i < expectedRecords.size(); i++) {
+            assertThat(retrievedRecords.nextSplit()).isEqualTo(split.splitId());
+            assertThat(retrievedRecords.finishedSplits()).isEmpty();
+            fetchedRecords.add(retrievedRecords.nextRecordFromSplit());
+        }
+        assertThat(retrievedRecords.nextSplit()).isNull();
+        assertThat(retrievedRecords.finishedSplits()).contains(split.splitId());
+        assertThat(fetchedRecords).containsExactlyInAnyOrderElementsOf(expectedRecords);
+    }
+
+    @Test
+    void testWakeUpIsNoOp() {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        assertThatNoException().isThrownBy(splitReader::wakeUp);
+    }
+
+    @Test
+    void testCloseClosesStreamProxy() {
+        TestKinesisStreamProxy testStreamProxy = getTestStreamProxy();
+        PollingKinesisShardSplitReader splitReader =
+                new PollingKinesisShardSplitReader(testStreamProxy);
+
+        assertThatNoException().isThrownBy(splitReader::close);
+        assertThat(testStreamProxy.isClosed()).isTrue();
+    }
+
+    private List<Record> readAllRecords(RecordsWithSplitIds<Record> recordsWithSplitIds) {
+        List<Record> outputRecords = new ArrayList<>();
+        Record record;
+        do {
+            record = recordsWithSplitIds.nextRecordFromSplit();
+            if (record != null) {
+                outputRecords.add(record);
+            }
+        } while (record != null);
+
+        return outputRecords;
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializerTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.apache.flink.core.io.VersionMismatchException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class KinesisShardSplitSerializerTest {
+
+    @Test
+    void testSerializeAndDeserializeEverythingSpecified() throws Exception {
+        final KinesisShardSplit initialSplit = getTestSplit();
+
+        KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
+
+        byte[] serialized = serializer.serialize(initialSplit);
+        KinesisShardSplit deserializedSplit =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserializedSplit).usingRecursiveComparison().isEqualTo(initialSplit);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideStartingPositions")
+    void testSerializeAndDeserializeWithStartingPosition(StartingPosition startingPosition)
+            throws Exception {
+        final KinesisShardSplit initialSplit = getTestSplit(startingPosition);
+
+        KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
+
+        byte[] serialized = serializer.serialize(initialSplit);
+        KinesisShardSplit deserializedSplit =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserializedSplit).usingRecursiveComparison().isEqualTo(initialSplit);
+    }
+
+    private static Stream<StartingPosition> provideStartingPositions() {
+        return Stream.of(
+                StartingPosition.fromStart(),
+                StartingPosition.continueFromSequenceNumber("some-sequence-number"),
+                StartingPosition.fromTimestamp(Instant.ofEpochMilli(1683817847000L)));
+    }
+
+    @Test
+    void testDeserializeWrongVersion() throws Exception {
+        final KinesisShardSplit initialSplit =
+                getTestSplit(StartingPosition.fromTimestamp(Instant.now()));
+
+        KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
+        KinesisShardSplitSerializer wrongVersionSerializer = new WrongVersionSerializer();
+
+        byte[] serialized = serializer.serialize(initialSplit);
+        assertThatExceptionOfType(VersionMismatchException.class)
+                .isThrownBy(
+                        () ->
+                                wrongVersionSerializer.deserialize(
+                                        serializer.getVersion(), serialized))
+                .withMessageContaining(
+                        "Trying to deserialize KinesisShardSplit serialized with unsupported version ")
+                .withMessageContaining(String.valueOf(wrongVersionSerializer.getVersion()))
+                .withMessageContaining(String.valueOf(serializer.getVersion()));
+    }
+
+    private static class WrongVersionSerializer extends KinesisShardSplitSerializer {
+        @Override
+        public int getVersion() {
+            return -1;
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitStateTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitStateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.split;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class KinesisShardSplitStateTest {
+
+    @Test
+    void testGetKinesisShardSplitDelegatesToInitialSplit() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getKinesisShardSplit()).usingRecursiveComparison().isEqualTo(split);
+    }
+
+    @Test
+    void testGetKinesisShardSplitUsesLatestStartingPosition() throws Exception {
+        KinesisShardSplitState splitState = new KinesisShardSplitState(getTestSplit());
+
+        StartingPosition nextStartingPosition = StartingPosition.fromTimestamp(Instant.now());
+        splitState.setNextStartingPosition(nextStartingPosition);
+
+        assertThat(splitState.getKinesisShardSplit().getStartingPosition())
+                .usingRecursiveComparison()
+                .isEqualTo(nextStartingPosition);
+    }
+
+    @Test
+    void testSplitIdDelegatesToInitialSplit() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getSplitId()).hasToString(split.splitId());
+    }
+
+    @Test
+    void testGetStreamArnDelegatesToInitialSplit() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getStreamArn()).hasToString(split.getStreamArn());
+    }
+
+    @Test
+    void testGetShardIdDelegatesToInitialSplit() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getShardId()).hasToString(split.getShardId());
+    }
+
+    @Test
+    void testGetAndSetNextStartingPosition() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getNextStartingPosition()).isEqualTo(split.getStartingPosition());
+
+        StartingPosition newStartingPosition = StartingPosition.fromTimestamp(Instant.now());
+        splitState.setNextStartingPosition(newStartingPosition);
+
+        assertThat(splitState.getNextStartingPosition())
+                .usingRecursiveComparison()
+                .isEqualTo(newStartingPosition);
+    }
+
+    @Test
+    void testGetAndSetShardIterator() throws Exception {
+        KinesisShardSplit split = getTestSplit();
+        KinesisShardSplitState splitState = new KinesisShardSplitState(split);
+
+        assertThat(splitState.getNextShardIterator()).isNull();
+
+        String newShardIterator = "some-shard-iterator";
+        splitState.setNextShardIterator(newShardIterator);
+
+        assertThat(splitState.getNextShardIterator()).hasToString(newShardIterator);
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitTest.java
@@ -1,0 +1,40 @@
+package org.apache.flink.connector.kinesis.source.split;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class KinesisShardSplitTest {
+
+    private static final String STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:290038087681:stream/keeneses_stream";
+    private static final String SHARD_ID = "shardId-000000000002";
+    private static final StartingPosition STARTING_POSITION = StartingPosition.fromStart();
+
+    @Test
+    void testStreamArnNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new KinesisShardSplit(null, SHARD_ID, STARTING_POSITION))
+                .withMessageContaining("streamArn cannot be null");
+    }
+
+    @Test
+    void testShardIdNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new KinesisShardSplit(STREAM_ARN, null, STARTING_POSITION))
+                .withMessageContaining("shardId cannot be null");
+    }
+
+    @Test
+    void testStartingPositionNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new KinesisShardSplit(STREAM_ARN, SHARD_ID, null))
+                .withMessageContaining("startingPosition cannot be null");
+    }
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(KinesisShardSplit.class).verify();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/StartingPositionTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/StartingPositionTest.java
@@ -1,0 +1,12 @@
+package org.apache.flink.connector.kinesis.source.split;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class StartingPositionTest {
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(StartingPosition.class).verify();
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisClientProvider.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisClientProvider.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.util;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.KinesisServiceClientConfiguration;
+import software.amazon.awssdk.services.kinesis.model.AccessDeniedException;
+import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
+import software.amazon.awssdk.services.kinesis.model.ExpiredNextTokenException;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
+import software.amazon.awssdk.services.kinesis.model.InvalidArgumentException;
+import software.amazon.awssdk.services.kinesis.model.KinesisException;
+import software.amazon.awssdk.services.kinesis.model.KmsAccessDeniedException;
+import software.amazon.awssdk.services.kinesis.model.KmsDisabledException;
+import software.amazon.awssdk.services.kinesis.model.KmsInvalidStateException;
+import software.amazon.awssdk.services.kinesis.model.KmsNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.KmsOptInRequiredException;
+import software.amazon.awssdk.services.kinesis.model.KmsThrottlingException;
+import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
+import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** Provides {@link KinesisClient} with mocked Kinesis Stream behavior. */
+public class KinesisClientProvider {
+
+    /**
+     * An implementation of the {@link KinesisClient} that allows control over Kinesis Service
+     * responses.
+     */
+    public static class TestingKinesisClient implements KinesisClient {
+
+        private Deque<ListShardItem> listShardQueue = new ArrayDeque<>();
+        private Deque<String> shardIterators = new ArrayDeque<>();
+        private Consumer<GetShardIteratorRequest> getShardIteratorValidation;
+        private GetRecordsResponse getRecordsResponse;
+        private Consumer<GetRecordsRequest> getRecordsValidation;
+        private boolean closed = false;
+
+        @Override
+        public String serviceName() {
+            return "kinesis";
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+
+        public void setNextShardIterator(String shardIterator) {
+            this.shardIterators.add(shardIterator);
+        }
+
+        public void setShardIteratorValidation(Consumer<GetShardIteratorRequest> validation) {
+            this.getShardIteratorValidation = validation;
+        }
+
+        @Override
+        public GetShardIteratorResponse getShardIterator(
+                GetShardIteratorRequest getShardIteratorRequest)
+                throws ResourceNotFoundException, InvalidArgumentException,
+                        ProvisionedThroughputExceededException, AccessDeniedException,
+                        AwsServiceException, SdkClientException, KinesisException {
+            getShardIteratorValidation.accept(getShardIteratorRequest);
+            return GetShardIteratorResponse.builder().shardIterator(shardIterators.poll()).build();
+        }
+
+        public void setListShardsResponses(List<ListShardItem> items) {
+            listShardQueue.addAll(items);
+        }
+
+        @Override
+        public ListShardsResponse listShards(ListShardsRequest listShardsRequest)
+                throws ResourceNotFoundException, InvalidArgumentException, LimitExceededException,
+                        ExpiredNextTokenException, ResourceInUseException, AccessDeniedException,
+                        AwsServiceException, SdkClientException, KinesisException {
+            ListShardItem item = listShardQueue.pop();
+
+            item.validation.accept(listShardsRequest);
+            return ListShardsResponse.builder()
+                    .shards(item.shards)
+                    .nextToken(item.nextToken)
+                    .build();
+        }
+
+        public void setGetRecordsResponse(GetRecordsResponse getRecordsResponse) {
+            this.getRecordsResponse = getRecordsResponse;
+        }
+
+        public void setGetRecordsValidation(Consumer<GetRecordsRequest> validation) {
+            this.getRecordsValidation = validation;
+        }
+
+        @Override
+        public GetRecordsResponse getRecords(GetRecordsRequest getRecordsRequest)
+                throws ResourceNotFoundException, InvalidArgumentException,
+                        ProvisionedThroughputExceededException, ExpiredIteratorException,
+                        KmsDisabledException, KmsInvalidStateException, KmsAccessDeniedException,
+                        KmsNotFoundException, KmsOptInRequiredException, KmsThrottlingException,
+                        AccessDeniedException, AwsServiceException, SdkClientException,
+                        KinesisException {
+            getRecordsValidation.accept(getRecordsRequest);
+            return getRecordsResponse;
+        }
+
+        @Override
+        public KinesisServiceClientConfiguration serviceClientConfiguration() {
+            // This is not used
+            return null;
+        }
+    }
+
+    /** Data class to provide a mocked response to ListShards() calls. */
+    public static class ListShardItem {
+        private final Consumer<ListShardsRequest> validation;
+        private final List<Shard> shards;
+        private final String nextToken;
+
+        private ListShardItem(
+                Consumer<ListShardsRequest> validation, List<Shard> shards, String nextToken) {
+            this.validation = validation;
+            this.shards = shards;
+            this.nextToken = nextToken;
+        }
+
+        public static ListShardItem.Builder builder() {
+            return new ListShardItem.Builder();
+        }
+
+        /** Builder for {@link ListShardItem}. */
+        public static class Builder {
+            private Consumer<ListShardsRequest> validation;
+            private List<Shard> shards;
+            private String nextToken;
+
+            public Builder validation(Consumer<ListShardsRequest> validation) {
+                this.validation = validation;
+                return this;
+            }
+
+            public Builder shards(List<Shard> shards) {
+                this.shards = shards;
+                return this;
+            }
+
+            public Builder nextToken(String nextToken) {
+                this.nextToken = nextToken;
+                return this;
+            }
+
+            public KinesisClientProvider.ListShardItem build() {
+                return new KinesisClientProvider.ListShardItem(validation, shards, nextToken);
+            }
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisStreamProxyProvider.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisStreamProxyProvider.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.util;
+
+import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jetbrains.annotations.Nullable;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Provides {@link StreamProxy} with mocked Kinesis Streams behavior. */
+public class KinesisStreamProxyProvider {
+
+    public static TestKinesisStreamProxy getTestStreamProxy() {
+        return new TestKinesisStreamProxy();
+    }
+
+    /**
+     * An implementation of the {@link StreamProxy} that allows control over shard and record
+     * behavior.
+     */
+    public static class TestKinesisStreamProxy implements StreamProxy {
+
+        // List shards configuration
+        private final List<Shard> shards = new ArrayList<>();
+        private Supplier<Exception> listShardsExceptionSupplier;
+        private boolean shouldRespectLastSeenShardId = true;
+        private String lastProvidedLastSeenShardId;
+
+        // GetRecords configuration
+        private final Map<ShardHandle, Deque<List<Record>>> storedRecords = new HashMap<>();
+        private boolean shouldCompleteNextShard = false;
+        private boolean closed = false;
+
+        @Override
+        public List<Shard> listShards(String streamArn, @Nullable String lastSeenShardId) {
+            this.lastProvidedLastSeenShardId = lastSeenShardId;
+
+            if (listShardsExceptionSupplier != null) {
+                try {
+                    throw listShardsExceptionSupplier.get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            List<Shard> results = new ArrayList<>();
+            for (Shard shard : shards) {
+                if (shouldRespectLastSeenShardId && shard.shardId().equals(lastSeenShardId)) {
+                    results.clear();
+                    continue;
+                }
+                results.add(shard);
+            }
+            return results;
+        }
+
+        @Override
+        public GetRecordsResponse getRecords(
+                String streamArn, String shardId, StartingPosition startingPosition) {
+            ShardHandle shardHandle = new ShardHandle(streamArn, shardId);
+
+            List<Record> records = null;
+            if (storedRecords.containsKey(shardHandle)) {
+                records = storedRecords.get(shardHandle).poll();
+            }
+
+            return GetRecordsResponse.builder()
+                    .records(records)
+                    .nextShardIterator(shouldCompleteNextShard ? null : "some-shard-iterator")
+                    .build();
+        }
+
+        public String getLastProvidedLastSeenShardId() {
+            return lastProvidedLastSeenShardId;
+        }
+
+        public void addShards(String... shardIds) {
+            for (String shardId : shardIds) {
+                shards.add(Shard.builder().shardId(shardId).build());
+            }
+        }
+
+        public void setListShardsExceptionSupplier(Supplier<Exception> exceptionSupplier) {
+            listShardsExceptionSupplier = exceptionSupplier;
+        }
+
+        public void setShouldRespectLastSeenShardId(boolean shouldRespectLastSeenShardId) {
+            this.shouldRespectLastSeenShardId = shouldRespectLastSeenShardId;
+        }
+
+        public void addRecords(String streamArn, String shardId, List<Record> records) {
+            Deque<List<Record>> recordsQueue = new ArrayDeque<>();
+            recordsQueue.add(records);
+            storedRecords.merge(
+                    new ShardHandle(streamArn, shardId), recordsQueue, this::mergeQueues);
+        }
+
+        private <T> Deque<T> mergeQueues(Deque<T> q1, Deque<T> q2) {
+            return Stream.of(q1, q2)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toCollection(ArrayDeque::new));
+        }
+
+        public void setShouldCompleteNextShard(boolean shouldCompleteNextShard) {
+            this.shouldCompleteNextShard = shouldCompleteNextShard;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+
+        private static class ShardHandle {
+            private final String streamArn;
+            private final String shardId;
+
+            public ShardHandle(String streamArn, String shardId) {
+                this.streamArn = streamArn;
+                this.shardId = shardId;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                ShardHandle that = (ShardHandle) o;
+
+                return new EqualsBuilder()
+                        .append(streamArn, that.streamArn)
+                        .append(shardId, that.shardId)
+                        .isEquals();
+            }
+
+            @Override
+            public int hashCode() {
+                return new HashCodeBuilder(17, 37).append(streamArn).append(shardId).toHashCode();
+            }
+        }
+    }
+}

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.util;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.time.Instant;
+
+/** Utilities class for testing Kinesis Source. */
+public class TestUtil {
+
+    public static final String STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:123456789012:stream/keenesesStream";
+    public static final String SHARD_ID = "shardId-000000000002";
+    public static final SimpleStringSchema STRING_SCHEMA = new SimpleStringSchema();
+
+    public static String generateShardId(int shardId) {
+        return String.format("shardId-%012d", shardId);
+    }
+
+    public static KinesisShardSplitState getTestSplitState() {
+        return new KinesisShardSplitState(getTestSplit());
+    }
+
+    public static KinesisShardSplitState getTestSplitState(KinesisShardSplit testSplit) {
+        return new KinesisShardSplitState(testSplit);
+    }
+
+    public static KinesisShardSplit getTestSplit() {
+        return getTestSplit(SHARD_ID);
+    }
+
+    public static KinesisShardSplit getTestSplit(String shardId) {
+        return getTestSplit(STREAM_ARN, shardId);
+    }
+
+    public static KinesisShardSplit getTestSplit(String streamArn, String shardId) {
+        return new KinesisShardSplit(streamArn, shardId, StartingPosition.fromStart());
+    }
+
+    public static KinesisShardSplit getTestSplit(StartingPosition startingPosition) {
+        return new KinesisShardSplit(STREAM_ARN, SHARD_ID, startingPosition);
+    }
+
+    public static ReaderInfo getTestReaderInfo(final int subtaskId) {
+        return new ReaderInfo(subtaskId, "some-location");
+    }
+
+    public static Record getTestRecord(String data) {
+        return Record.builder()
+                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize(data)))
+                .approximateArrivalTimestamp(Instant.now())
+                .build();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
- Implement FlinkKinesisSource using the new FLIP-27 Source interface

## Verifying this change

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
* The S3 file system connector: no

## Documentation
* Does this pull request introduce a new feature? no
* If yes, how is the feature documented? n/a

