### PR TITLE
[FLINK-33409][Connectors/AWS] Bump Guava in AWS Connectors to  to 32.1.3-jre

### DIFF
--- a/flink-connector-aws/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -27,6 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:aws-core:2.20.144
 - software.amazon.awssdk:aws-cbor-protocol:2.20.144
 - software.amazon.awssdk:auth:2.20.144
+- software.amazon.awssdk:arns:2.20.144
 - software.amazon.awssdk:apache-client:2.20.144
 - software.amazon.awssdk:annotations:2.20.144
 - org.apache.httpcomponents:httpcore:4.4.14
@@ -62,9 +63,9 @@ See bundled license files for details.
 
 - com.google.protobuf:protobuf-java:3.21.7
 
-This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
+This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).
 
-- org.reactivestreams:reactive-streams:1.0.3
+- org.reactivestreams:reactive-streams:1.0.4
 
 The Amazon Kinesis Producer Library includes http-parser, Copyright (c) Joyent, Inc. and other Node contributors, libc++, Copyright (c) 2003-2014, LLVM Project, and slf4j, Copyright (c) 2004-2013 QOS.ch, each of which is subject to the terms and conditions of the MIT license that states as follows:
 

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
@@ -40,7 +40,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty-buffer:4.1.86.Final
 - commons-logging:commons-logging:1.1.3
 
-This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
+This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).
 
-- org.reactivestreams:reactive-streams:1.0.3
+- org.reactivestreams:reactive-streams:1.0.4
 

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
@@ -44,6 +44,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 
 
-This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
+This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).
 
-- org.reactivestreams:reactive-streams:1.0.3
+- org.reactivestreams:reactive-streams:1.0.4

--- a/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
@@ -42,7 +42,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.15
 
-This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
+This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).
 
-- org.reactivestreams:reactive-streams:1.0.3
+- org.reactivestreams:reactive-streams:1.0.4
 

--- a/flink-connector-aws/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -12,5 +12,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-lang:commons-lang:2.6
 - commons-io:commons-io:2.11.0
 - commons-codec:commons-codec:1.15
-- com.google.guava:guava:32.0.0-jre
-- com.google.guava:failureaccess:1.0.1
+- com.google.guava:guava:32.1.3-jre

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ under the License.
         <flink.version>1.16.0</flink.version>
         <jackson-bom.version>2.14.3</jackson-bom.version>
         <glue.schema.registry.version>1.1.14</glue.schema.registry.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>32.1.3-jre</guava.version>
 
         <junit5.version>5.8.1</junit5.version>
         <assertj.version>3.21.0</assertj.version>


### PR DESCRIPTION
## Purpose of the change

Bump Guava in AWS Connectors to address CVE-2020-8908/CVE-2023-2976

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
