### PR TITLE
[FLINK-35269] Log information about failed records as warnings instead of debug for Kinesis and Firehose sinks

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
@@ -220,9 +220,8 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
         }
 
         LOG.warn(
-                "KDF Sink failed to write and will retry {} entries to KDF first request was {}",
+                "KDF Sink failed to write and will retry {} entries to KDF",
                 requestEntries.size(),
-                requestEntries.get(0).toString(),
                 err);
         requestResult.accept(requestEntries);
     }
@@ -238,10 +237,8 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
             return;
         }
 
-        LOG.debug(
-                "KDF Sink failed to write and will retry {} entries to KDF first request was {}",
-                requestEntries.size(),
-                requestEntries.get(0).toString());
+        LOG.warn(
+                "KDF Sink failed to write and will retry {} entries to KDF", requestEntries.size());
         List<Record> failedRequestEntries = new ArrayList<>(response.failedPutCount());
         List<PutRecordBatchResponseEntry> records = response.requestResponses();
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
@@ -231,7 +231,7 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
             Throwable err,
             List<PutRecordsRequestEntry> requestEntries,
             Consumer<List<PutRecordsRequestEntry>> requestResult) {
-        LOG.debug(
+        LOG.warn(
                 "KDS Sink failed to write and will retry {} entries to KDS",
                 requestEntries.size(),
                 err);
@@ -251,7 +251,7 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
             PutRecordsResponse response,
             List<PutRecordsRequestEntry> requestEntries,
             Consumer<List<PutRecordsRequestEntry>> requestResult) {
-        LOG.debug(
+        LOG.warn(
                 "KDS Sink failed to write and will retry {} entries to KDS",
                 response.failedRecordCount());
         numRecordsOutErrorsCounter.inc(response.failedRecordCount());


### PR DESCRIPTION
## Purpose of the change

Change logging level for information about records failed to be written by Kinesis and Firehose sinks from `debug` to `warn`.
Similar configuration is already in use for DynamoDB sink.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? not applicable
