### PR TITLE
[FLINK-32964][Connectors/AWS] Ensure that new instance of DefaultCredentialsProvider is created for each client

### DIFF
--- a/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
+++ b/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
@@ -171,7 +171,9 @@ public class AWSGeneralUtil {
                         configPrefix);
 
             case AUTO:
-                return DefaultCredentialsProvider.create();
+                // Using builder instead of DefaultCredentialsProvider.create
+                // to get new instance for each call.
+                return DefaultCredentialsProvider.builder().build();
 
             default:
                 throw new IllegalArgumentException(

--- a/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
+++ b/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
@@ -901,6 +901,21 @@ class AWSGeneralUtilTest {
                         "Secret key must be specified either via environment variable (AWS_SECRET_ACCESS_KEY) or system property (aws.secretAccessKey)");
     }
 
+    @Test
+    void testNewInstanceOfDefaultCredentialsProviderCreatedForEachClient() {
+        Properties properties = new Properties();
+        properties.setProperty(AWS_CREDENTIALS_PROVIDER, "AUTO");
+
+        AwsCredentialsProvider credentialsProvider =
+                AWSGeneralUtil.getCredentialsProvider(properties);
+        AwsCredentialsProvider credentialsProvider2 =
+                AWSGeneralUtil.getCredentialsProvider(properties);
+
+        assertThat(credentialsProvider)
+                .withFailMessage("Must create new instance for each call")
+                .isNotSameAs(credentialsProvider2);
+    }
+
     private WebIdentityTokenFileCredentialsProvider.Builder
             mockWebIdentityTokenFileCredentialsProviderBuilder() {
         WebIdentityTokenFileCredentialsProvider.Builder builder =


### PR DESCRIPTION
## Purpose of the change

Explicitly use `.builder().build()` instead of `.create()` method while constructing DefaultCredentialsProvider.
This way new instance of credentials provider will be created for each AWS SDK client to prevent failures when one of the clients closes a singleton instance, resulting in failures in others.

## Verifying this change

- *Added unit test*

## Significant changes
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? not applicable
