### PR TITLE
[FLINK-33506] Add support for jdk17 for AWS connectors

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -27,6 +27,11 @@ on:
         description: "Flink version to test against."
         required: true
         type: string
+      jdk_version:
+        description: "Jdk version to test against."
+        required: false
+        default: 8, 11
+        type: string
       cache_flink_binary:
         description: "Whether to cache the Flink binary. Should be false for SNAPSHOT URLs, true otherwise."
         required: true
@@ -47,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [ 8, 11 ]
+        jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,9 +26,11 @@ jobs:
     strategy:
       matrix:
         flink: [1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        java: [ '8, 11, 17, 21']
     uses: ./.github/workflows/common.yml
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}
       flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: false
     secrets: inherit
@@ -37,6 +39,8 @@ jobs:
     strategy:
       matrix:
         flink: [1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        java: [ '8, 11, 17, 21']
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         flink: [1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
-        java: [ '8, 11, 17, 21']
+        java: [ '8, 11, 17']
     uses: ./.github/workflows/common.yml
     with:
       flink_version: ${{ matrix.flink }}
@@ -39,8 +39,7 @@ jobs:
     strategy:
       matrix:
         flink: [1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
-        java: [ '8, 11, 17, 21']
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
-      jdk_version: ${{ matrix.java }}
+

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -27,8 +27,10 @@ jobs:
     strategy:
       matrix:
         flink: [1.18.1, 1.19.0]
+        java: [ '8, 11, 17, 21']
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}
       flink_url: https://archive.apache.org/dist/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
       cache_flink_binary: true
     secrets: inherit
@@ -37,6 +39,8 @@ jobs:
     strategy:
       matrix:
         flink: [1.18.1, 1.19.0]
+        java: [ '8, 11, 17, 21']
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         flink: [1.18.1, 1.19.0]
-        java: [ '8, 11, 17, 21']
+        java: [ '8, 11, 17']
     with:
       flink_version: ${{ matrix.flink }}
       jdk_version: ${{ matrix.java }}
@@ -39,8 +39,6 @@ jobs:
     strategy:
       matrix:
         flink: [1.18.1, 1.19.0]
-        java: [ '8, 11, 17, 21']
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
-      jdk_version: ${{ matrix.java }}

--- a/flink-connector-aws/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-aws/flink-connector-dynamodb/pom.xml
@@ -34,6 +34,9 @@ under the License.
 
     <packaging>jar</packaging>
 
+    <properties>
+        <flink.connector.module.config><!-- Required by DynamoDbSinkITCase --> --add-opens=java.base/java.util=ALL-UNNAMED</flink.connector.module.config>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/flink-connector-aws/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-aws/flink-connector-dynamodb/pom.xml
@@ -35,7 +35,10 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <flink.connector.module.config><!-- Required by DynamoDbSinkITCase --> --add-opens=java.base/java.util=ALL-UNNAMED</flink.connector.module.config>
+        <flink.connector.module.config><!--
+        Required by DynamoDbSinkITCase --> --add-opens=java.base/java.util=ALL-UNNAMED <!--
+        Required by DynamoDbSinkITCase --> --add-opens=java.base/java.lang=ALL-UNNAMED
+        </flink.connector.module.config>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/flink-connector-aws/flink-connector-kinesis/pom.xml
+++ b/flink-connector-aws/flink-connector-kinesis/pom.xml
@@ -35,7 +35,7 @@ under the License.
     <properties>
         <aws.kinesis-kpl.version>0.14.1</aws.kinesis-kpl.version>
         <aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <flink.connector.module.config><!--
         FlinkKinesisConsumerTest --> --add-opens=java.base/java.lang=ALL-UNNAMED <!--
         FlinkKinesisConsumerTest --> --add-opens=java.base/java.util=ALL-UNNAMED <!--
@@ -219,7 +219,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flink-connector-aws/flink-connector-kinesis/pom.xml
+++ b/flink-connector-aws/flink-connector-kinesis/pom.xml
@@ -36,6 +36,17 @@ under the License.
         <aws.kinesis-kpl.version>0.14.1</aws.kinesis-kpl.version>
         <aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <flink.connector.module.config><!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.lang=ALL-UNNAMED <!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.util=ALL-UNNAMED <!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.util.concurrent=ALL-UNNAMED <!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED <!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.lang.reflect=ALL-UNNAMED <!--
+        FlinkKinesisConsumerTest --> --add-opens=java.base/java.time=ALL-UNNAMED <!--
+        AWSUtilTest --> --add-opens=java.base/java.text=ALL-UNNAMED <!--
+        AWSUtilTest --> --add-opens=java.base/java.util.regex=ALL-UNNAMED <!--
+        AWSUtilTest --> --add-opens=java.base/java.net=ALL-UNNAMED <!--
+        KinesisConfigUtilTest --> --add-opens=java.base/java.util.stream=ALL-UNNAMED</flink.connector.module.config>
     </properties>
 
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,17 @@ under the License.
         <assertj.version>3.21.0</assertj.version>
         <archunit.version>0.22.0</archunit.version>
         <testcontainers.version>1.17.2</testcontainers.version>
-        <mockito.version>3.4.6</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <kotlin.version>1.7.10</kotlin.version>
 
         <flink.parent.artifactId>flink-connector-aws</flink.parent.artifactId>
+        <!-- This property should contain the add-opens/add-exports commands required for the tests
+         in the given connector's module to pass.
+         It MUST be a space-separated list not containing any newlines,
+         of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
+        <flink.connector.module.config/>
+        <flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${flink.connector.module.config}</flink.surefire.baseArgLine>
     </properties>
 
     <modules>
@@ -309,12 +315,12 @@ under the License.
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.10.14</version>
+                <version>1.14.4</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
-                <version>1.10.14</version>
+                <version>1.14.4</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
## Purpose of the change

The PR adds support for jdk17, it also adds java 17 to ci build matrix

## Verifying this change
maven

This change is already covered by existing tests + java 17 added to ci


## Significant changes

- [X] Dependencies have been added or upgraded