### PR TITLE
[FLINK-22828][Connectors/AWS] Configure custom AWS creds provider

### DIFF
--- a/docs/content.zh/docs/connectors/table/dynamodb.md
+++ b/docs/content.zh/docs/connectors/table/dynamodb.md
@@ -186,6 +186,14 @@ Connector Options
       <td>String</td>
       <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
     </tr>
+    <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>
@@ -272,6 +280,8 @@ Supported values are:
 - `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 - `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 - `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+- `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+  credential provider class via the constructor.
 
 ## Sink Partitioning
 

--- a/docs/content.zh/docs/connectors/table/firehose.md
+++ b/docs/content.zh/docs/connectors/table/firehose.md
@@ -183,7 +183,6 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.stsEndpoint</h5></td>
 	  <td>optional</td>
-      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The AWS endpoint for STS (derived from the AWS region setting if not set) to use when credential provider type is set to ASSUME_ROLE.</td>
@@ -201,6 +200,14 @@ Connector Options
    <td style="word-wrap: break-word;">(none)</td>
    <td>String</td>
    <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
+    </tr>
+    <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
     </tr>
     </tbody>
     <thead>
@@ -299,6 +306,8 @@ Supported values are:
 - `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 - `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 - `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+- `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+  credential provider class via the constructor.- 
 
 ## Data Type Mapping
 

--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -280,6 +280,15 @@ Connector Options
 	  <td>String</td>
 	  <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
     </tr>
+    <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+      <td>no</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>
@@ -832,6 +841,8 @@ Supported values are:
 * `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 * `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 * `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+* `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+credential provider class via the constructor.
 
 ### Start Reading Position
 

--- a/docs/content/docs/connectors/datastream/kinesis.md
+++ b/docs/content/docs/connectors/datastream/kinesis.md
@@ -72,6 +72,7 @@ Supported Credential Providers are:
 * `BASIC` - Using access key ID and secret key supplied as configuration. 
 * `ENV_VAR` - Using `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` environment variables.
 * `SYS_PROP` - Using Java system properties aws.accessKeyId and aws.secretKey.
+* `CUSTOM` - Use a custom user class as credential provider.
 * `PROFILE` - Use AWS credentials profile file to create the AWS credentials.
 * `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 * `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token. 

--- a/docs/content/docs/connectors/table/dynamodb.md
+++ b/docs/content/docs/connectors/table/dynamodb.md
@@ -186,6 +186,14 @@ Connector Options
       <td>String</td>
       <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
     </tr>
+     <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>
@@ -272,6 +280,9 @@ Supported values are:
 - `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 - `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 - `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+- `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+  credential provider class via the constructor. 
+
 
 ## Sink Partitioning
 

--- a/docs/content/docs/connectors/table/firehose.md
+++ b/docs/content/docs/connectors/table/firehose.md
@@ -183,7 +183,6 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.stsEndpoint</h5></td>
 	  <td>optional</td>
-      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The AWS endpoint for STS (derived from the AWS region setting if not set) to use when credential provider type is set to ASSUME_ROLE.</td>
@@ -201,6 +200,14 @@ Connector Options
    <td style="word-wrap: break-word;">(none)</td>
    <td>String</td>
    <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
+    </tr>
+    <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+      <td>(none)</td>
+	  <td style="word-wrap: break-word;">String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
     </tr>
     </tbody>
     <thead>
@@ -299,6 +306,8 @@ Supported values are:
 - `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 - `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 - `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+- `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+  credential provider class via the constructor. 
 
 ## Data Type Mapping
 

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -281,6 +281,15 @@ Connector Options
 	  <td>String</td>
 	  <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
     </tr>
+    <tr>
+	  <td><h5>aws.credentials.custom.class</h5></td>
+	  <td>required only if credential provider is set to CUSTOM</td>
+      <td>no</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The full path (in Java package notation) to the user provided
+      class to use if credential provider type is set to be CUSTOM e.g. org.user_company.auth.CustomAwsCredentialsProvider.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>
@@ -833,6 +842,8 @@ Supported values are:
 * `PROFILE` - Use an AWS credentials profile to create the AWS credentials.
 * `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
 * `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token.
+* `CUSTOM` - Provide a custom class that implements the interface `AWSCredentialsProvider` and has a constructor `MyCustomClass(java.util.Properties config)`. All connector properties will be passed down to this custom
+credential provider class via the constructor.
 
 ### Start Reading Position
 

--- a/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/config/AWSConfigConstants.java
+++ b/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/config/AWSConfigConstants.java
@@ -65,6 +65,9 @@ public class AWSConfigConstants {
          */
         WEB_IDENTITY_TOKEN,
 
+        /** Use a custom class specified by the user in connector config. */
+        CUSTOM,
+
         /**
          * A credentials provider chain will be used that searches for credentials in this order:
          * ENV_VARS, SYS_PROPS, WEB_IDENTITY_TOKEN, PROFILE in the AWS instance metadata. *
@@ -98,6 +101,13 @@ public class AWSConfigConstants {
      * credential provider type is set to be ASSUME_ROLE.
      */
     public static final String AWS_ROLE_STS_ENDPOINT = roleStsEndpoint(AWS_CREDENTIALS_PROVIDER);
+
+    /**
+     * The full path (e.g. org.user_company.auth.CustomAwsCredentialsProvider) to the user provided
+     * class to use if credential provider type is set to be CUSTOM.
+     */
+    public static final String CUSTOM_CREDENTIALS_PROVIDER_CLASS =
+            customCredentialsProviderClass(AWS_CREDENTIALS_PROVIDER);
 
     /**
      * The role ARN to use when credential provider type is set to ASSUME_ROLE or
@@ -178,6 +188,10 @@ public class AWSConfigConstants {
 
     public static String roleStsEndpoint(String prefix) {
         return prefix + ".role.stsEndpoint";
+    }
+
+    public static String customCredentialsProviderClass(String prefix) {
+        return prefix + ".custom.class";
     }
 
     public static String webIdentityTokenFile(String prefix) {


### PR DESCRIPTION
## Purpose of the change

Allow users to specify custom AWS Credential Provider classes.

## Verifying this change

- Added unit tests
- Manually verified by running the Kinesis connector on a AWS KDA Studio

![Screenshot 2023-04-20 at 15 17 11](https://user-images.githubusercontent.com/969071/233395428-49baccf3-765c-4bd8-ba6a-f0a9e94fe479.png)
![Screenshot 2023-04-20 at 15 16 59](https://user-images.githubusercontent.com/969071/233395436-5ec3dbf7-66f5-4140-b748-26c1b1ac846c.png)


## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
  - Markdown docs updated
  - JavaDocs
