### PR TITLE
[hotfix][ci] Add inherited secrets to workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,3 +31,4 @@ jobs:
       flink_version: ${{ matrix.flink }}
       flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: false
+    secrets: inherit

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,3 +31,4 @@ jobs:
       flink_version: ${{ matrix.flink }}
       flink_url: https://archive.apache.org/dist/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: true
+    secrets: inherit


### PR DESCRIPTION

## Purpose of the change
* Fix AWS end to end tests in CI build.

## Verifying this change
Verified that the secrets are pulled + AWS e2e tests run successfully in private repo.
https://github.com/hlteoh37/flink-connector-aws/actions/runs/6395003542

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
