### PR TITLE
[FLINK-33413][Connectors/AWS] Bump Avro version in AWS Connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,12 @@ under the License.
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.1</version>
+                <version>1.11.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.21</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
## Purpose of the change

Bump Avro version in AWS Connectors to address CVE-2023-39410

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
