### PR TITLE
[FLINK-31675][Connectors/AWS] Update AWS SDKv2 to v2.20.32 for 3.x

### DIFF
--- a/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriterTest.java
+++ b/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriterTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbServiceClientConfiguration;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
@@ -480,6 +481,11 @@ public class DynamoDbSinkWriterTest {
             return CompletableFuture.completedFuture(BatchWriteItemResponse.builder().build());
         }
 
+        @Override
+        public DynamoDbServiceClientConfiguration serviceClientConfiguration() {
+            return DynamoDbServiceClientConfiguration.builder().build();
+        }
+
         public List<List<WriteRequest>> getRequestHistory() {
             return requestHistory;
         }
@@ -535,6 +541,11 @@ public class DynamoDbSinkWriterTest {
             }
             return CompletableFuture.completedFuture(responseBuilder.build());
         }
+
+        @Override
+        public DynamoDbServiceClientConfiguration serviceClientConfiguration() {
+            return DynamoDbServiceClientConfiguration.builder().build();
+        }
     }
 
     private static class FailingRecordsDynamoDbAsyncClient implements DynamoDbAsyncClient {
@@ -587,6 +598,11 @@ public class DynamoDbSinkWriterTest {
                                 ImmutableMap.of(TABLE_NAME, failedRequests));
             }
             return CompletableFuture.completedFuture(responseBuilder.build());
+        }
+
+        @Override
+        public DynamoDbServiceClientConfiguration serviceClientConfiguration() {
+            return DynamoDbServiceClientConfiguration.builder().build();
         }
     }
 }

--- a/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
@@ -7,26 +7,26 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- software.amazon.awssdk:utils:2.19.14
-- software.amazon.awssdk:third-party-jackson-core:2.19.14
-- software.amazon.awssdk:sts:2.19.14
-- software.amazon.awssdk:sdk-core:2.19.14
-- software.amazon.awssdk:regions:2.19.14
-- software.amazon.awssdk:protocol-core:2.19.14
-- software.amazon.awssdk:profiles:2.19.14
-- software.amazon.awssdk:netty-nio-client:2.19.14
-- software.amazon.awssdk:metrics-spi:2.19.14
-- software.amazon.awssdk:json-utils:2.19.14
-- software.amazon.awssdk:http-client-spi:2.19.14
-- software.amazon.awssdk:endpoints-spi:2.19.14
-- software.amazon.awssdk:dynamodb:2.19.14
-- software.amazon.awssdk:dynamodb-enhanced:2.19.14
-- software.amazon.awssdk:aws-query-protocol:2.19.14
-- software.amazon.awssdk:aws-json-protocol:2.19.14
-- software.amazon.awssdk:aws-core:2.19.14
-- software.amazon.awssdk:auth:2.19.14
-- software.amazon.awssdk:apache-client:2.19.14
-- software.amazon.awssdk:annotations:2.19.14
+- software.amazon.awssdk:utils:2.20.32
+- software.amazon.awssdk:third-party-jackson-core:2.20.32
+- software.amazon.awssdk:sts:2.20.32
+- software.amazon.awssdk:sdk-core:2.20.32
+- software.amazon.awssdk:regions:2.20.32
+- software.amazon.awssdk:protocol-core:2.20.32
+- software.amazon.awssdk:profiles:2.20.32
+- software.amazon.awssdk:netty-nio-client:2.20.32
+- software.amazon.awssdk:metrics-spi:2.20.32
+- software.amazon.awssdk:json-utils:2.20.32
+- software.amazon.awssdk:http-client-spi:2.20.32
+- software.amazon.awssdk:endpoints-spi:2.20.32
+- software.amazon.awssdk:dynamodb:2.20.32
+- software.amazon.awssdk:dynamodb-enhanced:2.20.32
+- software.amazon.awssdk:aws-query-protocol:2.20.32
+- software.amazon.awssdk:aws-json-protocol:2.20.32
+- software.amazon.awssdk:aws-core:2.20.32
+- software.amazon.awssdk:auth:2.20.32
+- software.amazon.awssdk:apache-client:2.20.32
+- software.amazon.awssdk:annotations:2.20.32
 - org.apache.httpcomponents:httpcore:4.4.13
 - org.apache.httpcomponents:httpclient:4.5.13
 - io.netty:netty-transport:4.1.86.Final

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@ under the License.
 
             <!-- For dependency convergence -->
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.15</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
     </scm>
 
     <properties>
-        <aws.sdk.version>2.19.14</aws.sdk.version>
+        <aws.sdk.version>2.20.32</aws.sdk.version>
         <netty.version>4.1.86.Final</netty.version>
         <flink.version>1.16.0</flink.version>
         <flink.shaded.version>16.0</flink.shaded.version>


### PR DESCRIPTION
## Purpose of the change

AWS SDK v2 from 2.19.14 to 2.20.32
Reorder NOTICE files for consistency

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
- [x ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? NA
