### PR TITLE
[hotfix][Connectors/AWS] Bumping default Flink version in source to 1.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ under the License.
         <aws.sdkv1.version>1.12.439</aws.sdkv1.version>
         <aws.sdkv2.version>2.20.144</aws.sdkv2.version>
         <netty.version>4.1.86.Final</netty.version>
-        <flink.version>1.16.0</flink.version>
+        <flink.version>1.17.0</flink.version>
         <jackson-bom.version>2.14.3</jackson-bom.version>
         <glue.schema.registry.version>1.1.14</glue.schema.registry.version>
         <guava.version>32.1.3-jre</guava.version>


### PR DESCRIPTION
## Purpose of the change

Bumping default Flink version in source to 1.17.0

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
