### PR TITLE
[hotfix] Add MiniClusterExtension to ITCase tests

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/archunit-violations/a6cbd99c-b115-447a-8f19-43c1094db549
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/archunit-violations/a6cbd99c-b115-447a-8f19-43c1094db549
@@ -1,6 +1,0 @@
-org.apache.flink.connector.firehose.sink.KinesisFirehoseSinkITCase does not satisfy: only one of the following predicates match:\
-* reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
-* reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension\
-* reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
-* reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
- or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule

--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
@@ -22,11 +22,13 @@ import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
 import org.apache.flink.connector.aws.testutils.LocalstackContainer;
 import org.apache.flink.connector.firehose.sink.testutils.KinesisFirehoseTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -54,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration test suite for the {@code KinesisFirehoseSink} using a localstack container. */
 @Testcontainers
+@ExtendWith(MiniClusterExtension.class)
 class KinesisFirehoseSinkITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseSinkITCase.class);

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/archunit-violations/84abeb9c-8355-4165-96aa-dda65b04e5e7
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/archunit-violations/84abeb9c-8355-4165-96aa-dda65b04e5e7
@@ -1,6 +1,0 @@
-org.apache.flink.connector.kinesis.sink.KinesisStreamsSinkITCase does not satisfy: only one of the following predicates match:\
-* reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
-* reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension\
-* reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
-* reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
- or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumerator.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumerator.java
@@ -30,10 +30,6 @@ import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.split.StartingPosition;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.kinesis.model.Shard;
@@ -303,24 +299,26 @@ public class KinesisStreamsSourceEnumerator
 
         private ShardAssignerContext withPendingSplitAssignments(
                 Map<Integer, List<KinesisShardSplit>> pendingSplitAssignments) {
-            ImmutableMap.Builder<Integer, List<KinesisShardSplit>> mapBuilder =
-                    ImmutableMap.builder();
+            Map<Integer, List<KinesisShardSplit>> copyPendingSplitAssignments = new HashMap<>();
             for (Entry<Integer, List<KinesisShardSplit>> entry :
                     pendingSplitAssignments.entrySet()) {
-                mapBuilder.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+                copyPendingSplitAssignments.put(
+                        entry.getKey(),
+                        Collections.unmodifiableList(new ArrayList<>(entry.getValue())));
             }
-            this.pendingSplitAssignments = mapBuilder.build();
+            this.pendingSplitAssignments = Collections.unmodifiableMap(copyPendingSplitAssignments);
             return this;
         }
 
         @Override
         public Map<Integer, Set<KinesisShardSplit>> getCurrentSplitAssignment() {
-            ImmutableMap.Builder<Integer, Set<KinesisShardSplit>> mapBuilder =
-                    ImmutableMap.builder();
+            Map<Integer, Set<KinesisShardSplit>> copyCurrentSplitAssignment = new HashMap<>();
             for (Entry<Integer, Set<KinesisShardSplit>> entry : splitAssignment.entrySet()) {
-                mapBuilder.put(entry.getKey(), ImmutableSet.copyOf(entry.getValue()));
+                copyCurrentSplitAssignment.put(
+                        entry.getKey(),
+                        Collections.unmodifiableSet(new HashSet<>(entry.getValue())));
             }
-            return mapBuilder.build();
+            return Collections.unmodifiableMap(copyCurrentSplitAssignment);
         }
 
         @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkITCase.java
@@ -29,12 +29,14 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
 import org.apache.flink.streaming.api.functions.source.datagen.RandomGenerator;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
 import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.testcontainers.containers.Network;
@@ -65,6 +67,7 @@ import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL
 
 /** IT cases for using Kinesis Data Streams Sink based on Kinesalite. */
 @Testcontainers
+@ExtendWith(MiniClusterExtension.class)
 class KinesisStreamsSinkITCase {
 
     private static final String DEFAULT_FIRST_SHARD_NAME = "shardId-000000000000";

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
@@ -22,12 +22,12 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
 import org.apache.flink.core.io.VersionMismatchException;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
-
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.copyOf;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
@@ -40,10 +40,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
     @Test
     void testSerializeAndDeserializeEverythingSpecified() throws Exception {
         Set<String> completedShardIds =
-                ImmutableSet.of(
-                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
+                        .collect(Collectors.toSet());
         Set<KinesisShardSplit> unassignedSplits =
-                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
+                        .collect(Collectors.toSet());
         String lastSeenShardId = "shardId-000000000002";
         KinesisStreamsSourceEnumeratorState initialState =
                 new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
@@ -62,10 +63,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
     @Test
     void testDeserializeWithWrongVersionStateSerializer() throws Exception {
         Set<String> completedShardIds =
-                ImmutableSet.of(
-                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
+                        .collect(Collectors.toSet());
         Set<KinesisShardSplit> unassignedSplits =
-                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
+                        .collect(Collectors.toSet());
         String lastSeenShardId = "shardId-000000000002";
         KinesisStreamsSourceEnumeratorState initialState =
                 new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
@@ -92,10 +94,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
     @Test
     void testDeserializeWithWrongVersionSplitSerializer() throws Exception {
         Set<String> completedShardIds =
-                ImmutableSet.of(
-                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
+                        .collect(Collectors.toSet());
         Set<KinesisShardSplit> unassignedSplits =
-                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
+                        .collect(Collectors.toSet());
         String lastSeenShardId = "shardId-000000000002";
         KinesisStreamsSourceEnumeratorState initialState =
                 new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
@@ -120,10 +123,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
     @Test
     void testSerializeWithTrailingBytes() throws Exception {
         Set<String> completedShardIds =
-                ImmutableSet.of(
-                        "shardId-000000000001", "shardId-000000000002", "shardId-000000000003");
+                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
+                        .collect(Collectors.toSet());
         Set<KinesisShardSplit> unassignedSplits =
-                ImmutableSet.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)));
+                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
+                        .collect(Collectors.toSet());
         String lastSeenShardId = "shardId-000000000002";
         KinesisStreamsSourceEnumeratorState initialState =
                 new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorTest.java
@@ -29,9 +29,6 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.util.TestUtil;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -163,7 +160,7 @@ class KinesisStreamsSourceEnumeratorTest {
             TestKinesisStreamProxy streamProxy = getTestStreamProxy();
             final String completedShard = generateShardId(0);
             final String lastSeenShard = generateShardId(1);
-            final Set<String> completedShardIds = ImmutableSet.of(completedShard);
+            final Set<String> completedShardIds = Collections.singleton(completedShard);
 
             KinesisStreamsSourceEnumeratorState state =
                     new KinesisStreamsSourceEnumeratorState(Collections.emptySet(), lastSeenShard);
@@ -253,7 +250,7 @@ class KinesisStreamsSourceEnumeratorTest {
             // Given one shard split is returned
             KinesisShardSplit returnedSplit =
                     initialSplitAssignment.assignment().get(subtaskId).get(0);
-            enumerator.addSplitsBack(ImmutableList.of(returnedSplit), subtaskId);
+            enumerator.addSplitsBack(Collections.singletonList(returnedSplit), subtaskId);
 
             // When first periodic discovery runs
             context.runPeriodicCallable(0);
@@ -273,7 +270,7 @@ class KinesisStreamsSourceEnumeratorTest {
             TestKinesisStreamProxy streamProxy = getTestStreamProxy();
             KinesisStreamsSourceEnumerator enumerator =
                     getSimpleEnumeratorWithNoState(context, streamProxy);
-            List<KinesisShardSplit> splits = ImmutableList.of(getTestSplit());
+            List<KinesisShardSplit> splits = Collections.singletonList(getTestSplit());
 
             // Given enumerator has no assigned splits
             // When we add splits back
@@ -316,7 +313,7 @@ class KinesisStreamsSourceEnumeratorTest {
             // When we add splits back
             KinesisShardSplit returnedSplit =
                     initialSplitAssignment.assignment().get(subtaskId).get(0);
-            enumerator.addSplitsBack(ImmutableList.of(returnedSplit), 1);
+            enumerator.addSplitsBack(Collections.singletonList(returnedSplit), 1);
 
             // Then splits are reassigned
             assertThat(context.getSplitsAssignmentSequence()).hasSizeGreaterThan(1);

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitterTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitterTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 import org.apache.flink.connector.kinesis.source.split.StartingPosition;
 import org.apache.flink.util.Collector;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kinesis.model.Record;
@@ -39,6 +37,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplitState;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -51,20 +51,27 @@ class KinesisStreamsRecordEmitterTest {
     void testEmitRecord() throws Exception {
         final Instant startTime = Instant.now();
         List<Record> inputRecords =
-                ImmutableList.of(
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
-                                .approximateArrivalTimestamp(startTime)
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
-                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
-                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
-                                .sequenceNumber("some-sequence-number")
-                                .build());
+                Stream.of(
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-1")))
+                                        .approximateArrivalTimestamp(startTime)
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-2")))
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-3")))
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                        .sequenceNumber("some-sequence-number")
+                                        .build())
+                        .collect(Collectors.toList());
         final StartingPosition expectedStartingPosition =
                 StartingPosition.continueFromSequenceNumber("some-sequence-number");
         final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
@@ -91,22 +98,29 @@ class KinesisStreamsRecordEmitterTest {
     void testEmitRecordBasedOnSequenceNumber() throws Exception {
         final Instant startTime = Instant.now();
         List<Record> inputRecords =
-                ImmutableList.of(
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
-                                .sequenceNumber("emit")
-                                .approximateArrivalTimestamp(startTime)
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
-                                .sequenceNumber("emit")
-                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
-                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
-                                .sequenceNumber("do-not-emit")
-                                .build());
+                Stream.of(
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-1")))
+                                        .sequenceNumber("emit")
+                                        .approximateArrivalTimestamp(startTime)
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-2")))
+                                        .sequenceNumber("emit")
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-3")))
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                        .sequenceNumber("do-not-emit")
+                                        .build())
+                        .collect(Collectors.toList());
         final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
         final KinesisShardSplitState splitState = getTestSplitState();
 
@@ -126,20 +140,27 @@ class KinesisStreamsRecordEmitterTest {
     void testEmitRecordWithMetadata() throws Exception {
         final Instant startTime = Instant.now();
         List<Record> inputRecords =
-                ImmutableList.of(
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-1")))
-                                .approximateArrivalTimestamp(startTime)
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-2")))
-                                .approximateArrivalTimestamp(startTime.plusSeconds(10))
-                                .build(),
-                        Record.builder()
-                                .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize("data-3")))
-                                .approximateArrivalTimestamp(startTime.plusSeconds(20))
-                                .sequenceNumber("some-sequence-number")
-                                .build());
+                Stream.of(
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-1")))
+                                        .approximateArrivalTimestamp(startTime)
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-2")))
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(10))
+                                        .build(),
+                                Record.builder()
+                                        .data(
+                                                SdkBytes.fromByteArray(
+                                                        STRING_SCHEMA.serialize("data-3")))
+                                        .approximateArrivalTimestamp(startTime.plusSeconds(20))
+                                        .sequenceNumber("some-sequence-number")
+                                        .build())
+                        .collect(Collectors.toList());
         final CapturingSourceOutput<String> output = new CapturingSourceOutput<>();
         final KinesisShardSplitState splitState = getTestSplitState();
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
@@ -25,14 +25,14 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.TestKinesisStreamProxy;
 import org.apache.flink.connector.kinesis.source.util.TestUtil;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kinesis.model.Record;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
@@ -65,7 +65,7 @@ class PollingKinesisShardSplitReaderTest {
         String shardId = generateShardId(1);
         testStreamProxy.addShards(shardId);
         splitReader.handleSplitsChanges(
-                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+                new SplitsAddition<>(Collections.singletonList(getTestSplit(shardId))));
 
         // When fetching records
         RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
@@ -86,16 +86,16 @@ class PollingKinesisShardSplitReaderTest {
         String shardId = generateShardId(1);
         testStreamProxy.addShards(shardId);
         List<Record> expectedRecords =
-                ImmutableList.of(
-                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
+                        .collect(Collectors.toList());
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(0)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(0)));
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(1)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(1)));
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(2)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(2)));
         splitReader.handleSplitsChanges(
-                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+                new SplitsAddition<>(Collections.singletonList(getTestSplit(shardId))));
 
         // When fetching records
         List<Record> records = new ArrayList<>();
@@ -117,16 +117,16 @@ class PollingKinesisShardSplitReaderTest {
         String shardId = generateShardId(1);
         testStreamProxy.addShards(shardId);
         List<Record> expectedRecords =
-                ImmutableList.of(
-                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
+                        .collect(Collectors.toList());
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(0)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(0)));
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(1)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(1)));
         testStreamProxy.addRecords(
-                TestUtil.STREAM_ARN, shardId, ImmutableList.of(expectedRecords.get(2)));
+                TestUtil.STREAM_ARN, shardId, Collections.singletonList(expectedRecords.get(2)));
         splitReader.handleSplitsChanges(
-                new SplitsAddition<>(ImmutableList.of(getTestSplit(shardId))));
+                new SplitsAddition<>(Collections.singletonList(getTestSplit(shardId))));
 
         // When records are fetched
         List<Record> fetchedRecords = new ArrayList<>();
@@ -150,7 +150,7 @@ class PollingKinesisShardSplitReaderTest {
         testStreamProxy.addShards(shardId);
         testStreamProxy.addRecords(TestUtil.STREAM_ARN, shardId, Collections.emptyList());
         KinesisShardSplit split = getTestSplit(shardId);
-        splitReader.handleSplitsChanges(new SplitsAddition<>(ImmutableList.of(split)));
+        splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
         testStreamProxy.setShouldCompleteNextShard(true);
 
         // When fetching records
@@ -172,11 +172,11 @@ class PollingKinesisShardSplitReaderTest {
         String shardId = generateShardId(1);
         testStreamProxy.addShards(shardId);
         List<Record> expectedRecords =
-                ImmutableList.of(
-                        getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"));
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
+                        .collect(Collectors.toList());
         testStreamProxy.addRecords(TestUtil.STREAM_ARN, shardId, expectedRecords);
         KinesisShardSplit split = getTestSplit(shardId);
-        splitReader.handleSplitsChanges(new SplitsAddition<>(ImmutableList.of(split)));
+        splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
 
         // When fetching records
         List<Record> fetchedRecords = new ArrayList<>();


### PR DESCRIPTION
## Purpose of the change

* [Text for ITCase MiniCluster ArchUnitTest has been changed for Flink 1.18](https://github.com/apache/flink/pull/22399). This PR removes the need for this exception violation in ITCase, by registering a local MiniCluster environment in the Firehose ITCase.
* Change in the github workflow is merely to show that this case passes against `1.18-SNAPSHOT`. It will be removed before merging.

## Verifying this change
This change is to fix breaking ArchUnitTests.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
