### PR TITLE
[FLINK-16003][Connectors/Kinesis] Log non-retriable Kinesis exceptions from getRecords

### DIFF
--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -313,6 +313,9 @@ public class KinesisProxy implements KinesisProxyInterface {
                 } else {
                     throw ex;
                 }
+            } catch (RuntimeException ex) {
+                LOG.error("Encountered non-recoverable error while invoking getRecords.", ex);
+                throw ex;
             }
         }
 


### PR DESCRIPTION
We let these exceptions go up the call stack without logging them. This causes these exceptions from the Kinesis connector to be not visible to customers in their logs, despite their visibility in the exceptions tab on Flink UI.

## Purpose of the change

**Current behaviour:** Errors from `getRecords` are shown under the Exceptions tab on the Flink UI. But they don't appear in customer logs.

**Desired behaviour:** Non-retriable errors from `getRecords` are logged in addition to the current behaviour.

## Verifying this change

- Added unit tests

## Significant changes

N/A