### PR TITLE
[FLINK-30777] [Connectors/Kinesis] Allow Kinesis Table API Connector to specify shard assigner

### DIFF
--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -352,6 +352,14 @@ Connector Options
       <td>Maximum number of allowed concurrent requests for the EFO client. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
     </tr>
     <tr>
+      <td><h5>scan.shard-assigner</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">default</td>
+      <td>String</td>
+      <td>The shard assigner used to map shards to Flink subtasks (default|uniform). You can also supply your own shard assigner via the Java Service Provider Interfaces (SPI).</td></td>
+    </tr>
+    <tr>
       <td><h5>scan.stream.describe.maxretries</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -353,6 +353,14 @@ Connector Options
       <td>Maximum number of allowed concurrent requests for the EFO client. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
     </tr>
     <tr>
+      <td><h5>scan.shard-assigner</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">default</td>
+      <td>String</td>
+      <td>The shard assigner used to map shards to Flink subtasks (default|uniform). You can also supply your own shard assigner via the Java Service Provider Interfaces (SPI).</td></td>
+    </tr>
+    <tr>
       <td><h5>scan.stream.describe.maxretries</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisConnectorOptions.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisConnectorOptions.java
@@ -49,6 +49,17 @@ public class KinesisConnectorOptions extends AsyncSinkConnectorOptions {
                     .withDescription("AWS region of used Kinesis stream.");
 
     // -----------------------------------------------------------------------------------------
+    // Source options
+    // -----------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> SHARD_ASSIGNER =
+            ConfigOptions.key("scan.shard-assigner")
+                    .stringType()
+                    .defaultValue("default")
+                    .withDescription(
+                            "Shard assigner to use when mapping shards to Flink subtasks.");
+
+    // -----------------------------------------------------------------------------------------
     // Sink options
     // -----------------------------------------------------------------------------------------
 

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardMetadata;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kinesis.table.DefaultShardAssignerFactory;
 import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
 import org.apache.flink.streaming.connectors.kinesis.util.StreamConsumerRegistrarUtil;
 import org.apache.flink.streaming.connectors.kinesis.util.WatermarkTracker;
@@ -127,7 +128,8 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
     private final KinesisDeserializationSchema<T> deserializer;
 
     /** The function that determines which subtask a shard should be assigned to. */
-    private KinesisShardAssigner shardAssigner = KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+    private KinesisShardAssigner shardAssigner =
+            new DefaultShardAssignerFactory().getShardAssigner();
 
     private AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
     private WatermarkTracker watermarkTracker;

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -111,10 +111,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @SuppressWarnings("unchecked")
 @Internal
 public class KinesisDataFetcher<T> {
-
-    public static final KinesisShardAssigner DEFAULT_SHARD_ASSIGNER =
-            (shard, subtasks) -> shard.hashCode();
-
     private static final Logger LOG = LoggerFactory.getLogger(KinesisDataFetcher.class);
 
     // ------------------------------------------------------------------------

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/DefaultShardAssignerFactory.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/DefaultShardAssignerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
+
+/** A {@link KinesisDynamicShardAssignerFactory} that loads the default shard assigner. */
+@Internal
+public class DefaultShardAssignerFactory implements KinesisDynamicShardAssignerFactory {
+
+    private static final KinesisShardAssigner DEFAULT_SHARD_ASSIGNER =
+            (shard, subtasks) -> shard.hashCode();
+
+    public static final String IDENTIFIER = "default";
+
+    @Override
+    public String shardAssignerIdentifer() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public KinesisShardAssigner getShardAssigner() {
+        return DEFAULT_SHARD_ASSIGNER;
+    }
+}

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicShardAssignerFactory.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicShardAssignerFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
+
+/** Factory utility to dynamically load a {@link KinesisShardAssigner} instance. */
+@PublicEvolving
+public interface KinesisDynamicShardAssignerFactory {
+
+    /**
+     * Returns the identifier of shard assigner so it can be uniquely identified and loaded.
+     *
+     * @return identifier of shard assigner factory
+     */
+    String shardAssignerIdentifer();
+
+    /**
+     * Returns the specific implementation of {@link KinesisShardAssigner}.
+     *
+     * @return the shard assigner implementation loaded by this factory
+     */
+    KinesisShardAssigner getShardAssigner();
+}

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactory.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactory.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.SHARD_ASSIGNER;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.SINK_PARTITIONER;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.SINK_PARTITIONER_FIELD_DELIMITER;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.STREAM;
@@ -67,7 +68,11 @@ public class KinesisDynamicTableFactory implements DynamicTableSourceFactory {
         Properties properties = optionsUtils.getValidatedSourceConfigurations();
 
         return new KinesisDynamicSource(
-                physicalDataType, tableOptions.get(STREAM), properties, decodingFormat);
+                physicalDataType,
+                tableOptions.get(STREAM),
+                tableOptions.get(SHARD_ASSIGNER),
+                properties,
+                decodingFormat);
     }
 
     @Override
@@ -88,12 +93,13 @@ public class KinesisDynamicTableFactory implements DynamicTableSourceFactory {
         final Set<ConfigOption<?>> options = new HashSet<>();
         options.add(SINK_PARTITIONER);
         options.add(SINK_PARTITIONER_FIELD_DELIMITER);
+        options.add(SHARD_ASSIGNER);
         return options;
     }
 
     @Override
     public Set<ConfigOption<?>> forwardOptions() {
-        return Stream.of(STREAM, SINK_PARTITIONER, SINK_PARTITIONER_FIELD_DELIMITER)
+        return Stream.of(STREAM, SINK_PARTITIONER, SINK_PARTITIONER_FIELD_DELIMITER, SHARD_ASSIGNER)
                 .collect(Collectors.toSet());
     }
 }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/UniformShardAssignerFactory.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/UniformShardAssignerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
+import org.apache.flink.streaming.connectors.kinesis.util.UniformShardAssigner;
+
+/**
+ * A {@link KinesisDynamicShardAssignerFactory} that loads the {@link UniformShardAssigner} shard
+ * assigner.
+ */
+@PublicEvolving
+public class UniformShardAssignerFactory implements KinesisDynamicShardAssignerFactory {
+
+    public static final String IDENTIFIER = "uniform";
+
+    @Override
+    public String shardAssignerIdentifer() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public KinesisShardAssigner getShardAssigner() {
+        return new UniformShardAssigner();
+    }
+}

--- a/flink-connector-kinesis/src/main/resources/META-INF/services/org.apache.flink.streaming.connectors.kinesis.table.KinesisDynamicShardAssignerFactory
+++ b/flink-connector-kinesis/src/main/resources/META-INF/services/org.apache.flink.streaming.connectors.kinesis.table.KinesisDynamicShardAssignerFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.streaming.connectors.kinesis.table.DefaultShardAssignerFactory
+org.apache.flink.streaming.connectors.kinesis.table.UniformShardAssignerFactory

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardMetadata;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kinesis.table.DefaultShardAssignerFactory;
 import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisShardIdGenerator;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestRuntimeContext;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
@@ -498,7 +499,7 @@ public class FlinkKinesisConsumerMigrationTest {
                     runtimeContext,
                     configProps,
                     deserializationSchema,
-                    DEFAULT_SHARD_ASSIGNER,
+                    new DefaultShardAssignerFactory().getShardAssigner(),
                     null,
                     null);
 

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kinesis.table.DefaultShardAssignerFactory;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 
@@ -31,7 +32,6 @@ import java.util.Properties;
 
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
 import static java.util.Collections.singletonList;
-import static org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
 import static org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 import static org.mockito.Mockito.mock;
@@ -52,7 +52,7 @@ public class DynamoDBStreamsDataFetcherTest {
                         runtimeContext,
                         TestUtils.getStandardProperties(),
                         new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
-                        DEFAULT_SHARD_ASSIGNER,
+                        new DefaultShardAssignerFactory().getShardAssigner(),
                         config -> kinesis);
 
         StreamShardHandle dummyStreamShardHandle =

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyAsyncV2Interface;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
+import org.apache.flink.streaming.connectors.kinesis.table.DefaultShardAssignerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -91,7 +92,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
                 TestUtils.getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
                 fakeConfiguration,
                 deserializationSchema,
-                DEFAULT_SHARD_ASSIGNER,
+                new DefaultShardAssignerFactory().getShardAssigner(),
                 null,
                 null,
                 thrownErrorUnderTest,


### PR DESCRIPTION

## Purpose of the change

This pull request allows users of the Kinesis Table API Flink Connector to select from a list of shard assigner.

## Verifying this change

This change added tests and can be verified as follows:

Added unit tests

## Significant changes
*(Please check any boxes [x] if the answer is "yes" )*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
