### PR TITLE
[hotfix][ci] Set AWS end-to-end tests to run on all push

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -41,11 +41,6 @@ on:
         required: false
         type: number
         default: 50
-      run_aws_end_to_end_test:
-        description: "Whether to run the AWS end to end tests, requiring AWS credentials."
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   compile_and_test:
@@ -120,7 +115,7 @@ jobs:
           mvn clean
 
       - name: Run AWS e2e tests
-        if: ${{ inputs.run_aws_end_to_end_test }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           set -o pipefail
 

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -55,8 +55,8 @@ jobs:
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
       MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
-      FLINK_AWS_USER: ${{ vars.FLINK_AWS_USER }}
-      FLINK_AWS_PASSWORD: ${{ vars.FLINK_AWS_PASSWORD }}
+      FLINK_AWS_USER: ${{ secrets.FLINK_AWS_USER }}
+      FLINK_AWS_PASSWORD: ${{ secrets.FLINK_AWS_PASSWORD }}
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,4 +31,3 @@ jobs:
       flink_version: ${{ matrix.flink }}
       flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: false
-      run_aws_end_to_end_test: true


### PR DESCRIPTION

## Purpose of the change

* Flink nightlies are failing because the snapshots are not available to download from S3. We will temporarily swap over the tests to use the released versions because we want to test if they work, before INFRA revokes these credentials.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
