### PR TITLE
[FLINK-33279][Connector/Kinesis] Skip AWS e2e tests run if credentials not present

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -96,7 +96,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout_test }}
         run: |
           set -o pipefail
-          
+
           mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
             -Dflink.version=${{ inputs.flink_version }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
@@ -104,19 +104,19 @@ jobs:
       - name: Run e2e tests
         run: |
           set -o pipefail
-          
+
           cd flink-connector-aws-e2e-tests
-          
+
           mvn clean verify ${{ env.MVN_CONNECTION_OPTIONS }} \
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
             -Dflink.version=${{ inputs.flink_version }}  \
             -Prun-end-to-end-tests -DdistDir=${{ env.FLINK_CACHE_DIR }}/flink-${{ inputs.flink_version }} \
             | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
-          
+
           mvn clean
 
       - name: Run AWS e2e tests
-        if: env.HAS_AWS_CREDS
+        if: env.HAS_AWS_CREDS == 'true'
         run: |
           set -o pipefail
 


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Prevent AWS E2E tests running on PR.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

#### Manual verification:
Using actions with debug logging ([docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging))

##### Workflow setup:
```
##[debug]Evaluating: secrets.FLINK_AWS_USER
##[debug]Evaluating Index:
##[debug]..Evaluating secrets:
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'FLINK_AWS_USER'
##[debug]=> null
##[debug]Result: null
##[debug]Evaluating: secrets.FLINK_AWS_PASSWORD
##[debug]Evaluating Index:
##[debug]..Evaluating secrets:
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'FLINK_AWS_PASSWORD'
##[debug]=> null
##[debug]Result: null
##[debug]Evaluating: ((secrets.FLINK_AWS_USER != '') && (secrets.FLINK_AWS_PASSWORD != ''))
##[debug]Evaluating And:
##[debug]..Evaluating NotEqual:
##[debug]....Evaluating Index:
##[debug]......Evaluating secrets:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'FLINK_AWS_USER'
##[debug]....=> null
##[debug]....Evaluating String:
##[debug]....=> ''
##[debug]..=> false
##[debug]=> false
##[debug]Expanded: ((null != '') && (secrets['FLINK_AWS_PASSWORD'] != ''))
##[debug]Result: false
```

##### Before:
```
##[debug]Evaluating condition for step: 'Run AWS e2e tests'
##[debug]Evaluating: (success() && env.HAS_AWS_CREDS)
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'HAS_AWS_CREDS'
##[debug]..=> 'false'
##[debug]=> 'false'
##[debug]Expanded: (true && 'false')
##[debug]Result: 'false'
##[debug]Starting: Run AWS e2e tests
```
##### After:
```
##[debug]Evaluating condition for step: 'Run AWS e2e tests'
##[debug]Evaluating: (success() && (env.HAS_AWS_CREDS == 'true'))
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating Equal:
##[debug]....Evaluating Index:
##[debug]......Evaluating env:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'HAS_AWS_CREDS'
##[debug]....=> 'false'
##[debug]....Evaluating String:
##[debug]....=> 'true'
##[debug]..=> false
##[debug]=> false
##[debug]Expanded: (true && ('false' == 'true'))
##[debug]Result: false
```

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
