### PR TITLE
FLINK-35299: Add logic to respect initial position for new streams

### DIFF
--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -327,6 +327,17 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final String APPLY_STREAM_INITIAL_POSITION_FOR_NEW_STREAMS =
             "flink.stream.initpos-for-new-streams";
 
+    /**
+     * Property that can be used to ignore the restore state for a particular stream and instead use
+     * the initial position. This is useful to reset a specific stream to consume from TRIM_HORIZON
+     * or LATEST if needed. Values must be passed in a comma separated list.
+     *
+     * <p>If a stream is in this list, it will use initial position regardless of the value of the
+     * {@link #APPLY_STREAM_INITIAL_POSITION_FOR_NEW_STREAMS} property.
+     */
+    public static final String STREAMS_TO_APPLY_STREAM_INITIAL_POSITION_TO =
+            "flink.stream.initpos-streams";
+
     // ------------------------------------------------------------------------
     //  Default values for consumer configuration
     // ------------------------------------------------------------------------
@@ -335,6 +346,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
     /** False for now so that we preserve old behaviour. TODO switch to true in the next major */
     public static final boolean DEFAULT_APPLY_STREAM_INITIAL_POSITION_FOR_NEW_STREAMS = false;
+
+    public static final String DEFAULT_STREAMS_TO_APPLY_STREAM_INITIAL_POSITION_TO = "";
 
     public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT =
             "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -320,11 +320,21 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final String EFO_HTTP_CLIENT_READ_TIMEOUT_MILLIS =
             "flink.stream.efo.http-client.read-timeout";
 
+    /**
+     * Flag to configure whether {@link #STREAM_INITIAL_POSITION} should be considered for new
+     * streams, when the app is already consuming from other streams.
+     */
+    public static final String APPLY_STREAM_INITIAL_POSITION_FOR_NEW_STREAMS =
+            "flink.stream.initpos-for-new-streams";
+
     // ------------------------------------------------------------------------
     //  Default values for consumer configuration
     // ------------------------------------------------------------------------
 
     public static final String DEFAULT_STREAM_INITIAL_POSITION = InitialPosition.LATEST.toString();
+
+    /** False for now so that we preserve old behaviour. TODO switch to true in the next major */
+    public static final boolean DEFAULT_APPLY_STREAM_INITIAL_POSITION_FOR_NEW_STREAMS = false;
 
     public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT =
             "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

According to the javadoc, the `STREAM_INITIAL_POSITION` property defines where to start reading Kinesis streams from. However, in the current implementation this is only true if there isn't any restore state at all for any streams for that KinesisConsumer, otherwise the new stream is handled the same way a new shard for and existing stream is: start consuming from EARLIEST (same as TRIM_HORIZON initial position).

This MR changes that by making `FlinkKinesisConsumer` to use `STREAM_INITIAL_POSITION` config for new streams, which aligns with that is documented.

This behavior is disabled by default to not introduce a breaking change, but can be enabled by setting `flink.stream.initpos-for-new-streams` to true.

Additionally, a second config was created  - `flink.stream.initpos-streams` - to allow specific streams to be "reset" to whatever the STREAM_INITIAL_POSITION is defined. This is an important addition in this MR because users who notice this bug and want to enable the correct behaviour will want to reset the now recorded offset for the new stream.


## Verifying this change

**TODO**

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment*
- *Added unit tests*
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented) docs and JavaDocs where appropiate
