### PR TITLE
[FLINK-32399][Connectors/Kinesis] Update shading configuration for Kinesis SQL connector to support maven 3.8.6+

### DIFF
--- a/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-connector-kinesis-e2e-tests/pom.xml
@@ -34,12 +34,6 @@ under the License.
     <packaging>jar</packaging>
 
     <dependencies>
-        <!--		<dependency>-->
-        <!--			<groupId>org.apache.flink</groupId>-->
-        <!--			<artifactId>flink-streaming-kafka-test-base</artifactId>-->
-        <!--			<version>${flink.version}</version>-->
-        <!--		</dependency>-->
-
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
@@ -82,6 +76,22 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils-junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/flink-connector-aws/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connector-aws/flink-sql-connector-kinesis/pom.xml
@@ -67,7 +67,16 @@ under the License.
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>*:*</include>
+                                    <include>com.google.guava:guava</include>
+                                    <include>commons-codec:commons-codec</include>
+                                    <include>commons-io:commons-io</include>
+                                    <include>commons-lang:commons-lang</include>
+                                    <include>commons-logging:commons-logging</include>
+                                    <include>org.apache.commons:commons-lang3</include>
+                                    <include>org.apache.flink:flink-connector-base</include>
+                                    <include>org.apache.flink:flink-connector-kinesis</include>
+                                    <include>org.apache.flink:flink-connector-kinesis-streams</include>
+                                    <include>joda-time:joda-time</include>
                                 </includes>
                                 <excludes>
                                     <!-- Exclude unnecessary dependencies.
@@ -88,6 +97,8 @@ under the License.
                                         <exclude>mozilla/public-suffix-list.txt</exclude>
                                         <exclude>VersionInfo.java</exclude>
                                         <exclude>mime.types</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>.gitkeep</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/flink-connector-aws/flink-sql-connector-kinesis/src/test/java/org/apache/flink/connectors/kinesis/PackagingITCase.java
+++ b/flink-connector-aws/flink-sql-connector-kinesis/src/test/java/org/apache/flink/connectors/kinesis/PackagingITCase.java
@@ -40,20 +40,7 @@ class PackagingITCase {
                         "META-INF/",
                         "amazon-kinesis-producer-native-binaries/",
                         "cacerts/",
-                        "google/",
-                        "LICENSE",
-                        "io/",
-                        "javax/",
-                        ".gitkeep",
-                        "software/amazon/",
-                        "com/esotericsoftware/",
-                        "com/fasterxml/",
-                        "com/ibm/",
-                        "com/amazonaws/",
-                        "com/ibm/",
-                        "org/objenesis/",
-                        "org/reactivestreams/",
-                        "org/slf4j/"));
+                        "google/"));
         PackagingTestUtils.assertJarContainsServiceEntry(jar, Factory.class);
     }
 }


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Update shading configuration for `flink-sql-connector-kinesis` to support build using Maven 3.8.6 and newer.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
