### PR TITLE
[hotfix] Add IssueNavigationLink in Intellij VCS config

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="FLINK\-\d+" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="FLIP\-\d+" />
+          <option name="linkRegexp" value="https://cwiki.apache.org/confluence/display/FLINK/$0" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/apache/flink-connector-aws/pull/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/tools/releasing/shared" vcs="Git" />


### PR DESCRIPTION
## Purpose of the change

Add instructions for Intellij on how to interpret Jira ticket ids and FLIPs.
This change allows to easily navigate from git log view in IDE to these locations.

Similar to [Flink](https://github.com/apache/flink/blob/master/.idea/vcs.xml) and [Kafka connector](https://github.com/apache/flink-connector-kafka/blob/main/.idea/vcs.xml) repos

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? not applicable
