### PR TITLE
[FLINK-33181] Allow a table definition can be used to read & write data to.

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/util/KinesisStreamsConnectorOptionsUtils.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/util/KinesisStreamsConnectorOptionsUtils.java
@@ -62,6 +62,8 @@ public class KinesisStreamsConnectorOptionsUtils {
     /** Key for accessing kinesisAsyncClient properties. */
     public static final String KINESIS_CLIENT_PROPERTIES_KEY = "sink.client.properties";
 
+    public static final String CONSUMER_PREFIX = "scan.";
+
     private final AsyncClientOptionsUtils asyncClientOptionsUtils;
     private final AsyncSinkConfigurationValidator asyncSinkconfigurationValidator;
     private final Map<String, String> resolvedOptions;
@@ -75,8 +77,8 @@ public class KinesisStreamsConnectorOptionsUtils {
     private static final String[] NON_VALIDATED_PREFIXES =
             new String[] {
                 AWSOptionUtils.AWS_PROPERTIES_PREFIX,
-                AsyncClientOptionsUtils.SINK_CLIENT_PREFIX,
-                KinesisProducerOptionsMapper.KINESIS_PRODUCER_PREFIX
+                KinesisProducerOptionsMapper.PRODUCER_PREFIX,
+                CONSUMER_PREFIX
             };
 
     public KinesisStreamsConnectorOptionsUtils(
@@ -121,6 +123,9 @@ public class KinesisStreamsConnectorOptionsUtils {
     public static class KinesisProducerOptionsMapper {
         private static final Logger LOG =
                 LoggerFactory.getLogger(KinesisProducerOptionsMapper.class);
+
+        public static final String PRODUCER_PREFIX = "sink.";
+
         /** prefix for deprecated producer options fallback keys. */
         public static final String KINESIS_PRODUCER_PREFIX = "sink.producer.";
 

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisConsumerOptionsUtil.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisConsumerOptionsUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.table;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.aws.table.util.AWSOptionUtils;
+import org.apache.flink.connector.kinesis.table.util.KinesisStreamsConnectorOptionsUtils;
 import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
 
 import java.util.Arrays;
@@ -60,7 +61,10 @@ public class KinesisConsumerOptionsUtil extends AWSOptionUtils {
 
     @Override
     public List<String> getNonValidatedPrefixes() {
-        return Arrays.asList(AWS_PROPERTIES_PREFIX, CONSUMER_PREFIX);
+        return Arrays.asList(
+                AWS_PROPERTIES_PREFIX,
+                CONSUMER_PREFIX,
+                KinesisStreamsConnectorOptionsUtils.KinesisProducerOptionsMapper.PRODUCER_PREFIX);
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Allow a table can be used as a source and sink when it's defined with both consumer & producer options. The ability is achieved by not verifying an option if it's *indicated* as consumer (by `scan.` prefix) or producer (by `sink.` prefix) option when creating a source/sink based on the table definition.

Example: following table definition can be used for both source & sink operators:

```
%flink.ssql(type=update)

DROP TABLE IF EXISTS `kds_input`;
CREATE TABLE `kds_input` (
`some_string` STRING,
`some_int` BIGINT,
`time` AS PROCTIME()
) WITH (
'connector' = 'kinesis',
'stream' = 'ExampleInputStream',
'aws.region' = 'us-east-1',
'scan.stream.initpos' = 'LATEST',
'sink.fail-on-error' = 'true',
'format' = 'csv'
);
```

## Verifying this change

This change added tests and can be verified as follows:
- *Added unit tests*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
