### PR TITLE
[FLINK-34044] Copy dynamic table options before mapping deprecated configs

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/util/KinesisStreamsConnectorOptionsUtils.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/util/KinesisStreamsConnectorOptionsUtils.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -148,13 +149,13 @@ public class KinesisStreamsConnectorOptionsUtils {
         public KinesisProducerOptionsMapper(
                 ReadableConfig tableOptions, Map<String, String> resolvedOptions) {
             this.tableOptions = tableOptions;
-            this.resolvedOptions = resolvedOptions;
+            this.resolvedOptions = new HashMap<>(resolvedOptions);
         }
 
         @VisibleForTesting
         public KinesisProducerOptionsMapper(Map<String, String> allOptions) {
             this.tableOptions = Configuration.fromMap(allOptions);
-            this.resolvedOptions = allOptions;
+            this.resolvedOptions = new HashMap<>(allOptions);
         }
 
         public Map<String, String> mapDeprecatedClientOptions() {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/util/KinesisProducerOptionsMapperTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/util/KinesisProducerOptionsMapperTest.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.connector.kinesis.table.util;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.aws.config.AWSConfigConstants;
 import org.apache.flink.connector.kinesis.table.util.KinesisStreamsConnectorOptionsUtils.KinesisProducerOptionsMapper;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -75,5 +77,26 @@ class KinesisProducerOptionsMapperTest {
                 producerOptionsMapper.mapDeprecatedClientOptions();
 
         Assertions.assertThat(actualMappedProperties).isEqualTo(expectedOptions);
+    }
+
+    @Test
+    void testProducerOptionsMapperDoesNotModifyOptionsInstance() {
+        Map<String, String> deprecatedOptions = new HashMap<>();
+        deprecatedOptions.put("sink.producer.kinesis-endpoint", "some-end-point.kinesis");
+        deprecatedOptions.put("sink.producer.kinesis-port", "1234");
+
+        Map<String, String> deprecatedOptionsImmutable =
+                Collections.unmodifiableMap(deprecatedOptions);
+        Assertions.assertThatNoException()
+                .isThrownBy(
+                        () ->
+                                new KinesisProducerOptionsMapper(deprecatedOptionsImmutable)
+                                        .mapDeprecatedClientOptions());
+        Assertions.assertThatNoException()
+                .isThrownBy(
+                        () ->
+                                new KinesisProducerOptionsMapper(
+                                                new Configuration(), deprecatedOptionsImmutable)
+                                        .mapDeprecatedClientOptions());
     }
 }


### PR DESCRIPTION

<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Perform Table Options mapping on copy of Table options instead of original instance, this fixes FLINK-34044 where [Table descriptor](https://github.com/apache/flink/blob/94b55d1ae61257f21c7bb511660e7497f269abc7/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java#L70) creation of Kinesis tables passes an unmodifiable instance of map. 

## Verifying this change

This change added tests and can be verified as follows:

- *Added unit tests*
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? NA
