### PR TITLE
[hotfix] Fix dead link in e2e-test module's README.md.

### DIFF
--- a/flink-connector-aws-e2e-tests/README.md
+++ b/flink-connector-aws-e2e-tests/README.md
@@ -2,13 +2,12 @@
 
 To run the end-to-end tests you will need a `flink-dist`. You can build Flink from source or download 
 from https://dist.apache.org/repos/dist/release/flink. For example, download
-[flink-1.16.0-bin-scala_2.12.tgz](https://dist.apache.org/repos/dist/release/flink/flink-1.16.0/flink-1.16.0-bin-scala_2.12.tgz)
-and extract, then find `flink-dist-1.16.0.jar` in the `lib` folder.
+`flink-{FLINK_VERSION}-bin-scala_{SCALA_VERSION}.tgz` and extract, then find `flink-dist-{FLINK_VERSION}.jar` in the `lib` folder.
 
 The end-to-end tests are disabled by default, to run them you can use the `run-end-to-end-tests` maven profile.
 
 Example command to run end-to-end tests:
 ```
-mvn clean verify -Prun-end-to-end-tests -DdistDir=<path-to-dist>/flink-1.16.0/lib/flink-dist-1.16.0.jar 
+mvn clean verify -Prun-end-to-end-tests -DdistDir=<path-to-dist>/flink-{FLINK_VERSION}/lib/flink-dist-{FLINK_VERSION}.jar 
 ```
 


### PR DESCRIPTION
## Purpose of the change

*The `README.md` in e2e-test module uses `flink-1.16.0` as an example, but with the release of `flink`, it no longer exists(replaced by 1.16.1). Maybe we should change it to a more general form instead of updating it every time with the release of `flink`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes

- [] Dependencies have been added or upgraded
- [] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [] Serializers have been changed
- [] New feature has been introduced
