### PR TITLE
[FLINK-31108][Connectors/Kinesis] Use Stream ARN instead of Stream Na…

### DIFF
--- a/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws-kinesis-streams/pom.xml
@@ -58,6 +58,11 @@ under the License.
             <artifactId>kinesis</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+        </dependency>
+
         <!--Table API dependencies-->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilder.java
+++ b/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilder.java
@@ -30,13 +30,13 @@ import java.util.Properties;
  * Builder to construct {@link KinesisStreamsSink}.
  *
  * <p>The following example shows the minimum setup to create a {@link KinesisStreamsSink} that
- * writes String values to a Kinesis Data Streams stream named your_stream_here.
+ * writes String values to a Kinesis Data Streams stream.
  *
  * <pre>{@code
  * KinesisStreamsSink<String> kdsSink =
  *                 KinesisStreamsSink.<String>builder()
  *                         .setElementConverter(elementConverter)
- *                         .setStreamName("your_stream_name")
+ *                         .setStreamArn("your_stream_arn")
  *                         .setSerializationSchema(new SimpleStringSchema())
  *                         .setPartitionKeyGenerator(element -> String.valueOf(element.hashCode()))
  *                         .build();
@@ -71,6 +71,7 @@ public class KinesisStreamsSinkBuilder<InputT>
 
     private Boolean failOnError;
     private String streamName;
+    private String streamArn;
     private Properties kinesisClientProperties;
     private SerializationSchema<InputT> serializationSchema;
     private PartitionKeyGenerator<InputT> partitionKeyGenerator;
@@ -78,15 +79,20 @@ public class KinesisStreamsSinkBuilder<InputT>
     KinesisStreamsSinkBuilder() {}
 
     /**
-     * Sets the name of the KDS stream that the sink will connect to. There is no default for this
-     * parameter, therefore, this must be provided at sink creation time otherwise the build will
-     * fail.
+     * Providing the stream name is deprecated. Please provide stream ARN using {@link
+     * KinesisStreamsSinkBuilder#setStreamArn} instead.
      *
      * @param streamName the name of the stream
      * @return {@link KinesisStreamsSinkBuilder} itself
      */
+    @Deprecated
     public KinesisStreamsSinkBuilder<InputT> setStreamName(String streamName) {
         this.streamName = streamName;
+        return this;
+    }
+
+    public KinesisStreamsSinkBuilder<InputT> setStreamArn(String streamArn) {
+        this.streamArn = streamArn;
         return this;
     }
 
@@ -129,6 +135,7 @@ public class KinesisStreamsSinkBuilder<InputT>
                 Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(DEFAULT_MAX_RECORD_SIZE_IN_B),
                 Optional.ofNullable(failOnError).orElse(DEFAULT_FAIL_ON_ERROR),
                 streamName,
+                streamArn,
                 Optional.ofNullable(kinesisClientProperties).orElse(new Properties()));
     }
 }

--- a/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilderTest.java
+++ b/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilderTest.java
@@ -39,7 +39,7 @@ class KinesisStreamsSinkBuilderTest {
     }
 
     @Test
-    void streamNameOfSinkMustBeSetWhenBuilt() {
+    void streamNameOrStreamArnMustBeSetWhenBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -63,6 +63,33 @@ class KinesisStreamsSinkBuilderTest {
                                         .build())
                 .withMessageContaining(
                         "The stream name must be set when initializing the KDS Sink.");
+    }
+
+    @Test
+    void streamArnMustNotBeEmptyWhenBuilt() {
+        Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                KinesisStreamsSink.<String>builder()
+                                        .setPartitionKeyGenerator(PARTITION_KEY_GENERATOR)
+                                        .setSerializationSchema(SERIALIZATION_SCHEMA)
+                                        .setStreamArn("")
+                                        .build())
+                .withMessageContaining("Malformed ARN - doesn't start with 'arn:'");
+    }
+
+    @Test
+    void streamArnResouceMustNotBeEmptyWhenBuilt() {
+        Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                KinesisStreamsSink.<String>builder()
+                                        .setPartitionKeyGenerator(PARTITION_KEY_GENERATOR)
+                                        .setSerializationSchema(SERIALIZATION_SCHEMA)
+                                        .setStreamArn(
+                                                "arn:aws:kinesis:us-east-1:000000000000:stream/")
+                                        .build())
+                .withMessageContaining("resource must not be blank or empty.");
     }
 
     @Test

--- a/flink-connector-kinesis/pom.xml
+++ b/flink-connector-kinesis/pom.xml
@@ -76,6 +76,10 @@ under the License.
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
             <version>${aws.kinesis-kpl.version}</version>
         </dependency>

--- a/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -8,6 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - software.amazon.ion:ion-java:1.0.2
 - software.amazon.eventstream:eventstream:1.0.1
+- software.amazon.awssdk:arns:2.20.32
 - software.amazon.awssdk:utils:2.20.32
 - software.amazon.awssdk:third-party-jackson-dataformat-cbor:2.20.32
 - software.amazon.awssdk:third-party-jackson-core:2.20.32
@@ -45,15 +46,15 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- com.amazonaws:jmespath-java:1.12.276
+- com.amazonaws:jmespath-java:1.12.439
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
-- com.amazonaws:aws-java-sdk-sts:1.12.276
-- com.amazonaws:aws-java-sdk-s3:1.12.276
-- com.amazonaws:aws-java-sdk-kms:1.12.276
-- com.amazonaws:aws-java-sdk-kinesis:1.12.276
-- com.amazonaws:aws-java-sdk-dynamodb:1.12.276
-- com.amazonaws:aws-java-sdk-core:1.12.276
-- com.amazonaws:aws-java-sdk-cloudwatch:1.12.276
+- com.amazonaws:aws-java-sdk-sts:1.12.439
+- com.amazonaws:aws-java-sdk-s3:1.12.439
+- com.amazonaws:aws-java-sdk-kms:1.12.439
+- com.amazonaws:aws-java-sdk-kinesis:1.12.439
+- com.amazonaws:aws-java-sdk-dynamodb:1.12.439
+- com.amazonaws:aws-java-sdk-core:1.12.439
+- com.amazonaws:aws-java-sdk-cloudwatch:1.12.439
 - com.amazonaws:amazon-kinesis-producer:0.14.1
 - com.amazonaws:amazon-kinesis-client:1.14.8
 

--- a/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxyTest.java
+++ b/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxyTest.java
@@ -35,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DynamoDBStreamsProxyTest {
 
     private static final String FAKE_STREAM_NAME = "fake-stream";
+    private static final String FAKE_STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:123456789012:stream/fake-stream";
 
     private static final List<String> SHARD_IDS =
             Arrays.asList(
@@ -76,7 +78,7 @@ class DynamoDBStreamsProxyTest {
 
         protected AmazonKinesis createKinesisClient(Properties configProps) {
             return FakeKinesisClientFactory.resourceNotFoundWhenGettingShardIterator(
-                    FAKE_STREAM_NAME, SHARD_IDS);
+                    FAKE_STREAM_NAME, FAKE_STREAM_ARN, SHARD_IDS);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
     </scm>
 
     <properties>
-        <aws.sdkv1.version>1.12.276</aws.sdkv1.version>
+        <aws.sdkv1.version>1.12.439</aws.sdkv1.version>
         <aws.sdkv2.version>2.20.32</aws.sdkv2.version>
         <netty.version>4.1.86.Final</netty.version>
         <flink.version>1.16.0</flink.version>


### PR DESCRIPTION
…me for Kinesis API calls

## Purpose of the change
- Change Kinesis API calls to use streamARN instead of streamName. This allows for lower request latency on Kinesis service side.
- We could have also made a bigger change to allow users to specify streamARN in rather than streamName. However, that would require state migration, so we have passed on that for now.
- Updated AWS SDKv1 version to allow specification of streamARN

## Verifying this change
This change added tests and can be verified as follows:
- Modified existing unit tests for ListShards and GetShardIterator

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
