### PR TITLE
[FLINK-35705][Connector/Kinesis] Use region from stream ARN to create Kinesis client

### DIFF
--- a/flink-connector-aws-base/pom.xml
+++ b/flink-connector-aws-base/pom.xml
@@ -60,6 +60,11 @@ under the License.
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
 

--- a/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
+++ b/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -358,6 +359,17 @@ public class AWSGeneralUtil {
             final AttributeMap config, final ApacheHttpClient.Builder httpClientBuilder) {
         httpClientBuilder.connectionAcquisitionTimeout(CONNECTION_ACQUISITION_TIMEOUT);
         return httpClientBuilder.buildWithDefaults(config.merge(HTTP_CLIENT_DEFAULTS));
+    }
+
+    /**
+     * Extract region from resource ARN.
+     *
+     * @param arn resource ARN
+     * @return An {@link Optional} containing region name (e.g. us-east-1), or an empty {@link
+     *     Optional} if ARN does not contain region component
+     */
+    public static Optional<String> getRegionFromArn(final String arn) {
+        return Arn.fromString(arn).region();
     }
 
     /**

--- a/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
+++ b/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
@@ -787,6 +787,32 @@ class AWSGeneralUtilTest {
     }
 
     @Test
+    void testGetRegionFromValidArn() {
+        assertThat(
+                        AWSGeneralUtil.getRegionFromArn(
+                                "arn:aws:service:eu-west-2:123456789012:resource/test-resource"))
+                .contains("eu-west-2");
+        assertThat(
+                        AWSGeneralUtil.getRegionFromArn(
+                                "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream"))
+                .contains("us-east-1");
+        assertThat(
+                        AWSGeneralUtil.getRegionFromArn(
+                                "arn:aws:service:us-gov-west-1:123456789012:resource/test-resource"))
+                .contains("us-gov-west-1");
+
+        assertThat(AWSGeneralUtil.getRegionFromArn("arn:aws:s3:::resource/test-resource"))
+                .isEmpty();
+    }
+
+    @Test
+    void testGetRegionFromInvalidArn() {
+        assertThatThrownBy(() -> AWSGeneralUtil.getRegionFromArn("malformed-arn"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Malformed ARN");
+    }
+
+    @Test
     void testGetRegion() {
         Region region = AWSGeneralUtil.getRegion(TestUtil.properties(AWS_REGION, "eu-west-2"));
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.aws.config.AWSConfigConstants;
 import org.apache.flink.connector.aws.util.AWSClientUtil;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -185,8 +186,15 @@ public class KinesisStreamsSource<T>
                 AWSGeneralUtil.createSyncHttpClient(
                         AttributeMap.builder().build(), ApacheHttpClient.builder());
 
+        String region =
+                AWSGeneralUtil.getRegionFromArn(streamArn)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Unable to determine region from stream arn"));
         Properties kinesisClientProperties = new Properties();
         consumerConfig.addAllToProperties(kinesisClientProperties);
+        kinesisClientProperties.put(AWSConfigConstants.AWS_REGION, region);
 
         AWSGeneralUtil.validateAwsCredentials(kinesisClientProperties);
         KinesisClient kinesisClient =

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/examples/SourceFromKinesis.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/examples/SourceFromKinesis.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.aws.config.AWSConfigConstants;
 import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
 import org.apache.flink.connector.kinesis.source.enumerator.assigner.ShardAssignerFactory;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -39,11 +38,9 @@ public class SourceFromKinesis {
         env.setParallelism(2);
 
         Configuration sourceConfig = new Configuration();
-        sourceConfig.setString(AWSConfigConstants.AWS_REGION, "us-east-1");
         KinesisStreamsSource<String> kdsSource =
                 KinesisStreamsSource.<String>builder()
-                        .setStreamArn(
-                                "arn:aws:kinesis:us-east-1:290038087681:stream/LoadTestBeta_Input_35")
+                        .setStreamArn("arn:aws:kinesis:us-east-1:123456789012:stream/test-stream")
                         .setSourceConfig(sourceConfig)
                         .setDeserializationSchema(new SimpleStringSchema())
                         .setKinesisShardAssigner(ShardAssignerFactory.uniformShardAssigner())

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
@@ -26,6 +26,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:auth:2.20.144
 - software.amazon.awssdk:apache-client:2.20.144
 - software.amazon.awssdk:annotations:2.20.144
+- software.amazon.awssdk:arns:2.20.144
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
 - io.netty:netty-transport:4.1.86.Final

--- a/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
@@ -25,6 +25,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:aws-json-protocol:2.20.144
 - software.amazon.awssdk:aws-core:2.20.144
 - software.amazon.awssdk:auth:2.20.144
+- software.amazon.awssdk:arns:2.20.144
 - software.amazon.awssdk:apache-client:2.20.144
 - software.amazon.awssdk:annotations:2.20.144
 - org.apache.httpcomponents:httpcore:4.4.14


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Use region provided as part of stream ARN to create Kinesis SDK client.

## Verifying this change

Unit tests.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? not applicable
