### PR TITLE
[FLINK-32595][Connectors/Kinesis][backport] Fix the deserialization schema version in the datastream conneter doc

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -29,5 +29,5 @@ jobs:
         flink: [1.16.1]
     with:
       flink_version: ${{ matrix.flink }}
-      flink_url: https://dist.apache.org/repos/dist/release/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      flink_url: https://archive.apache.org/dist/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: true

--- a/docs/content/docs/connectors/datastream/kinesis.md
+++ b/docs/content/docs/connectors/datastream/kinesis.md
@@ -178,7 +178,7 @@ For convenience, Flink provides the following schemas out of the box:
        
 {{< tabs "8c6721c7-4a48-496e-b0fe-6522cf6a5e13" >}}
 {{< tab "GlueSchemaRegistryJsonDeserializationSchema" >}}
-{{< artifact flink-jsonschema-glue-schema-registry >}}
+{{< connector_artifact flink-json-glue-schema-registry kinesis >}}
 {{< /tab >}}
 {{< /tabs >}}
     
@@ -200,7 +200,7 @@ For convenience, Flink provides the following schemas out of the box:
 {{< artifact flink-avro >}}
 {{< /tab >}}
 {{< tab "GlueSchemaRegistryAvroDeserializationSchema" >}}
-{{< artifact flink-avro-glue-schema-registry >}}
+{{< connector_artifact flink-avro-glue-schema-registry kinesis >}}
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

*backport https://github.com/apache/flink-connector-aws/pull/88 to v4.1.*

## Verifying this change

This change is a backport without tests.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
