### PR TITLE
[FLINK-33260] Allow user to provide a list of recoverable exceptions

### DIFF
--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -681,6 +681,14 @@ Connector Options
       <td>The interval (in milliseconds) after which to consider a shard idle for purposes of watermark generation. A positive value will allow the watermark to progress even when some shards don't receive new records.</td>
     </tr>
     <tr>
+      <td><h5>shard.consumer.error.recoverable[0].exception</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>User-specified Exception to retry indefinitely. Example value: `java.net.UnknownHostException`. This configuration is a zero-based array. As such, the specified exceptions must start with index 0. Specified exceptions must be valid Throwables in classpath, or connector will fail to initialize and fail fast.</td>
+    </tr> 
+    <tr>
       <td><h5>scan.watermark.sync.interval</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -681,6 +681,14 @@ Connector Options
       <td>Long</td>
       <td>The interval (in milliseconds) after which to consider a shard idle for purposes of watermark generation. A positive value will allow the watermark to progress even when some shards don't receive new records.</td>
     </tr>
+   <tr>
+      <td><h5>shard.consumer.error.recoverable[0].exception</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>User-specified Exception to retry indefinitely. Example value: `java.net.UnknownHostException`. This configuration is a zero-based array. As such, the specified exceptions must start with index 0. Specified exceptions must be valid Throwables in classpath, or connector will fail to initialize and fail fast.</td>
+    </tr> 
     <tr>
       <td><h5>scan.watermark.sync.interval</h5></td>
       <td>optional</td>

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -191,6 +191,13 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final String REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT =
             "flink.stream.registerstreamconsumer.backoff.expconst";
 
+    /**
+     * The user-provided list of exceptions to recover from. These exceptions are retried
+     * indefinitely.
+     */
+    public static final String RECOVERABLE_EXCEPTIONS_PREFIX =
+            "flink.shard.consumer.error.recoverable";
+
     /** The maximum number of deregisterStream attempts if we get a recoverable exception. */
     public static final String DEREGISTER_STREAM_RETRIES =
             "flink.stream.deregisterstreamconsumer.maxretries";

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ExceptionConfig.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ExceptionConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.config;
+
+/**
+ * Helper class to hold information/behaviour about Exceptions. Used for configuring recoverable
+ * exceptions.
+ */
+public class ExceptionConfig {
+    private final Class<?> exceptionClass;
+
+    public ExceptionConfig(Class<?> exClass) {
+        this.exceptionClass = exClass;
+    }
+
+    public Class<?> getExceptionClass() {
+        return exceptionClass;
+    }
+}

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/RecoverableErrorsConfig.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/RecoverableErrorsConfig.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.config;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Hosts the recoverable exception configuration. Recoverable exceptions are retried indefinitely.
+ */
+public class RecoverableErrorsConfig {
+    public static final String INVALID_CONFIG_MESSAGE =
+            "Invalid config for recoverable consumer exceptions. "
+                    + "Valid config example: "
+                    + "`flink.shard.consumer.error.recoverable[0].exception=net.java.UnknownHostException`. "
+                    + "Your config array must use zero-based indexing as shown in the example.";
+
+    /**
+     * Parses the array of recoverable error configs.
+     *
+     * @param config connector configuration
+     * @return an Optional of RecoverableErrorsConfig
+     */
+    public static Optional<RecoverableErrorsConfig> createConfigFromPropertiesOrThrow(
+            final Properties config) {
+        List<ExceptionConfig> exConfs = new ArrayList<>();
+        int idx = 0;
+        String exceptionConfigKey =
+                String.format(
+                        "%s[%d].exception",
+                        ConsumerConfigConstants.RECOVERABLE_EXCEPTIONS_PREFIX, idx);
+        while (config.containsKey(exceptionConfigKey)) {
+            String exPath = config.getProperty(exceptionConfigKey);
+            try {
+                Class<?> aClass = Class.forName(exPath);
+                if (!Throwable.class.isAssignableFrom(aClass)) {
+                    throw new ClassCastException();
+                }
+                exConfs.add(new ExceptionConfig(aClass));
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException(
+                        "Provided recoverable exception class is not a Throwable: " + exPath);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(
+                        "Provided recoverable exception class could not be found: " + exPath);
+            }
+            exceptionConfigKey =
+                    String.format(
+                            "%s[%d].exception",
+                            ConsumerConfigConstants.RECOVERABLE_EXCEPTIONS_PREFIX, ++idx);
+        }
+        if (idx > 0) {
+            // We processed configs successfully
+            return Optional.of(new RecoverableErrorsConfig(exConfs));
+        }
+
+        // Check if user provided wrong config suffix, so they fail faster
+        for (Object key : config.keySet()) {
+            if (((String) key).startsWith(ConsumerConfigConstants.RECOVERABLE_EXCEPTIONS_PREFIX)) {
+                throw new IllegalArgumentException(RecoverableErrorsConfig.INVALID_CONFIG_MESSAGE);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private final List<ExceptionConfig> exceptionConfigs;
+
+    public RecoverableErrorsConfig(List<ExceptionConfig> exceptionConfigs) {
+        this.exceptionConfigs = exceptionConfigs;
+    }
+
+    public boolean hasNoConfig() {
+        return CollectionUtils.isEmpty(exceptionConfigs);
+    }
+
+    public List<ExceptionConfig> getExceptionConfigs() {
+        return exceptionConfigs;
+    }
+}

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -168,7 +168,8 @@ public class FanOutRecordPublisher implements RecordPublisher {
                         subscribedShard.getShard().getShardId(),
                         kinesisProxy,
                         configuration.getSubscribeToShardTimeout(),
-                        runningSupplier);
+                        runningSupplier,
+                        configuration.getRecoverableErrorsConfig());
         RecordPublisherRunResult result;
 
         try {

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.internals.publisher.fanout
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.config.RecoverableErrorsConfig;
 import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
 import org.apache.flink.util.Preconditions;
 
@@ -117,6 +118,9 @@ public class FanOutRecordPublisherConfiguration {
 
     /** Exponential backoff power constant for the describe stream consumer operation. */
     private final double describeStreamConsumerExpConstant;
+
+    /** Recoverable error configuration. These are retried indefinitely. */
+    private final RecoverableErrorsConfig recoverableErrorsConfig;
 
     /**
      * Creates a FanOutRecordPublisherConfiguration.
@@ -318,6 +322,8 @@ public class FanOutRecordPublisherConfiguration {
                         .orElse(
                                 ConsumerConfigConstants
                                         .DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT);
+
+        this.recoverableErrorsConfig = this.parseRecoverableErrorConfig(configProps);
     }
 
     // ------------------------------------------------------------------------
@@ -471,5 +477,13 @@ public class FanOutRecordPublisherConfiguration {
      */
     public Optional<String> getStreamConsumerArn(String stream) {
         return Optional.ofNullable(streamConsumerArns.get(stream));
+    }
+
+    public RecoverableErrorsConfig parseRecoverableErrorConfig(final Properties config) {
+        return RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config).orElse(null);
+    }
+
+    public RecoverableErrorsConfig getRecoverableErrorsConfig() {
+        return recoverableErrorsConfig;
     }
 }

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConsta
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.InitialPosition;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
 import org.apache.flink.streaming.connectors.kinesis.config.ProducerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.RecoverableErrorsConfig;
 
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 
@@ -322,6 +323,12 @@ public class KinesisConfigUtil {
                 config,
                 ConsumerConfigConstants.EFO_HTTP_CLIENT_MAX_CONCURRENCY,
                 "Invalid value given for EFO HTTP client max concurrency. Must be positive.");
+
+        validateRecoverableErrorConfig(config);
+    }
+
+    private static void validateRecoverableErrorConfig(Properties config) {
+        RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config);
     }
 
     /**

--- a/flink-connector-aws/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/config/RecoverableErrorsConfigTest.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/config/RecoverableErrorsConfigTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.config;
+
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link RecoverableErrorsConfig}. */
+public class RecoverableErrorsConfigTest {
+
+    @Test
+    public void testParseConfigFromProperties() {
+        Properties config = new Properties();
+        config.setProperty(
+                "flink.shard.consumer.error.recoverable[0].exception",
+                "java.net.UnknownHostException");
+        config.setProperty(
+                "flink.shard.consumer.error.recoverable[1].exception",
+                "java.lang.IllegalArgumentException");
+        Optional<RecoverableErrorsConfig> recoverableErrorsConfigOptional =
+                RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config);
+        assertTrue(recoverableErrorsConfigOptional.isPresent());
+        RecoverableErrorsConfig recoverableErrorsConfig = recoverableErrorsConfigOptional.get();
+        assertFalse(recoverableErrorsConfig.hasNoConfig());
+        assertThat(recoverableErrorsConfig.getExceptionConfigs().size()).isEqualTo(2);
+        assertThat(recoverableErrorsConfig.getExceptionConfigs().get(0).getExceptionClass())
+                .isEqualTo(java.net.UnknownHostException.class);
+        assertThat(recoverableErrorsConfig.getExceptionConfigs().get(1).getExceptionClass())
+                .isEqualTo(java.lang.IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testReturnEmptyWhenConfigNotFound() {
+        Optional<RecoverableErrorsConfig> recoverableErrorsConfigOptional =
+                RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(new Properties());
+        assertFalse(recoverableErrorsConfigOptional.isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsExceptionWhenProvidedClassIsNotThrowable() {
+        Properties config = new Properties();
+        config.setProperty(
+                "flink.shard.consumer.error.recoverable[0].exception", "java.util.Properties");
+        RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsExceptionWhenProvidedClassCanNotBeFound() {
+        Properties config = new Properties();
+        config.setProperty(
+                "flink.shard.consumer.error.recoverable[0].exception", "made.up.TestClass");
+        RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsExceptionWhenProvidedConfigSuffixIsNotValid() {
+        Properties config = new Properties();
+        config.setProperty(
+                "flink.shard.consumer.error.recoverable[0].exceptionnm", "java.lang.Exception");
+        RecoverableErrorsConfig.createConfigFromPropertiesOrThrow(config);
+    }
+}

--- a/flink-connector-aws/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -1021,4 +1021,28 @@ public class KinesisConfigUtilTest {
                 .containsKey("aws.kinesis.client.user-agent-prefix")
                 .hasSize(2);
     }
+
+    @Test
+    public void testInvalidCustomRecoverableErrorConfiguration() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(
+                "Provided recoverable exception class could not be found: com.NonExistentExceptionClass");
+
+        Properties testConfig = TestUtils.getStandardProperties();
+        testConfig.setProperty(
+                ConsumerConfigConstants.RECOVERABLE_EXCEPTIONS_PREFIX + "[0].exception",
+                "com.NonExistentExceptionClass");
+
+        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+    }
+
+    @Test
+    public void testValidCustomRecoverableErrorConfiguration() {
+        Properties testConfig = TestUtils.getStandardProperties();
+        testConfig.setProperty(
+                ConsumerConfigConstants.RECOVERABLE_EXCEPTIONS_PREFIX + "[0].exception",
+                "java.net.UnknownHostException");
+
+        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+    }
 }


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Allow users to configure a list of exceptions that will be retried indefinitely ("Recoverable Exceptions"). Applies to Fan Out consumers only, it can later be extended to other modes.

The config key is as follows:

```
flink.shard.consumer.error.recoverable[0].exception=java.net.UnknownHostException
flink.shard.consumer.error.recoverable[1].exception=java.net.SocketTimeoutException
```

This will later allow us to add (if needs be) pattern matching, for example:

```
flink.shard.consumer.error.recoverable[0].exception=java.net.SocketTimeoutException
flink.shard.consumer.error.recoverable[0].pattern="^Some Exception Message Pattern[0-9]+"
```

## Verifying this change

- ✅ Unit tests 
- ✅ Manual end to end testing: Tested only positive path. It is not easy to reproduce the negative path (i.e. make the Kinesis endpoint/connector internals throw the specified custom Exception)
 
## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
  - ✅ Java docs
  - ✅ markdowns docs
