### PR TITLE
[FLINK-31108][Connectors/Kinesis] Use Stream ARN instead of Stream Na…

### DIFF
--- a/flink-connector-kinesis/pom.xml
+++ b/flink-connector-kinesis/pom.xml
@@ -72,6 +72,10 @@ under the License.
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudwatch</artifactId>
         </dependency>
         <dependency>

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkDynamoDBStreamsConsumer.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkDynamoDBStreamsConsumer.java
@@ -64,13 +64,13 @@ public class FlinkDynamoDBStreamsConsumer<T> extends FlinkKinesisConsumer<T> {
 
     @Override
     protected KinesisDataFetcher<T> createFetcher(
-            List<String> streams,
+            List<String> streamArns,
             SourceFunction.SourceContext<T> sourceContext,
             RuntimeContext runtimeContext,
             Properties configProps,
             KinesisDeserializationSchema<T> deserializationSchema) {
         return new DynamoDBStreamsDataFetcher<T>(
-                streams,
+                streamArns,
                 sourceContext,
                 runtimeContext,
                 configProps,

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer;
 import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
+import org.apache.flink.streaming.connectors.kinesis.util.StreamConverterUtil;
 
 import java.time.Duration;
 
@@ -416,12 +417,13 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final long MAX_SHARD_GETRECORDS_INTERVAL_MILLIS = 300000L;
 
     /**
-     * Build the key of an EFO consumer ARN according to a stream name.
+     * Build the key of an EFO consumer ARN according to a stream ARN. Only the stream name is
+     * included
      *
-     * @param streamName the stream name the key is built upon.
+     * @param streamArn the stream ARN the key is built upon.
      * @return a key of EFO consumer ARN.
      */
-    public static String efoConsumerArn(final String streamName) {
-        return EFO_CONSUMER_ARN_PREFIX + "." + streamName;
+    public static String efoConsumerArn(final String streamArn) {
+        return EFO_CONSUMER_ARN_PREFIX + "." + StreamConverterUtil.getStreamName(streamArn);
     }
 }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -116,7 +116,7 @@ public class ShardConsumer<T> implements Runnable {
                                     if (!batch.getDeaggregatedRecords().isEmpty()) {
                                         LOG.debug(
                                                 "stream: {}, shard: {}, millis behind latest: {}, batch size: {}",
-                                                subscribedShard.getStreamName(),
+                                                subscribedShard.getStreamArn(),
                                                 subscribedShard.getShard().getShardId(),
                                                 batch.getMillisBehindLatest(),
                                                 batch.getDeaggregatedRecordSize());

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -111,7 +111,7 @@ public class FanOutRecordPublisher implements RecordPublisher {
             throws InterruptedException {
         LOG.info(
                 "Running fan out record publisher on {}::{} from {} - {}",
-                subscribedShard.getStreamName(),
+                subscribedShard.getStreamArn(),
                 subscribedShard.getShard().getShardId(),
                 nextStartingPosition.getShardIteratorType(),
                 nextStartingPosition.getStartingMarker());
@@ -131,7 +131,7 @@ public class FanOutRecordPublisher implements RecordPublisher {
 
         LOG.info(
                 "Subscription expired {}::{}, with status {}",
-                subscribedShard.getStreamName(),
+                subscribedShard.getStreamArn(),
                 subscribedShard.getShard().getShardId(),
                 result);
 

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
@@ -122,17 +122,17 @@ public class FanOutRecordPublisherConfiguration {
      * Creates a FanOutRecordPublisherConfiguration.
      *
      * @param configProps the configuration properties from config file.
-     * @param streams the streams which is sent to match the EFO consumer arn if the EFO
+     * @param streamArns the stream ARNs which is sent to match the EFO consumer arn if the EFO
      *     registration mode is set to `NONE`.
      */
     public FanOutRecordPublisherConfiguration(
-            final Properties configProps, final List<String> streams) {
+            final Properties configProps, final List<String> streamArns) {
         Preconditions.checkArgument(
                 configProps
                         .getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE)
                         .equals(RecordPublisherType.EFO.toString()),
                 "Only efo record publisher can register a FanOutProperties.");
-        KinesisConfigUtil.validateEfoConfiguration(configProps, streams);
+        KinesisConfigUtil.validateEfoConfiguration(configProps, streamArns);
 
         efoRegistrationType =
                 EFORegistrationType.valueOf(
@@ -146,10 +146,10 @@ public class FanOutRecordPublisherConfiguration {
             consumerName = configProps.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
         }
 
-        for (String stream : streams) {
-            String key = efoConsumerArn(stream);
+        for (String streamArn : streamArns) {
+            String key = efoConsumerArn(streamArn);
             if (configProps.containsKey(key)) {
-                streamConsumerArns.put(stream, configProps.getProperty(key));
+                streamConsumerArns.put(streamArn, configProps.getProperty(key));
             }
         }
 
@@ -466,10 +466,10 @@ public class FanOutRecordPublisherConfiguration {
     }
 
     /**
-     * Get the according consumer arn to the stream, will be null if efo registration type is 'LAZY'
-     * or 'EAGER'.
+     * Get the according consumer arn to the stream ARN, will be null if efo registration type is
+     * 'LAZY' or 'EAGER'.
      */
-    public Optional<String> getStreamConsumerArn(String stream) {
-        return Optional.ofNullable(streamConsumerArns.get(stream));
+    public Optional<String> getStreamConsumerArn(String streamArn) {
+        return Optional.ofNullable(streamConsumerArns.get(streamArn));
     }
 }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
@@ -79,11 +79,11 @@ public class FanOutRecordPublisherFactory implements RecordPublisherFactory {
         Preconditions.checkNotNull(metricGroup);
         Preconditions.checkNotNull(streamShardHandle);
 
-        String stream = streamShardHandle.getStreamName();
+        String streamArn = streamShardHandle.getStreamArn();
         FanOutRecordPublisherConfiguration configuration =
-                new FanOutRecordPublisherConfiguration(consumerConfig, singletonList(stream));
+                new FanOutRecordPublisherConfiguration(consumerConfig, singletonList(streamArn));
 
-        Optional<String> streamConsumerArn = configuration.getStreamConsumerArn(stream);
+        Optional<String> streamConsumerArn = configuration.getStreamConsumerArn(streamArn);
         Preconditions.checkState(streamConsumerArn.isPresent());
 
         return new FanOutRecordPublisher(

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/KinesisStreamShard.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/KinesisStreamShard.java
@@ -118,7 +118,7 @@ public class KinesisStreamShard implements Serializable {
             KinesisStreamShard kinesisStreamShard) {
         StreamShardMetadata streamShardMetadata = new StreamShardMetadata();
 
-        streamShardMetadata.setStreamName(kinesisStreamShard.getStreamName());
+        streamShardMetadata.setStreamArn(kinesisStreamShard.getStreamName());
         streamShardMetadata.setShardId(kinesisStreamShard.getShard().getShardId());
         streamShardMetadata.setParentShardId(kinesisStreamShard.getShard().getParentShardId());
         streamShardMetadata.setAdjacentParentShardId(

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
@@ -98,15 +98,16 @@ public class DynamoDBStreamsProxy extends KinesisProxy {
     }
 
     @Override
-    public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds)
+    public GetShardListResult getShardList(Map<String, String> streamArnsWithLastSeenShardIds)
             throws InterruptedException {
         GetShardListResult result = new GetShardListResult();
 
         for (Map.Entry<String, String> streamNameWithLastSeenShardId :
-                streamNamesWithLastSeenShardIds.entrySet()) {
-            String stream = streamNameWithLastSeenShardId.getKey();
+                streamArnsWithLastSeenShardIds.entrySet()) {
+            String streamArn = streamNameWithLastSeenShardId.getKey();
             String lastSeenShardId = streamNameWithLastSeenShardId.getValue();
-            result.addRetrievedShardsToStream(stream, getShardsOfStream(stream, lastSeenShardId));
+            result.addRetrievedShardsToStream(
+                    streamArn, getShardsOfStream(streamArn, lastSeenShardId));
         }
         return result;
     }
@@ -122,7 +123,7 @@ public class DynamoDBStreamsProxy extends KinesisProxy {
                     "Received ResourceNotFoundException. "
                             + "Shard {} of stream {} is no longer valid, marking it as complete.",
                     shard.getShard().getShardId(),
-                    shard.getStreamName());
+                    shard.getStreamArn());
             return null;
         }
     }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/GetShardListResult.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/GetShardListResult.java
@@ -36,35 +36,32 @@ public class GetShardListResult {
     private final Map<String, LinkedList<StreamShardHandle>> streamsToRetrievedShardList =
             new HashMap<>();
 
-    public void addRetrievedShardToStream(String stream, StreamShardHandle retrievedShard) {
-        if (!streamsToRetrievedShardList.containsKey(stream)) {
-            streamsToRetrievedShardList.put(stream, new LinkedList<StreamShardHandle>());
+    public void addRetrievedShardToStream(String streamArn, StreamShardHandle retrievedShard) {
+        if (!streamsToRetrievedShardList.containsKey(streamArn)) {
+            streamsToRetrievedShardList.put(streamArn, new LinkedList<>());
         }
-        streamsToRetrievedShardList.get(stream).add(retrievedShard);
+        streamsToRetrievedShardList.get(streamArn).add(retrievedShard);
     }
 
-    public void addRetrievedShardsToStream(String stream, List<StreamShardHandle> retrievedShards) {
+    public void addRetrievedShardsToStream(
+            String streamArn, List<StreamShardHandle> retrievedShards) {
         if (retrievedShards.size() != 0) {
-            if (!streamsToRetrievedShardList.containsKey(stream)) {
-                streamsToRetrievedShardList.put(stream, new LinkedList<StreamShardHandle>());
+            if (!streamsToRetrievedShardList.containsKey(streamArn)) {
+                streamsToRetrievedShardList.put(streamArn, new LinkedList<>());
             }
-            streamsToRetrievedShardList.get(stream).addAll(retrievedShards);
+            streamsToRetrievedShardList.get(streamArn).addAll(retrievedShards);
         }
     }
 
-    public List<StreamShardHandle> getRetrievedShardListOfStream(String stream) {
-        if (!streamsToRetrievedShardList.containsKey(stream)) {
-            return null;
-        } else {
-            return streamsToRetrievedShardList.get(stream);
-        }
+    public List<StreamShardHandle> getRetrievedShardListOfStream(String streamArn) {
+        return streamsToRetrievedShardList.getOrDefault(streamArn, null);
     }
 
-    public StreamShardHandle getLastSeenShardOfStream(String stream) {
-        if (!streamsToRetrievedShardList.containsKey(stream)) {
+    public StreamShardHandle getLastSeenShardOfStream(String streamArn) {
+        if (!streamsToRetrievedShardList.containsKey(streamArn)) {
             return null;
         } else {
-            return streamsToRetrievedShardList.get(stream).getLast();
+            return streamsToRetrievedShardList.get(streamArn).getLast();
         }
     }
 

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyInterface.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyInterface.java
@@ -20,7 +20,10 @@ package org.apache.flink.streaming.connectors.kinesis.proxy;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 
+import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
+
+import javax.annotation.Nullable;
 
 import java.util.Map;
 
@@ -71,13 +74,24 @@ public interface KinesisProxyInterface {
      * Get shard list of multiple Kinesis streams, ignoring the shards of each stream before a
      * specified last seen shard id.
      *
-     * @param streamNamesWithLastSeenShardIds a map with stream as key, and last seen shard id as
+     * @param streamArnsWithLastSeenShardIds a map with stream as key, and last seen shard id as
      *     value
      * @return result of the shard list query
      * @throws InterruptedException this method will retry with backoff if AWS Kinesis complains
      *     that the operation has exceeded the rate limit; this exception will be thrown if the
      *     backoff is interrupted.
      */
-    GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds)
+    GetShardListResult getShardList(Map<String, String> streamArnsWithLastSeenShardIds)
             throws InterruptedException;
+
+    /**
+     * Get metainfo for a Kinesis stream, which contains information about which shards this Kinesis
+     * stream possess.
+     *
+     * @param streamName the stream to describe
+     * @param startShardId which shard to start with for this describe operation
+     * @return the result of the describe stream operation
+     */
+    DescribeStreamResult describeStream(String streamName, @Nullable String startShardId)
+        throws InterruptedException;
 }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -91,7 +91,7 @@ public class KinesisConfigUtil {
     }
 
     /** Validate configuration properties for {@link FlinkKinesisConsumer}. */
-    public static void validateConsumerConfiguration(Properties config, List<String> streams) {
+    public static void validateConsumerConfiguration(Properties config, List<String> streamArns) {
         checkNotNull(config, "config can not be null");
 
         validateAwsConfiguration(config);
@@ -99,7 +99,7 @@ public class KinesisConfigUtil {
         RecordPublisherType recordPublisherType = validateRecordPublisherType(config);
 
         if (recordPublisherType == RecordPublisherType.EFO) {
-            validateEfoConfiguration(config, streams);
+            validateEfoConfiguration(config, streamArns);
         }
 
         if (!(config.containsKey(AWSConfigConstants.AWS_REGION)
@@ -357,10 +357,10 @@ public class KinesisConfigUtil {
      * Validate if the given config is a valid EFO configuration.
      *
      * @param config config properties.
-     * @param streams the streams which is sent to match the EFO consumer arn if the EFO
+     * @param streamArns the stream ARNs which is sent to match the EFO consumer arn if the EFO
      *     registration mode is set to `NONE`.
      */
-    public static void validateEfoConfiguration(Properties config, List<String> streams) {
+    public static void validateEfoConfiguration(Properties config, List<String> streamArns) {
         EFORegistrationType efoRegistrationType;
         if (config.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE)) {
             String typeInString = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
@@ -383,9 +383,10 @@ public class KinesisConfigUtil {
             // if the registration type is NONE, then for each stream there must be an according
             // consumer ARN
             List<String> missingConsumerArnKeys = new ArrayList<>();
-            for (String stream : streams) {
+            for (String streamArn : streamArns) {
+                String streamName = StreamConverterUtil.getStreamName(streamArn);
                 String efoConsumerARNKey =
-                        ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream;
+                        ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + streamName;
                 if (!config.containsKey(efoConsumerARNKey)) {
                     missingConsumerArnKeys.add(efoConsumerARNKey);
                 }

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConverterUtil.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConverterUtil.java
@@ -1,0 +1,37 @@
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import com.amazonaws.arn.Arn;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This util class exists to convert Stream name into Stream ARN and vice versa.
+ */
+public class StreamConverterUtil {
+
+    public static String getStreamName(final Arn streamArn) {
+        return streamArn.getResource().getResource();
+    }
+
+    public static String getStreamName(final String streamArn) {
+        return Arn.fromString(streamArn).getResource().getResource();
+    }
+
+    public static String getStreamArn(
+        final String streamNameOrArn, final Properties configProps)
+        throws ExecutionException, InterruptedException {
+        try {
+            return Arn.fromString(streamNameOrArn).toString();
+        } catch (IllegalArgumentException e) {
+            KinesisProxyInterface kinesis = KinesisProxy.create(configProps);
+            return kinesis
+                .describeStream(streamNameOrArn, null)
+                .getStreamDescription()
+                .getStreamARN();
+        }
+    }
+}

--- a/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
+++ b/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
@@ -53,6 +53,6 @@ public class UniformShardAssigner implements KinesisShardAssigner {
         // distributed in the same way, even if they are sharded in the same way.
         // (The caller takes result modulo nSubtasks.)
         return hashKeyMid.multiply(BigInteger.valueOf(nSubtasks)).divide(HASH_KEY_BOUND).intValue()
-                + streamShardHandle.getStreamName().hashCode();
+                + streamShardHandle.getStreamArn().hashCode();
     }
 }

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
@@ -78,7 +78,7 @@ public class FlinkKinesisConsumerMigrationTest {
      */
     private final FlinkVersion flinkGenerateSavepointVersion = null;
 
-    private static final String TEST_STREAM_NAME = "fakeStream1";
+    private static final String TEST_STREAM_NAME = "arn:aws:kinesis:us-east-1:123456789012:stream/fakeStream1";
     private static final SequenceNumber TEST_SEQUENCE_NUMBER = new SequenceNumber("987654321");
     private static final String TEST_SHARD_ID = KinesisShardIdGenerator.generateFromShardOrder(0);
 
@@ -86,7 +86,7 @@ public class FlinkKinesisConsumerMigrationTest {
 
     static {
         StreamShardMetadata shardMetadata = new StreamShardMetadata();
-        shardMetadata.setStreamName(TEST_STREAM_NAME);
+        shardMetadata.setStreamArn(TEST_STREAM_NAME);
         shardMetadata.setShardId(TEST_SHARD_ID);
 
         TEST_STATE.put(shardMetadata, TEST_SEQUENCE_NUMBER);
@@ -141,7 +141,7 @@ public class FlinkKinesisConsumerMigrationTest {
             sequenceNumberRange.withStartingSequenceNumber("1");
             shard.setSequenceNumberRange(sequenceNumberRange);
 
-            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamName(), shard));
+            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamArn(), shard));
         }
 
         final TestFetcher<String> fetcher =
@@ -184,7 +184,7 @@ public class FlinkKinesisConsumerMigrationTest {
         // job wasn't running,
         // and therefore should be consumed from the earliest sequence number
         KinesisStreamShardState restoredShardState = fetcher.getSubscribedShardsState().get(0);
-        assertThat(restoredShardState.getStreamShardHandle().getStreamName())
+        assertThat(restoredShardState.getStreamShardHandle().getStreamArn())
                 .isEqualTo(TEST_STREAM_NAME);
         assertThat(restoredShardState.getStreamShardHandle().getShard().getShardId())
                 .isEqualTo(TEST_SHARD_ID);
@@ -207,7 +207,7 @@ public class FlinkKinesisConsumerMigrationTest {
             sequenceNumberRange.withStartingSequenceNumber("1");
             shard.setSequenceNumberRange(sequenceNumberRange);
 
-            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamName(), shard));
+            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamArn(), shard));
         }
 
         final TestFetcher<String> fetcher =
@@ -251,7 +251,7 @@ public class FlinkKinesisConsumerMigrationTest {
                 .isEqualTo(TEST_SEQUENCE_NUMBER);
 
         KinesisStreamShardState restoredShardState = fetcher.getSubscribedShardsState().get(0);
-        assertThat(restoredShardState.getStreamShardHandle().getStreamName())
+        assertThat(restoredShardState.getStreamShardHandle().getStreamArn())
                 .isEqualTo(TEST_STREAM_NAME);
         assertThat(restoredShardState.getStreamShardHandle().getShard().getShardId())
                 .isEqualTo(TEST_SHARD_ID);
@@ -278,7 +278,7 @@ public class FlinkKinesisConsumerMigrationTest {
             closedShard.setSequenceNumberRange(closedSequenceNumberRange);
 
             initialDiscoveryShards.add(
-                    new StreamShardHandle(shardMetadata.getStreamName(), closedShard));
+                    new StreamShardHandle(shardMetadata.getStreamArn(), closedShard));
 
             // setup the new shards
             Shard newSplitShard1 = new Shard();
@@ -300,9 +300,9 @@ public class FlinkKinesisConsumerMigrationTest {
             newSplitShard2.setParentShardId(TEST_SHARD_ID);
 
             initialDiscoveryShards.add(
-                    new StreamShardHandle(shardMetadata.getStreamName(), newSplitShard1));
+                    new StreamShardHandle(shardMetadata.getStreamArn(), newSplitShard1));
             initialDiscoveryShards.add(
-                    new StreamShardHandle(shardMetadata.getStreamName(), newSplitShard2));
+                    new StreamShardHandle(shardMetadata.getStreamArn(), newSplitShard2));
         }
 
         final TestFetcher<String> fetcher =
@@ -347,7 +347,7 @@ public class FlinkKinesisConsumerMigrationTest {
 
         KinesisStreamShardState restoredClosedShardState =
                 fetcher.getSubscribedShardsState().get(0);
-        assertThat(restoredClosedShardState.getStreamShardHandle().getStreamName())
+        assertThat(restoredClosedShardState.getStreamShardHandle().getStreamArn())
                 .isEqualTo(TEST_STREAM_NAME);
         assertThat(restoredClosedShardState.getStreamShardHandle().getShard().getShardId())
                 .isEqualTo(TEST_SHARD_ID);
@@ -356,7 +356,7 @@ public class FlinkKinesisConsumerMigrationTest {
                 .isEqualTo(TEST_SEQUENCE_NUMBER);
 
         KinesisStreamShardState restoredNewSplitShard1 = fetcher.getSubscribedShardsState().get(1);
-        assertThat(restoredNewSplitShard1.getStreamShardHandle().getStreamName())
+        assertThat(restoredNewSplitShard1.getStreamShardHandle().getStreamArn())
                 .isEqualTo(TEST_STREAM_NAME);
         assertThat(restoredNewSplitShard1.getStreamShardHandle().getShard().getShardId())
                 .isEqualTo(KinesisShardIdGenerator.generateFromShardOrder(1));
@@ -366,7 +366,7 @@ public class FlinkKinesisConsumerMigrationTest {
                 .isEqualTo(SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM.get());
 
         KinesisStreamShardState restoredNewSplitShard2 = fetcher.getSubscribedShardsState().get(2);
-        assertThat(restoredNewSplitShard2.getStreamShardHandle().getStreamName())
+        assertThat(restoredNewSplitShard2.getStreamShardHandle().getStreamArn())
                 .isEqualTo(TEST_STREAM_NAME);
         assertThat(restoredNewSplitShard2.getStreamShardHandle().getShard().getShardId())
                 .isEqualTo(KinesisShardIdGenerator.generateFromShardOrder(2));
@@ -393,7 +393,7 @@ public class FlinkKinesisConsumerMigrationTest {
             sequenceNumberRange.withStartingSequenceNumber("1");
             shard.setSequenceNumberRange(sequenceNumberRange);
 
-            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamName(), shard));
+            initialDiscoveryShards.add(new StreamShardHandle(shardMetadata.getStreamArn(), shard));
         }
 
         final TestFetcher<String> fetcher =
@@ -468,7 +468,7 @@ public class FlinkKinesisConsumerMigrationTest {
 
         @Override
         protected KinesisDataFetcher<T> createFetcher(
-                List<String> streams,
+                List<String> streamArns,
                 SourceContext<T> sourceContext,
                 RuntimeContext runtimeContext,
                 Properties configProps,

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -344,7 +344,7 @@ public class KinesisDataFetcherTest extends TestLogger {
         for (Map.Entry<StreamShardHandle, String> restoredState :
                 restoredStateUnderTest.entrySet()) {
             fetcher.advanceLastDiscoveredShardOfStream(
-                    restoredState.getKey().getStreamName(),
+                    restoredState.getKey().getStreamArn(),
                     restoredState.getKey().getShard().getShardId());
             fetcher.registerNewSubscribedShardState(
                     new KinesisStreamShardState(
@@ -451,7 +451,7 @@ public class KinesisDataFetcherTest extends TestLogger {
         for (Map.Entry<StreamShardHandle, String> restoredState :
                 restoredStateUnderTest.entrySet()) {
             fetcher.advanceLastDiscoveredShardOfStream(
-                    restoredState.getKey().getStreamName(),
+                    restoredState.getKey().getStreamArn(),
                     restoredState.getKey().getShard().getShardId());
             fetcher.registerNewSubscribedShardState(
                     new KinesisStreamShardState(
@@ -558,7 +558,7 @@ public class KinesisDataFetcherTest extends TestLogger {
         for (Map.Entry<StreamShardHandle, String> restoredState :
                 restoredStateUnderTest.entrySet()) {
             fetcher.advanceLastDiscoveredShardOfStream(
-                    restoredState.getKey().getStreamName(),
+                    restoredState.getKey().getStreamArn(),
                     restoredState.getKey().getShard().getShardId());
             fetcher.registerNewSubscribedShardState(
                     new KinesisStreamShardState(
@@ -668,7 +668,7 @@ public class KinesisDataFetcherTest extends TestLogger {
         for (Map.Entry<StreamShardHandle, String> restoredState :
                 restoredStateUnderTest.entrySet()) {
             fetcher.advanceLastDiscoveredShardOfStream(
-                    restoredState.getKey().getStreamName(),
+                    restoredState.getKey().getStreamArn(),
                     restoredState.getKey().getShard().getShardId());
             fetcher.registerNewSubscribedShardState(
                     new KinesisStreamShardState(
@@ -716,7 +716,7 @@ public class KinesisDataFetcherTest extends TestLogger {
         String endingSequenceNumber = "seq-00000031";
 
         StreamShardMetadata kinesisStreamShard = new StreamShardMetadata();
-        kinesisStreamShard.setStreamName(streamName);
+        kinesisStreamShard.setStreamArn(streamName);
         kinesisStreamShard.setShardId(shardId);
         kinesisStreamShard.setParentShardId(parentShardId);
         kinesisStreamShard.setAdjacentParentShardId(adjacentParentShardId);
@@ -760,7 +760,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                 KinesisDataFetcher<T> fetcher,
                 int numParallelSubtasks,
                 int subtaskIndex) {
-            super("test", mock(KinesisDeserializationSchema.class), properties);
+            super("arn:aws:kinesis:us-east-1:123456789012:stream/test", mock(KinesisDeserializationSchema.class), properties);
             this.fetcher = fetcher;
             this.numParallelSubtasks = numParallelSubtasks;
             this.subtaskIndex = subtaskIndex;
@@ -768,7 +768,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 
         @Override
         protected KinesisDataFetcher<T> createFetcher(
-                List<String> streams,
+                List<String> streamArns,
                 SourceFunction.SourceContext<T> sourceContext,
                 RuntimeContext runtimeContext,
                 Properties configProps,
@@ -951,7 +951,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 
     @Test
     public void testOriginalExceptionIsPreservedWhenInterruptedDuringShutdown() throws Exception {
-        String stream = "fakeStream";
+        String stream = "arn:aws:kinesis:us-east-1:123456789012:stream/fakeStream";
 
         Map<String, List<BlockingQueue<String>>> streamsToShardQueues = new HashMap<>();
         LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>(10);

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
@@ -95,7 +95,7 @@ public class ShardConsumerTestUtils {
         ShardConsumerMetricsReporter shardMetricsReporter =
                 new ShardConsumerMetricsReporter(metricGroup);
 
-        StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
+        StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("arn:aws:kinesis:us-east-1:123456789012:stream/fakeStream", 0);
 
         LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest = new LinkedList<>();
         subscribedShardsStateUnderTest.add(
@@ -110,7 +110,7 @@ public class ShardConsumerTestUtils {
                 new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema());
         TestableKinesisDataFetcher<String> fetcher =
                 new TestableKinesisDataFetcher<>(
-                        Collections.singletonList("fakeStream"),
+                        Collections.singletonList("arn:aws:kinesis:us-east-1:123456789012:stream/fakeStream"),
                         sourceContext,
                         consumerProperties,
                         deserializationSchema,
@@ -120,7 +120,7 @@ public class ShardConsumerTestUtils {
                         subscribedShardsStateUnderTest,
                         KinesisDataFetcher
                                 .createInitialSubscribedStreamsToLastDiscoveredShardsState(
-                                        Collections.singletonList("fakeStream")),
+                                        Collections.singletonList("arn:aws:kinesis:us-east-1:123456789012:stream/fakeStream")),
                         Mockito.mock(KinesisProxyInterface.class),
                         Mockito.mock(KinesisProxyAsyncV2Interface.class));
 

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
@@ -29,9 +29,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -48,6 +46,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FanOutRecordPublisherConfiguration}. */
 public class FanOutRecordPublisherConfigurationTest extends TestLogger {
+    private static final String STREAM_1_NAME = "fakedstream1";
+    private static final String STREAM_1_ARN = "arn:aws:kinesis:us-east-1:123456789012:stream/fakedstream1";
+    private static final String STREAM_2_NAME = "fakedstream2";
+    private static final String STREAM_2_ARN = "arn:aws:kinesis:us-east-1:123456789012:stream/fakedstream2";
 
     @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -88,25 +90,25 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 
     @Test
     public void testNoneStrategyWithStreams() {
-        List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+        List<String> streamNames = Arrays.asList(STREAM_1_NAME, STREAM_2_NAME);
+        List<String> streamArns = Arrays.asList(STREAM_1_ARN, STREAM_2_ARN);
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
         testConfig.setProperty(EFO_REGISTRATION_TYPE, NONE.toString());
-        streams.forEach(
+        streamNames.forEach(
                 stream -> testConfig.setProperty(EFO_CONSUMER_ARN_PREFIX + "." + stream, stream));
         FanOutRecordPublisherConfiguration fanOutRecordPublisherConfiguration =
-                new FanOutRecordPublisherConfiguration(testConfig, streams);
-        Map<String, String> expectedStreamArns = new HashMap<>();
-        expectedStreamArns.put("fakedstream1", "fakedstream1");
-        expectedStreamArns.put("fakedstream2", "fakedstream2");
+                new FanOutRecordPublisherConfiguration(testConfig, streamArns);
 
-        assertThat(Optional.of("fakedstream1"))
-                .isEqualTo(fanOutRecordPublisherConfiguration.getStreamConsumerArn("fakedstream1"));
+        assertThat(Optional.of(STREAM_1_NAME))
+                .isEqualTo(fanOutRecordPublisherConfiguration.getStreamConsumerArn(STREAM_1_ARN));
+        assertThat(Optional.of(STREAM_2_NAME))
+            .isEqualTo(fanOutRecordPublisherConfiguration.getStreamConsumerArn(STREAM_2_ARN));
     }
 
     @Test
     public void testNoneStrategyWithNoStreams() {
-        List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+        List<String> streams = Arrays.asList(STREAM_1_ARN, STREAM_2_ARN);
 
         String msg =
                 "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream1, flink.stream.efo.consumerarn.fakedstream2";
@@ -122,7 +124,7 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 
     @Test
     public void testNoneStrategyWithNotEnoughStreams() {
-        List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+        List<String> streams = Arrays.asList(STREAM_1_ARN, STREAM_2_ARN);
 
         String msg =
                 "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream2";
@@ -132,7 +134,7 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
         testConfig.setProperty(EFO_REGISTRATION_TYPE, NONE.toString());
-        testConfig.setProperty(EFO_CONSUMER_ARN_PREFIX + "." + "fakedstream1", "fakedstream1");
+        testConfig.setProperty(EFO_CONSUMER_ARN_PREFIX + "." + STREAM_1_NAME, STREAM_1_NAME);
 
         new FanOutRecordPublisherConfiguration(testConfig, streams);
     }

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/StreamConsumerRegistrarTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/StreamConsumerRegistrarTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -50,6 +51,7 @@ import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesi
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.STREAM_CONSUMER_ARN_NEW;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.StreamConsumerFakeKinesisSync.NUMBER_OF_DESCRIBE_REQUESTS_TO_ACTIVATE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -64,7 +66,7 @@ import static org.mockito.Mockito.when;
 /** Tests for {@link StreamConsumerRegistrar}. */
 public class StreamConsumerRegistrarTest {
 
-    private static final String STREAM = "stream";
+    private static final String STREAM = "arn:aws:kinesis:us-east-1:123456789012:stream/stream";
 
     private static final long EXPECTED_REGISTRATION_MAX = 1;
     private static final long EXPECTED_REGISTRATION_BASE = 2;
@@ -78,7 +80,8 @@ public class StreamConsumerRegistrarTest {
 
     @Test
     public void testStreamNotFoundWhenRegisteringThrowsException() throws Exception {
-        thrown.expect(ResourceNotFoundException.class);
+        thrown.expect(ExecutionException.class);
+        thrown.expectCause(instanceOf(ResourceNotFoundException.class));
 
         KinesisProxySyncV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.streamNotFound();
         StreamConsumerRegistrar registrar = createRegistrar(kinesis, mock(FullJitterBackoff.class));
@@ -141,7 +144,7 @@ public class StreamConsumerRegistrarTest {
             throws Exception {
         thrown.expect(FlinkKinesisTimeoutException.class);
         thrown.expectMessage(
-                "Timeout waiting for stream consumer to become active: name on stream-arn");
+                "Timeout waiting for stream consumer to become active: name on arn:aws:kinesis:us-east-1:123456789012:stream/stream");
 
         StreamConsumerFakeKinesisSync kinesis =
                 FakeKinesisFanOutBehavioursFactory.registerExistingConsumerAndWaitToBecomeActive();

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -355,20 +355,20 @@ public class KinesisProxyTest {
     @Test
     public void testGetShardWithNoNewShards() throws Exception {
         // given
-        String fakeStreamName = "fake-stream";
+        String fakeStreamArn = "arn:aws:kinesis:us-east-1:123456789012:stream/fake-stream";
 
         AmazonKinesis mockClient = mock(AmazonKinesis.class);
         KinesisProxy kinesisProxy = getProxy(mockClient);
 
         when(mockClient.listShards(
                         new ListShardsRequest()
-                                .withStreamName(fakeStreamName)
+                                .withStreamARN(fakeStreamArn)
                                 .withExclusiveStartShardId(
                                         KinesisShardIdGenerator.generateFromShardOrder(1))))
                 .thenReturn(new ListShardsResult().withShards(Collections.emptyList()));
 
         HashMap<String, String> streamHashMap = new HashMap<>();
-        streamHashMap.put(fakeStreamName, KinesisShardIdGenerator.generateFromShardOrder(1));
+        streamHashMap.put(fakeStreamArn, KinesisShardIdGenerator.generateFromShardOrder(1));
 
         // when
         GetShardListResult shardListResult = kinesisProxy.getShardList(streamHashMap);

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisClientFactory.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisClientFactory.java
@@ -99,7 +99,7 @@ public class FakeKinesisClientFactory {
             @Override
             public GetShardIteratorResult getShardIterator(
                     GetShardIteratorRequest getShardIteratorRequest) {
-                if (getShardIteratorRequest.getStreamName().equals(streamName)
+                if (getShardIteratorRequest.getStreamARN().equals(streamName)
                         && shardIds.contains(getShardIteratorRequest.getShardId())) {
                     return new GetShardIteratorResult().withShardIterator("fakeShardIterator");
                 }

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -294,7 +294,7 @@ public class KinesisConfigUtilTest {
         testConfig.setProperty(
                 ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + ".stream1", "fakedArn1");
         List<String> streams = new ArrayList<>();
-        streams.add("stream1");
+        streams.add("arn:aws:kinesis:us-east-1:123456789012:stream/stream1");
         KinesisConfigUtil.validateEfoConfiguration(testConfig, streams);
     }
 
@@ -312,7 +312,7 @@ public class KinesisConfigUtilTest {
         testConfig.setProperty(
                 ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + ".stream2", "fakedArn2");
         List<String> streams = new ArrayList<>();
-        streams.add("stream1");
+        streams.add("arn:aws:kinesis:us-east-1:123456789012:stream/stream1");
         KinesisConfigUtil.validateEfoConfiguration(testConfig, streams);
     }
 
@@ -333,7 +333,7 @@ public class KinesisConfigUtilTest {
                 ConsumerConfigConstants.EFORegistrationType.NONE.toString());
         testConfig.setProperty(
                 ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + ".stream1", "fakedArn1");
-        List<String> streams = Arrays.asList("stream1", "stream2");
+        List<String> streams = Arrays.asList("arn:aws:kinesis:us-east-1:123456789012:stream/stream1", "arn:aws:kinesis:us-east-1:123456789012:stream/stream2");
         KinesisConfigUtil.validateEfoConfiguration(testConfig, streams);
     }
 

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtilTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtilTest.java
@@ -39,22 +39,24 @@ import static org.mockito.Mockito.when;
 
 /** Tests for {@link StreamConsumerRegistrar}. */
 public class StreamConsumerRegistrarUtilTest {
+    private static final String STREAM_1_ARN = "arn:aws:kinesis:us-east-1:123456789012:stream/stream-1";
+    private static final String STREAM_2_ARN = "arn:aws:kinesis:us-east-1:123456789012:stream/stream-2";
 
     @Test
     public void testRegisterStreamConsumers() throws Exception {
         Properties configProps = getDefaultConfiguration();
         StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
-        when(registrar.registerStreamConsumer("stream-1", "consumer-name"))
+        when(registrar.registerStreamConsumer(STREAM_1_ARN, "consumer-name"))
                 .thenReturn("stream-1-consumer-arn");
-        when(registrar.registerStreamConsumer("stream-2", "consumer-name"))
+        when(registrar.registerStreamConsumer(STREAM_2_ARN, "consumer-name"))
                 .thenReturn("stream-2-consumer-arn");
 
         StreamConsumerRegistrarUtil.registerStreamConsumers(
-                registrar, configProps, Arrays.asList("stream-1", "stream-2"));
+                registrar, configProps, Arrays.asList(STREAM_1_ARN, STREAM_2_ARN));
 
-        assertThat(configProps.getProperty(efoConsumerArn("stream-1")))
+        assertThat(configProps.getProperty(efoConsumerArn(STREAM_1_ARN)))
                 .isEqualTo("stream-1-consumer-arn");
-        assertThat(configProps.getProperty(efoConsumerArn("stream-2")))
+        assertThat(configProps.getProperty(efoConsumerArn(STREAM_2_ARN)))
                 .isEqualTo("stream-2-consumer-arn");
     }
 
@@ -62,13 +64,13 @@ public class StreamConsumerRegistrarUtilTest {
     public void testDeregisterStreamConsumersMissingStreamArn() throws Exception {
         Properties configProps = getDefaultConfiguration();
         configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
-        List<String> streams = Arrays.asList("stream-1", "stream-2");
+        List<String> streams = Arrays.asList(STREAM_1_ARN, STREAM_2_ARN);
         StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
 
         StreamConsumerRegistrarUtil.deregisterStreamConsumers(registrar, configProps, streams);
 
-        verify(registrar).deregisterStreamConsumer("stream-1");
-        verify(registrar).deregisterStreamConsumer("stream-2");
+        verify(registrar).deregisterStreamConsumer(STREAM_1_ARN);
+        verify(registrar).deregisterStreamConsumer(STREAM_2_ARN);
     }
 
     @Test
@@ -76,7 +78,7 @@ public class StreamConsumerRegistrarUtilTest {
         Properties configProps = getDefaultConfiguration();
         configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
         configProps.put(EFO_REGISTRATION_TYPE, EAGER.name());
-        List<String> streams = Arrays.asList("stream-1");
+        List<String> streams = Arrays.asList(STREAM_1_ARN);
         StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
 
         StreamConsumerRegistrarUtil.deregisterStreamConsumers(registrar, configProps, streams);

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
     </scm>
 
     <properties>
-        <aws.sdkv1.version>1.12.276</aws.sdkv1.version>
+        <aws.sdkv1.version>1.12.439</aws.sdkv1.version>
         <aws.sdkv2.version>2.19.14</aws.sdkv2.version>
         <netty.version>4.1.86.Final</netty.version>
         <flink.version>1.16.0</flink.version>


### PR DESCRIPTION
…me for Kinesis API calls

## Purpose of the change
Modifies Kinesis Source to use Stream ARN instead of Stream name.

## Verifying this change
This change added tests and can be verified as follows:
- Added unit tests

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [x] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
