### PR TITLE
[FLINK-32218][Connector/Kinesis] Add support for parent-child shard ordering to Kinesis streams source

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -88,12 +88,14 @@ public class KinesisStreamsSource<T>
     private final Configuration sourceConfig;
     private final KinesisDeserializationSchema<T> deserializationSchema;
     private final KinesisShardAssigner kinesisShardAssigner;
+    private final boolean preserveShardOrder;
 
     KinesisStreamsSource(
             String streamArn,
             Configuration sourceConfig,
             KinesisDeserializationSchema<T> deserializationSchema,
-            KinesisShardAssigner kinesisShardAssigner) {
+            KinesisShardAssigner kinesisShardAssigner,
+            boolean preserveShardOrder) {
         Preconditions.checkNotNull(streamArn);
         Preconditions.checkArgument(!streamArn.isEmpty(), "stream ARN cannot be empty string");
         Preconditions.checkNotNull(sourceConfig);
@@ -103,6 +105,7 @@ public class KinesisStreamsSource<T>
         this.sourceConfig = sourceConfig;
         this.deserializationSchema = deserializationSchema;
         this.kinesisShardAssigner = kinesisShardAssigner;
+        this.preserveShardOrder = preserveShardOrder;
     }
 
     /**
@@ -167,7 +170,8 @@ public class KinesisStreamsSource<T>
                 sourceConfig,
                 createKinesisStreamProxy(sourceConfig),
                 kinesisShardAssigner,
-                checkpoint);
+                checkpoint,
+                preserveShardOrder);
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceBuilder.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceBuilder.java
@@ -55,6 +55,7 @@ public class KinesisStreamsSourceBuilder<T> {
     private Configuration sourceConfig;
     private KinesisDeserializationSchema<T> deserializationSchema;
     private KinesisShardAssigner kinesisShardAssigner = ShardAssignerFactory.uniformShardAssigner();
+    private boolean preserveShardOrder = true;
 
     public KinesisStreamsSourceBuilder<T> setStreamArn(String streamArn) {
         this.streamArn = streamArn;
@@ -84,8 +85,17 @@ public class KinesisStreamsSourceBuilder<T> {
         return this;
     }
 
+    public KinesisStreamsSourceBuilder<T> setPreserveShardOrder(boolean preserveShardOrder) {
+        this.preserveShardOrder = preserveShardOrder;
+        return this;
+    }
+
     public KinesisStreamsSource<T> build() {
         return new KinesisStreamsSource<>(
-                streamArn, sourceConfig, deserializationSchema, kinesisShardAssigner);
+                streamArn,
+                sourceConfig,
+                deserializationSchema,
+                kinesisShardAssigner,
+                preserveShardOrder);
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisShardSplitWithAssignmentStatus.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisShardSplitWithAssignmentStatus.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import java.util.Objects;
+
+/** Kinesis shard split with assignment status. */
+@Internal
+public class KinesisShardSplitWithAssignmentStatus {
+    private final KinesisShardSplit kinesisShardSplit;
+    private final SplitAssignmentStatus splitAssignmentStatus;
+
+    public KinesisShardSplitWithAssignmentStatus(
+            KinesisShardSplit kinesisShardSplit, SplitAssignmentStatus splitAssignmentStatus) {
+        this.kinesisShardSplit = kinesisShardSplit;
+        this.splitAssignmentStatus = splitAssignmentStatus;
+    }
+
+    public KinesisShardSplit split() {
+        return kinesisShardSplit;
+    }
+
+    public SplitAssignmentStatus assignmentStatus() {
+        return splitAssignmentStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KinesisShardSplitWithAssignmentStatus that = (KinesisShardSplitWithAssignmentStatus) o;
+        return Objects.equals(kinesisShardSplit, that.kinesisShardSplit)
+                && Objects.equals(splitAssignmentStatus, that.splitAssignmentStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kinesisShardSplit, splitAssignmentStatus);
+    }
+
+    @Override
+    public String toString() {
+        return "KinesisShardSplitWithAssignmentStatus{"
+                + "kinesisShardSplit="
+                + kinesisShardSplit
+                + ", splitAssignmentStatus="
+                + splitAssignmentStatus
+                + '}';
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateV0.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateV0.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kinesis.source.enumerator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 
 import javax.annotation.Nullable;
 
@@ -27,15 +28,18 @@ import java.util.List;
 /**
  * State for the {@link KinesisStreamsSourceEnumerator}. This class is stored in state, so any
  * changes need to be backwards compatible
+ *
+ * @deprecated This class is preserved to test state compatibility only.
  */
 @Internal
-public class KinesisStreamsSourceEnumeratorState {
-    private final List<KinesisShardSplitWithAssignmentStatus> knownSplits;
+@Deprecated
+public class KinesisStreamsSourceEnumeratorStateV0 {
+    private final List<KinesisShardSplit> unassignedSplits;
     @Nullable private final String lastSeenShardId;
 
-    public KinesisStreamsSourceEnumeratorState(
-            List<KinesisShardSplitWithAssignmentStatus> knownSplits, String lastSeenShardId) {
-        this.knownSplits = knownSplits;
+    public KinesisStreamsSourceEnumeratorStateV0(
+            List<KinesisShardSplit> unassignedSplits, String lastSeenShardId) {
+        this.unassignedSplits = unassignedSplits;
         this.lastSeenShardId = lastSeenShardId;
     }
 
@@ -43,7 +47,7 @@ public class KinesisStreamsSourceEnumeratorState {
         return lastSeenShardId;
     }
 
-    public List<KinesisShardSplitWithAssignmentStatus> getKnownSplits() {
-        return knownSplits;
+    public List<KinesisShardSplit> getKnownSplits() {
+        return unassignedSplits;
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/SplitAssignmentStatus.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/SplitAssignmentStatus.java
@@ -20,30 +20,31 @@ package org.apache.flink.connector.kinesis.source.enumerator;
 
 import org.apache.flink.annotation.Internal;
 
-import javax.annotation.Nullable;
-
-import java.util.List;
-
 /**
- * State for the {@link KinesisStreamsSourceEnumerator}. This class is stored in state, so any
- * changes need to be backwards compatible
+ * Assignment status of {@link org.apache.flink.connector.kinesis.source.split.KinesisShardSplit}.
  */
 @Internal
-public class KinesisStreamsSourceEnumeratorState {
-    private final List<KinesisShardSplitWithAssignmentStatus> knownSplits;
-    @Nullable private final String lastSeenShardId;
+public enum SplitAssignmentStatus {
+    ASSIGNED(0),
+    UNASSIGNED(1);
 
-    public KinesisStreamsSourceEnumeratorState(
-            List<KinesisShardSplitWithAssignmentStatus> knownSplits, String lastSeenShardId) {
-        this.knownSplits = knownSplits;
-        this.lastSeenShardId = lastSeenShardId;
+    private final int statusCode;
+
+    SplitAssignmentStatus(int statusCode) {
+        this.statusCode = statusCode;
     }
 
-    public String getLastSeenShardId() {
-        return lastSeenShardId;
+    public int getStatusCode() {
+        return statusCode;
     }
 
-    public List<KinesisShardSplitWithAssignmentStatus> getKnownSplits() {
-        return knownSplits;
+    public static SplitAssignmentStatus fromStatusCode(int statusCode) {
+        for (SplitAssignmentStatus status : SplitAssignmentStatus.values()) {
+            if (status.getStatusCode() == statusCode) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown status code: " + statusCode);
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/tracker/SplitTracker.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/enumerator/tracker/SplitTracker.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator.tracker;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardSplitWithAssignmentStatus;
+import org.apache.flink.connector.kinesis.source.enumerator.SplitAssignmentStatus;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/** This class is used to track shard hierarchy. */
+@Internal
+public class SplitTracker {
+    /**
+     * Flag controlling if tracker should wait before all parent splits will be completed before
+     * assigning split to readers.
+     */
+    private final boolean preserveShardOrdering;
+
+    /** Map of all discovered splits that have not been completed. Split id is used as a key. */
+    private final Map<String, KinesisShardSplit> knownSplits = new ConcurrentHashMap<>();
+
+    /** Set of ids for currently assigned splits. */
+    private final Set<String> assignedSplits = new HashSet<>();
+
+    public SplitTracker(boolean preserveShardOrdering) {
+        this(preserveShardOrdering, Collections.emptyList());
+    }
+
+    public SplitTracker(
+            boolean preserveShardOrdering,
+            List<KinesisShardSplitWithAssignmentStatus> initialState) {
+        this.preserveShardOrdering = preserveShardOrdering;
+
+        initialState.forEach(
+                splitWithStatus -> {
+                    knownSplits.put(splitWithStatus.split().splitId(), splitWithStatus.split());
+                    if (SplitAssignmentStatus.ASSIGNED.equals(splitWithStatus.assignmentStatus())) {
+                        assignedSplits.add(splitWithStatus.split().splitId());
+                    }
+                });
+    }
+
+    /**
+     * Add newly discovered splits to tracker.
+     *
+     * @param splitsToAdd collection of splits to add to tracking
+     */
+    public void addSplits(Collection<KinesisShardSplit> splitsToAdd) {
+        splitsToAdd.forEach(split -> knownSplits.put(split.splitId(), split));
+    }
+
+    /**
+     * Mark splits as assigned. Assigned splits will no longer be returned as pending splits.
+     *
+     * @param splitsToAssign collection of splits to mark as assigned
+     */
+    public void markAsAssigned(Collection<KinesisShardSplit> splitsToAssign) {
+        splitsToAssign.forEach(split -> assignedSplits.add(split.splitId()));
+    }
+
+    /**
+     * Mark splits with specified ids as finished.
+     *
+     * @param finishedSplitIds collection of split ids to mark as finished
+     */
+    public void markAsFinished(Collection<String> finishedSplitIds) {
+        finishedSplitIds.forEach(
+                splitId -> {
+                    assignedSplits.remove(splitId);
+                    knownSplits.remove(splitId);
+                });
+    }
+
+    /**
+     * Checks if split with specified id had been assigned to the reader.
+     *
+     * @param splitId split id
+     * @return {@code true} if split had been assigned, otherwise {@code false}
+     */
+    public boolean isAssigned(String splitId) {
+        return assignedSplits.contains(splitId);
+    }
+
+    /**
+     * Returns list of splits that can be assigned to readers. Does not include splits that are
+     * already assigned or finished. If shard ordering is enabled, only splits with finished parents
+     * will be returned.
+     *
+     * @return list of splits that can be assigned to readers.
+     */
+    public List<KinesisShardSplit> splitsAvailableForAssignment() {
+        return knownSplits.values().stream()
+                .filter(
+                        split -> {
+                            boolean splitIsNotAssigned = !isAssigned(split.splitId());
+                            if (preserveShardOrdering) {
+                                // Check if all parent splits were finished
+                                return splitIsNotAssigned
+                                        && verifyAllParentSplitsAreFinished(split);
+                            } else {
+                                return splitIsNotAssigned;
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Prepare split graph representation to store in state. Method returns only splits that are
+     * currently assigned to readers or unassigned. Finished splits are not included in the result.
+     *
+     * @param checkpointId id of the checkpoint
+     * @return list of splits with current assignment status
+     */
+    public List<KinesisShardSplitWithAssignmentStatus> snapshotState(long checkpointId) {
+        return knownSplits.values().stream()
+                .map(
+                        split -> {
+                            SplitAssignmentStatus assignmentStatus =
+                                    isAssigned(split.splitId())
+                                            ? SplitAssignmentStatus.ASSIGNED
+                                            : SplitAssignmentStatus.UNASSIGNED;
+                            return new KinesisShardSplitWithAssignmentStatus(
+                                    split, assignmentStatus);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private boolean verifyAllParentSplitsAreFinished(KinesisShardSplit split) {
+        boolean allParentsFinished = true;
+        for (String parentSplitId : split.getParentShardIds()) {
+            allParentsFinished = allParentsFinished && isFinished(parentSplitId);
+        }
+
+        return allParentsFinished;
+    }
+
+    private boolean isFinished(String splitId) {
+        return !knownSplits.containsKey(splitId);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/event/SplitsFinishedEvent.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/event/SplitsFinishedEvent.java
@@ -16,34 +16,33 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.kinesis.source.enumerator;
+package org.apache.flink.connector.kinesis.source.event;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceEvent;
 
-import javax.annotation.Nullable;
+import java.util.Set;
 
-import java.util.List;
-
-/**
- * State for the {@link KinesisStreamsSourceEnumerator}. This class is stored in state, so any
- * changes need to be backwards compatible
- */
+/** Source event used by source reader to communicate that splits are finished to enumerator. */
 @Internal
-public class KinesisStreamsSourceEnumeratorState {
-    private final List<KinesisShardSplitWithAssignmentStatus> knownSplits;
-    @Nullable private final String lastSeenShardId;
+public class SplitsFinishedEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
 
-    public KinesisStreamsSourceEnumeratorState(
-            List<KinesisShardSplitWithAssignmentStatus> knownSplits, String lastSeenShardId) {
-        this.knownSplits = knownSplits;
-        this.lastSeenShardId = lastSeenShardId;
+    private final Set<String> finishedSplitIds;
+
+    public SplitsFinishedEvent(Set<String> finishedSplitIds) {
+        this.finishedSplitIds = finishedSplitIds;
     }
 
-    public String getLastSeenShardId() {
-        return lastSeenShardId;
+    public Set<String> getFinishedSplitIds() {
+        return finishedSplitIds;
     }
 
-    public List<KinesisShardSplitWithAssignmentStatus> getKnownSplits() {
-        return knownSplits;
+    @Override
+    public String toString() {
+        return "SplitsFinishedEvent{"
+                + "finishedSplitIds=["
+                + String.join(",", finishedSplitIds)
+                + "]}";
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/ListShardsStartingPosition.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/ListShardsStartingPosition.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.proxy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import software.amazon.awssdk.services.kinesis.model.ShardFilter;
+import software.amazon.awssdk.services.kinesis.model.ShardFilterType;
+
+import java.time.Instant;
+
+/** Starting position to perform list shard request. */
+@Internal
+public class ListShardsStartingPosition {
+    private final ShardFilter shardFilter;
+
+    private ListShardsStartingPosition(ShardFilter shardFilter) {
+        this.shardFilter = shardFilter;
+    }
+
+    /** Returns shard filter used to perform listShard request. */
+    public ShardFilter getShardFilter() {
+        return shardFilter;
+    }
+
+    /** Used to get shards that were active at or after specified timestamp. */
+    public static ListShardsStartingPosition fromTimestamp(Instant timestamp) {
+        Preconditions.checkNotNull(timestamp, "timestamp cannot be null");
+
+        return new ListShardsStartingPosition(
+                ShardFilter.builder()
+                        .type(ShardFilterType.FROM_TIMESTAMP)
+                        .timestamp(timestamp)
+                        .build());
+    }
+
+    /** Used to get shards after specified shard id. */
+    public static ListShardsStartingPosition fromShardId(String exclusiveStartShardId) {
+        Preconditions.checkNotNull(exclusiveStartShardId, "exclusiveStartShardId cannot be null");
+
+        return new ListShardsStartingPosition(
+                ShardFilter.builder()
+                        .type(ShardFilterType.AFTER_SHARD_ID)
+                        .shardId(exclusiveStartShardId)
+                        .build());
+    }
+
+    /** Used to get all shards starting from TRIM_HORIZON. */
+    public static ListShardsStartingPosition fromStart() {
+        return new ListShardsStartingPosition(
+                ShardFilter.builder().type(ShardFilterType.FROM_TRIM_HORIZON).build());
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/StreamProxy.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/StreamProxy.java
@@ -23,8 +23,7 @@ import org.apache.flink.connector.kinesis.source.split.StartingPosition;
 
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.Shard;
-
-import javax.annotation.Nullable;
+import software.amazon.awssdk.services.kinesis.model.StreamDescriptionSummary;
 
 import java.io.Closeable;
 import java.util.List;
@@ -32,16 +31,23 @@ import java.util.List;
 /** Interface for a StreamProxy to interact with Streams service in a given region. */
 @Internal
 public interface StreamProxy extends Closeable {
+    /**
+     * Obtains stream metadata.
+     *
+     * @param streamArn the ARN of the stream
+     * @return stream information.
+     */
+    StreamDescriptionSummary getStreamDescriptionSummary(String streamArn);
 
     /**
      * Obtains the shards associated with a given stream.
      *
      * @param streamArn the ARN of the stream
-     * @param lastSeenShardId the last seen shard Id. Used for reducing the number of results
-     *     returned.
+     * @param startingPosition starting position for shard discovery request. Used to skip already
+     *     discovered/not used shards
      * @return shard list
      */
-    List<Shard> listShards(String streamArn, @Nullable String lastSeenShardId);
+    List<Shard> listShards(String streamArn, ListShardsStartingPosition startingPosition);
 
     /**
      * Retrieves records from the stream.

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplit.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplit.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumerator;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -39,15 +41,22 @@ public final class KinesisShardSplit implements SourceSplit {
     private final String streamArn;
     private final String shardId;
     private final StartingPosition startingPosition;
+    private final Set<String> parentShardIds;
 
-    public KinesisShardSplit(String streamArn, String shardId, StartingPosition startingPosition) {
+    public KinesisShardSplit(
+            String streamArn,
+            String shardId,
+            StartingPosition startingPosition,
+            Set<String> parentShardIds) {
         checkNotNull(streamArn, "streamArn cannot be null");
         checkNotNull(shardId, "shardId cannot be null");
         checkNotNull(startingPosition, "startingPosition cannot be null");
+        checkNotNull(parentShardIds, "parentShardIds cannot be null");
 
         this.streamArn = streamArn;
         this.shardId = shardId;
         this.startingPosition = startingPosition;
+        this.parentShardIds = new HashSet<>(parentShardIds);
     }
 
     @Override
@@ -67,6 +76,10 @@ public final class KinesisShardSplit implements SourceSplit {
         return startingPosition;
     }
 
+    public Set<String> getParentShardIds() {
+        return parentShardIds;
+    }
+
     @Override
     public String toString() {
         return "KinesisShardSplit{"
@@ -78,6 +91,9 @@ public final class KinesisShardSplit implements SourceSplit {
                 + '\''
                 + ", startingPosition="
                 + startingPosition
+                + ", parentShardIds=["
+                + String.join(",", parentShardIds)
+                + ']'
                 + '}';
     }
 
@@ -92,11 +108,12 @@ public final class KinesisShardSplit implements SourceSplit {
         KinesisShardSplit that = (KinesisShardSplit) o;
         return Objects.equals(streamArn, that.streamArn)
                 && Objects.equals(shardId, that.shardId)
-                && Objects.equals(startingPosition, that.startingPosition);
+                && Objects.equals(startingPosition, that.startingPosition)
+                && Objects.equals(parentShardIds, that.parentShardIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(streamArn, shardId, startingPosition);
+        return Objects.hash(streamArn, shardId, startingPosition, parentShardIds);
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitState.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitState.java
@@ -39,7 +39,8 @@ public class KinesisShardSplitState {
         return new KinesisShardSplit(
                 kinesisShardSplit.getStreamArn(),
                 kinesisShardSplit.getShardId(),
-                nextStartingPosition);
+                nextStartingPosition,
+                kinesisShardSplit.getParentShardIds());
     }
 
     public String getSplitId() {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/KinesisStreamsSourceEnumeratorStateSerializerTest.java
@@ -20,18 +20,19 @@ package org.apache.flink.connector.kinesis.source.enumerator;
 
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
+import org.apache.flink.connector.kinesis.source.util.TestUtil;
 import org.apache.flink.core.io.VersionMismatchException;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.copyOf;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
-import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
@@ -39,15 +40,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
 
     @Test
     void testSerializeAndDeserializeEverythingSpecified() throws Exception {
-        Set<String> completedShardIds =
-                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
-                        .collect(Collectors.toSet());
-        Set<KinesisShardSplit> unassignedSplits =
-                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
-                        .collect(Collectors.toSet());
-        String lastSeenShardId = "shardId-000000000002";
+        List<KinesisShardSplitWithAssignmentStatus> splitsToStore =
+                getSplits(IntStream.rangeClosed(0, 3), IntStream.rangeClosed(4, 10));
+        String lastSeenShardId = generateShardId(10);
         KinesisStreamsSourceEnumeratorState initialState =
-                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+                new KinesisStreamsSourceEnumeratorState(splitsToStore, lastSeenShardId);
 
         KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
         KinesisStreamsSourceEnumeratorStateSerializer serializer =
@@ -62,15 +59,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
 
     @Test
     void testDeserializeWithWrongVersionStateSerializer() throws Exception {
-        Set<String> completedShardIds =
-                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
-                        .collect(Collectors.toSet());
-        Set<KinesisShardSplit> unassignedSplits =
-                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
-                        .collect(Collectors.toSet());
-        String lastSeenShardId = "shardId-000000000002";
+        List<KinesisShardSplitWithAssignmentStatus> splitsToStore =
+                getSplits(IntStream.rangeClosed(0, 3), IntStream.rangeClosed(4, 10));
+        String lastSeenShardId = generateShardId(10);
         KinesisStreamsSourceEnumeratorState initialState =
-                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+                new KinesisStreamsSourceEnumeratorState(splitsToStore, lastSeenShardId);
 
         KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
         KinesisStreamsSourceEnumeratorStateSerializer serializer =
@@ -93,15 +86,11 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
 
     @Test
     void testDeserializeWithWrongVersionSplitSerializer() throws Exception {
-        Set<String> completedShardIds =
-                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
-                        .collect(Collectors.toSet());
-        Set<KinesisShardSplit> unassignedSplits =
-                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
-                        .collect(Collectors.toSet());
-        String lastSeenShardId = "shardId-000000000002";
+        List<KinesisShardSplitWithAssignmentStatus> splitsToStore =
+                getSplits(IntStream.rangeClosed(0, 3), IntStream.rangeClosed(4, 10));
+        String lastSeenShardId = generateShardId(10);
         KinesisStreamsSourceEnumeratorState initialState =
-                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+                new KinesisStreamsSourceEnumeratorState(splitsToStore, lastSeenShardId);
 
         KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
         KinesisStreamsSourceEnumeratorStateSerializer serializer =
@@ -116,21 +105,17 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
                 .isThrownBy(() -> serializer.deserialize(serializer.getVersion(), serialized))
                 .withMessageContaining(
                         "Trying to deserialize KinesisShardSplit serialized with unsupported version")
-                .withMessageContaining(String.valueOf(serializer.getVersion()))
-                .withMessageContaining(String.valueOf(wrongVersionStateSerializer.getVersion()));
+                .withMessageContaining(String.valueOf(splitSerializer.getVersion()))
+                .withMessageContaining(String.valueOf(wrongVersionSplitSerializer.getVersion()));
     }
 
     @Test
     void testSerializeWithTrailingBytes() throws Exception {
-        Set<String> completedShardIds =
-                Stream.of("shardId-000000000001", "shardId-000000000002", "shardId-000000000003")
-                        .collect(Collectors.toSet());
-        Set<KinesisShardSplit> unassignedSplits =
-                Stream.of(getTestSplit(generateShardId(1)), getTestSplit(generateShardId(2)))
-                        .collect(Collectors.toSet());
-        String lastSeenShardId = "shardId-000000000002";
+        List<KinesisShardSplitWithAssignmentStatus> splitsToStore =
+                getSplits(IntStream.rangeClosed(0, 3), IntStream.rangeClosed(4, 10));
+        String lastSeenShardId = generateShardId(10);
         KinesisStreamsSourceEnumeratorState initialState =
-                new KinesisStreamsSourceEnumeratorState(unassignedSplits, lastSeenShardId);
+                new KinesisStreamsSourceEnumeratorState(splitsToStore, lastSeenShardId);
 
         KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
         KinesisStreamsSourceEnumeratorStateSerializer serializer =
@@ -143,6 +128,57 @@ class KinesisStreamsSourceEnumeratorStateSerializerTest {
                 .isThrownBy(
                         () -> serializer.deserialize(serializer.getVersion(), extraBytesSerialized))
                 .withMessageContaining("Unexpected trailing bytes when deserializing.");
+    }
+
+    @Test
+    void testDeserializeCompatibilityWithV0() throws Exception {
+        // V0 state only contains UNASSIGNED splits
+        List<KinesisShardSplitWithAssignmentStatus> splitsWithStatusToStore =
+                getSplits(IntStream.empty(), IntStream.rangeClosed(10, 15));
+        String lastSeenShardId =
+                splitsWithStatusToStore.get(splitsWithStatusToStore.size() - 1).split().splitId();
+        KinesisStreamsSourceEnumeratorState expectedState =
+                new KinesisStreamsSourceEnumeratorState(splitsWithStatusToStore, lastSeenShardId);
+
+        int version = 0;
+        List<KinesisShardSplit> splitsToStoreForOldVersion =
+                splitsWithStatusToStore.stream()
+                        .map(KinesisShardSplitWithAssignmentStatus::split)
+                        .collect(Collectors.toList());
+        KinesisStreamsSourceEnumeratorStateV0 initialState =
+                new KinesisStreamsSourceEnumeratorStateV0(
+                        splitsToStoreForOldVersion, lastSeenShardId);
+
+        KinesisShardSplitSerializer splitSerializer = new KinesisShardSplitSerializer();
+        KinesisStreamsSourceEnumeratorStateSerializer serializer =
+                new KinesisStreamsSourceEnumeratorStateSerializer(splitSerializer);
+
+        byte[] serialized = serializer.serializeV0(initialState);
+        KinesisStreamsSourceEnumeratorState deserializedState =
+                serializer.deserialize(version, serialized);
+
+        assertThat(deserializedState).usingRecursiveComparison().isEqualTo(expectedState);
+    }
+
+    private List<KinesisShardSplitWithAssignmentStatus> getSplits(
+            IntStream assignedShardIdRange, IntStream unassignedShardIdRange) {
+        Stream<KinesisShardSplitWithAssignmentStatus> assignedSplits =
+                assignedShardIdRange
+                        .mapToObj(TestUtil::generateShardId)
+                        .map(TestUtil::getTestSplit)
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.ASSIGNED));
+        Stream<KinesisShardSplitWithAssignmentStatus> unassignedSplits =
+                unassignedShardIdRange
+                        .mapToObj(TestUtil::generateShardId)
+                        .map(TestUtil::getTestSplit)
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.UNASSIGNED));
+        return Stream.concat(assignedSplits, unassignedSplits).collect(Collectors.toList());
     }
 
     private static class WrongVersionStateSerializer

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssignerTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/assigner/UniformShardAssignerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.kinesis.source.enumerator.assigner;
 
 import org.apache.flink.api.connector.source.ReaderInfo;

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/tracker/SplitTrackerTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/enumerator/tracker/SplitTrackerTest.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.enumerator.tracker;
+
+import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardSplitWithAssignmentStatus;
+import org.apache.flink.connector.kinesis.source.enumerator.SplitAssignmentStatus;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class SplitTrackerTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testSplitWithoutParentAreAvailableToAssign(boolean preserveShardOrdering) {
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering);
+
+        KinesisShardSplit split = getTestSplit(generateShardId(1), Collections.emptySet());
+
+        splitTracker.addSplits(Collections.singletonList(split));
+
+        List<KinesisShardSplit> pendingSplits = splitTracker.splitsAvailableForAssignment();
+
+        assertThat(pendingSplits).containsExactly(split);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testStateSnapshot(boolean preserveShardOrdering) {
+        List<KinesisShardSplit> assignedSplits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()));
+        List<KinesisShardSplit> unassignedSplits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(3), Collections.emptySet()),
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+
+        List<KinesisShardSplitWithAssignmentStatus> assignedSplitsWithStatus =
+                assignedSplits.stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.ASSIGNED))
+                        .collect(Collectors.toList());
+        List<KinesisShardSplitWithAssignmentStatus> unassignedSplitsWithStatus =
+                unassignedSplits.stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.UNASSIGNED))
+                        .collect(Collectors.toList());
+        List<KinesisShardSplitWithAssignmentStatus> expectedState =
+                new ArrayList<>(assignedSplitsWithStatus);
+        expectedState.addAll(unassignedSplitsWithStatus);
+
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering);
+
+        splitTracker.addSplits(assignedSplits);
+        splitTracker.addSplits(unassignedSplits);
+        splitTracker.markAsAssigned(assignedSplits);
+
+        // Verify that produced state is the same
+        assertThat(splitTracker.snapshotState(0))
+                .containsExactlyInAnyOrderElementsOf(expectedState);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testSplitSnapshotStateDoesNotIncludeFinishedSplits(boolean preserveShardOrdering) {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        getTestSplit(generateShardId(3), Collections.emptySet()));
+
+        List<KinesisShardSplitWithAssignmentStatus> expectedSplitState =
+                splits.stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.ASSIGNED))
+                        .collect(Collectors.toList());
+
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering);
+        splitTracker.addSplits(splits);
+        splitTracker.markAsAssigned(splits);
+
+        String splitIdToFinish = expectedSplitState.get(0).split().splitId();
+        splitTracker.markAsFinished(Collections.singletonList(splitIdToFinish));
+
+        // Verify that state does not contain finished split
+        assertThat(splitTracker.snapshotState(0))
+                .doesNotContain(expectedSplitState.get(0))
+                .containsExactlyInAnyOrder(expectedSplitState.get(1), expectedSplitState.get(2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testStateRestore(boolean preserveShardOrdering) {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        getTestSplit(generateShardId(3), Collections.emptySet()),
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+
+        Stream<KinesisShardSplitWithAssignmentStatus> assignedSplits =
+                splits.subList(0, 3).stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.ASSIGNED));
+        Stream<KinesisShardSplitWithAssignmentStatus> unassignedSplits =
+                splits.subList(3, splits.size()).stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.UNASSIGNED));
+        List<KinesisShardSplitWithAssignmentStatus> initialState =
+                Stream.concat(assignedSplits, unassignedSplits).collect(Collectors.toList());
+
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering, initialState);
+
+        // Verify that produced state is the same
+        assertThat(splitTracker.snapshotState(0)).containsExactlyInAnyOrderElementsOf(initialState);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testMarkUnknownSplitAsAssignedIsNoop(boolean preserveShardOrdering) {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+        List<KinesisShardSplitWithAssignmentStatus> initialState =
+                splits.stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.UNASSIGNED))
+                        .collect(Collectors.toList());
+
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering, initialState);
+        List<KinesisShardSplit> splitsToAssign =
+                Collections.singletonList(getTestSplit(generateShardId(0)));
+
+        assertThatNoException().isThrownBy(() -> splitTracker.markAsAssigned(splitsToAssign));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testMarkUnknownSplitAsFinishedIsNoop(boolean preserveShardOrdering) {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+        List<KinesisShardSplitWithAssignmentStatus> initialState =
+                splits.stream()
+                        .map(
+                                split ->
+                                        new KinesisShardSplitWithAssignmentStatus(
+                                                split, SplitAssignmentStatus.UNASSIGNED))
+                        .collect(Collectors.toList());
+
+        SplitTracker splitTracker = new SplitTracker(preserveShardOrdering, initialState);
+        List<String> splitIdsToFinish = Collections.singletonList(generateShardId(0));
+
+        assertThatNoException().isThrownBy(() -> splitTracker.markAsFinished(splitIdsToFinish));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Shard ordering disabled
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    public void testUnorderedAllUnassignedSplitsAvailableForAssignment() {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        getTestSplit(generateShardId(3), Collections.emptySet()),
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+
+        SplitTracker splitTracker = new SplitTracker(false);
+        splitTracker.addSplits(splits);
+
+        List<KinesisShardSplit> pendingSplits = splitTracker.splitsAvailableForAssignment();
+
+        assertThat(pendingSplits).containsExactlyInAnyOrderElementsOf(splits);
+    }
+
+    @Test
+    public void testUnorderedAssignedSplitsNoLongerReturnedAsAvailableToAssign() {
+        List<KinesisShardSplit> assignedSplits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        getTestSplit(generateShardId(3), Collections.emptySet()));
+        List<KinesisShardSplit> unassignedSplits =
+                Arrays.asList(
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+
+        SplitTracker splitTracker = new SplitTracker(false);
+        splitTracker.addSplits(assignedSplits);
+        splitTracker.addSplits(unassignedSplits);
+
+        splitTracker.markAsAssigned(assignedSplits);
+
+        List<KinesisShardSplit> pendingSplits = splitTracker.splitsAvailableForAssignment();
+
+        assertThat(pendingSplits).containsExactlyInAnyOrderElementsOf(unassignedSplits);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Shard ordering enabled
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    public void testOrderedAllUnassignedSplitsWithoutParentsAvailableForAssignment() {
+        List<KinesisShardSplit> splitsWithoutParents =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        getTestSplit(generateShardId(3), Collections.emptySet()));
+        List<KinesisShardSplit> splitsWithParents =
+                Arrays.asList(
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(1))),
+                        getTestSplit(generateShardId(5), Collections.singleton(generateShardId(1))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(6),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(2), generateShardId(3)))));
+
+        SplitTracker splitTracker = new SplitTracker(true);
+        splitTracker.addSplits(splitsWithParents);
+        splitTracker.addSplits(splitsWithoutParents);
+
+        List<KinesisShardSplit> pendingSplits = splitTracker.splitsAvailableForAssignment();
+
+        assertThat(pendingSplits).containsExactlyInAnyOrderElementsOf(splitsWithoutParents);
+    }
+
+    @Test
+    public void testOrderedMarkingParentSplitAsFinishedMakesChildrenAvailableForAssignment() {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(0), Collections.emptySet()),
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(3), Collections.singleton(generateShardId(0))),
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(0))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(5),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(1), generateShardId(2)))));
+
+        SplitTracker splitTracker = new SplitTracker(true);
+        splitTracker.addSplits(splits);
+
+        splitTracker.markAsAssigned(splits.subList(0, 3));
+        // All splits without parents were assigned, no eligible splits
+        assertThat(splitTracker.splitsAvailableForAssignment()).isEmpty();
+
+        // Split 0 has 2 children (shard split)
+        splitTracker.markAsFinished(Collections.singletonList(splits.get(0).splitId()));
+        assertThat(splitTracker.splitsAvailableForAssignment())
+                .containsExactlyInAnyOrder(splits.get(3), splits.get(4));
+    }
+
+    @Test
+    public void
+            testOrderedAllParentSplitShouldBeMarkedAsFinishedForChildrenToBecomeAvailableForAssignment() {
+        List<KinesisShardSplit> splits =
+                Arrays.asList(
+                        // Shards without parents
+                        getTestSplit(generateShardId(0), Collections.emptySet()),
+                        getTestSplit(generateShardId(1), Collections.emptySet()),
+                        getTestSplit(generateShardId(2), Collections.emptySet()),
+                        // Shards produced by splitting parent shard
+                        getTestSplit(generateShardId(3), Collections.singleton(generateShardId(0))),
+                        getTestSplit(generateShardId(4), Collections.singleton(generateShardId(0))),
+                        // Shard produced by merging 2 parent shards
+                        getTestSplit(
+                                generateShardId(5),
+                                new HashSet<>(
+                                        Arrays.asList(generateShardId(1), generateShardId(2)))));
+
+        SplitTracker splitTracker = new SplitTracker(true);
+        splitTracker.addSplits(splits);
+
+        splitTracker.markAsAssigned(splits.subList(0, 3));
+        // All splits without parents were assigned, no eligible splits
+        assertThat(splitTracker.splitsAvailableForAssignment()).isEmpty();
+
+        // Splits 1 and 2 has 1 common child (shard merge)
+        // Marking split 1 as finished would not make child available, because another parent is
+        // still being read
+        splitTracker.markAsFinished(Collections.singletonList(splits.get(1).splitId()));
+        assertThat(splitTracker.splitsAvailableForAssignment()).isEmpty();
+
+        // Marking split 2 as finished makes child split available since both parent are finished
+        // now
+        splitTracker.markAsFinished(Collections.singletonList(splits.get(2).splitId()));
+        assertThat(splitTracker.splitsAvailableForAssignment()).containsExactly(splits.get(5));
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/ListShardsStartingPositionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/ListShardsStartingPositionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.proxy;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.kinesis.model.ShardFilter;
+import software.amazon.awssdk.services.kinesis.model.ShardFilterType;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class ListShardsStartingPositionTest {
+    @Test
+    void testShardPositionFromTimestamp() {
+        Instant timestamp = Instant.ofEpochMilli(1720543032243L);
+        ListShardsStartingPosition startingPosition =
+                ListShardsStartingPosition.fromTimestamp(timestamp);
+
+        ShardFilter expected =
+                ShardFilter.builder()
+                        .type(ShardFilterType.FROM_TIMESTAMP)
+                        .timestamp(timestamp)
+                        .build();
+
+        assertThat(startingPosition.getShardFilter()).isEqualTo(expected);
+    }
+
+    @Test
+    void testShardPositionFromTimestampShouldFailOnNullTimestamp() {
+        assertThatThrownBy(() -> ListShardsStartingPosition.fromTimestamp(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testShardPositionFromShardId() {
+        String shardId = "shard-00000000002";
+        ListShardsStartingPosition startingPosition =
+                ListShardsStartingPosition.fromShardId(shardId);
+
+        ShardFilter expected =
+                ShardFilter.builder().type(ShardFilterType.AFTER_SHARD_ID).shardId(shardId).build();
+
+        assertThat(startingPosition.getShardFilter()).isEqualTo(expected);
+    }
+
+    @Test
+    void testShardPositionFromShardIdShouldFailOnNullTimestamp() {
+        assertThatThrownBy(() -> ListShardsStartingPosition.fromShardId(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testShardPositionFromStart() {
+        ListShardsStartingPosition startingPosition = ListShardsStartingPosition.fromStart();
+
+        ShardFilter expected =
+                ShardFilter.builder().type(ShardFilterType.FROM_TRIM_HORIZON).build();
+
+        assertThat(startingPosition.getShardFilter()).isEqualTo(expected);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializerTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitSerializerTest.java
@@ -20,38 +20,30 @@ package org.apache.flink.connector.kinesis.source.split;
 
 import org.apache.flink.core.io.VersionMismatchException;
 
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.STREAM_ARN;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 class KinesisShardSplitSerializerTest {
 
-    @Test
-    void testSerializeAndDeserializeEverythingSpecified() throws Exception {
-        final KinesisShardSplit initialSplit = getTestSplit();
-
-        KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
-
-        byte[] serialized = serializer.serialize(initialSplit);
-        KinesisShardSplit deserializedSplit =
-                serializer.deserialize(serializer.getVersion(), serialized);
-
-        assertThat(deserializedSplit).usingRecursiveComparison().isEqualTo(initialSplit);
-    }
-
     @ParameterizedTest
-    @MethodSource("provideStartingPositions")
-    void testSerializeAndDeserializeWithStartingPosition(StartingPosition startingPosition)
+    @MethodSource("provideKinesisShardSplits")
+    void testSerializeAndDeserializeEverythingSpecified(KinesisShardSplit initialSplit)
             throws Exception {
-        final KinesisShardSplit initialSplit = getTestSplit(startingPosition);
-
         KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
 
         byte[] serialized = serializer.serialize(initialSplit);
@@ -61,11 +53,39 @@ class KinesisShardSplitSerializerTest {
         assertThat(deserializedSplit).usingRecursiveComparison().isEqualTo(initialSplit);
     }
 
-    private static Stream<StartingPosition> provideStartingPositions() {
+    private static Stream<KinesisShardSplit> provideKinesisShardSplits() {
         return Stream.of(
-                StartingPosition.fromStart(),
-                StartingPosition.continueFromSequenceNumber("some-sequence-number"),
-                StartingPosition.fromTimestamp(Instant.ofEpochMilli(1683817847000L)));
+                getTestSplit(),
+                getTestSplit(generateShardId(2), Collections.singleton(generateShardId(1))),
+                getTestSplit(
+                        generateShardId(5),
+                        new HashSet<>(Arrays.asList(generateShardId(1), generateShardId(2)))),
+                getTestSplit(StartingPosition.fromStart()),
+                getTestSplit(StartingPosition.continueFromSequenceNumber("some-sequence-number")),
+                getTestSplit(StartingPosition.fromTimestamp(Instant.ofEpochMilli(1683817847000L))));
+    }
+
+    @Test
+    void testDeserializeVersion0() throws Exception {
+        final KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
+
+        final KinesisShardSplit initialSplit =
+                new KinesisShardSplit(
+                        STREAM_ARN,
+                        generateShardId(10),
+                        StartingPosition.continueFromSequenceNumber("some-sequence-number"),
+                        new HashSet<>(Arrays.asList(generateShardId(2), generateShardId(5))));
+
+        byte[] oldSerializedState = serializer.serializeV0(initialSplit);
+        KinesisShardSplit deserializedSplit = serializer.deserialize(0, oldSerializedState);
+
+        assertThat(deserializedSplit)
+                .usingRecursiveComparison(
+                        RecursiveComparisonConfiguration.builder()
+                                .withIgnoredFields("parentShardIds")
+                                .build())
+                .isEqualTo(initialSplit);
+        assertThat(deserializedSplit.getParentShardIds()).isNotNull().matches(Set::isEmpty);
     }
 
     @Test
@@ -76,16 +96,16 @@ class KinesisShardSplitSerializerTest {
         KinesisShardSplitSerializer serializer = new KinesisShardSplitSerializer();
         KinesisShardSplitSerializer wrongVersionSerializer = new WrongVersionSerializer();
 
-        byte[] serialized = serializer.serialize(initialSplit);
+        byte[] serialized = wrongVersionSerializer.serialize(initialSplit);
         assertThatExceptionOfType(VersionMismatchException.class)
                 .isThrownBy(
                         () ->
-                                wrongVersionSerializer.deserialize(
-                                        serializer.getVersion(), serialized))
+                                serializer.deserialize(
+                                        wrongVersionSerializer.getVersion(), serialized))
                 .withMessageContaining(
                         "Trying to deserialize KinesisShardSplit serialized with unsupported version ")
-                .withMessageContaining(String.valueOf(wrongVersionSerializer.getVersion()))
-                .withMessageContaining(String.valueOf(serializer.getVersion()));
+                .withMessageContaining(String.valueOf(serializer.getVersion()))
+                .withMessageContaining(String.valueOf(wrongVersionSerializer.getVersion()));
     }
 
     private static class WrongVersionSerializer extends KinesisShardSplitSerializer {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/KinesisShardSplitTest.java
@@ -1,7 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.kinesis.source.split;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
@@ -11,26 +32,42 @@ class KinesisShardSplitTest {
             "arn:aws:kinesis:us-east-1:290038087681:stream/keeneses_stream";
     private static final String SHARD_ID = "shardId-000000000002";
     private static final StartingPosition STARTING_POSITION = StartingPosition.fromStart();
+    private static final Set<String> PARENT_SHARD_IDS = Collections.emptySet();
 
     @Test
     void testStreamArnNull() {
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new KinesisShardSplit(null, SHARD_ID, STARTING_POSITION))
+                .isThrownBy(
+                        () ->
+                                new KinesisShardSplit(
+                                        null, SHARD_ID, STARTING_POSITION, PARENT_SHARD_IDS))
                 .withMessageContaining("streamArn cannot be null");
     }
 
     @Test
     void testShardIdNull() {
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new KinesisShardSplit(STREAM_ARN, null, STARTING_POSITION))
+                .isThrownBy(
+                        () ->
+                                new KinesisShardSplit(
+                                        STREAM_ARN, null, STARTING_POSITION, PARENT_SHARD_IDS))
                 .withMessageContaining("shardId cannot be null");
     }
 
     @Test
     void testStartingPositionNull() {
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new KinesisShardSplit(STREAM_ARN, SHARD_ID, null))
+                .isThrownBy(
+                        () -> new KinesisShardSplit(STREAM_ARN, SHARD_ID, null, PARENT_SHARD_IDS))
                 .withMessageContaining("startingPosition cannot be null");
+    }
+
+    @Test
+    void testParentShardIdsNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(
+                        () -> new KinesisShardSplit(STREAM_ARN, SHARD_ID, STARTING_POSITION, null))
+                .withMessageContaining("parentShardIds cannot be null");
     }
 
     @Test

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/StartingPositionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/split/StartingPositionTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.kinesis.source.split;
 
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisClientProvider.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/KinesisClientProvider.java
@@ -23,6 +23,8 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.kinesis.KinesisServiceClientConfiguration;
 import software.amazon.awssdk.services.kinesis.model.AccessDeniedException;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.ExpiredNextTokenException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
@@ -64,6 +66,8 @@ public class KinesisClientProvider {
         private Consumer<GetShardIteratorRequest> getShardIteratorValidation;
         private GetRecordsResponse getRecordsResponse;
         private Consumer<GetRecordsRequest> getRecordsValidation;
+        private DescribeStreamSummaryResponse describeStreamSummaryResponse;
+        private Consumer<DescribeStreamSummaryRequest> describeStreamSummaryRequestValidation;
         private boolean closed = false;
 
         @Override
@@ -134,6 +138,26 @@ public class KinesisClientProvider {
                         KinesisException {
             getRecordsValidation.accept(getRecordsRequest);
             return getRecordsResponse;
+        }
+
+        public void setDescribeStreamSummaryResponse(
+                DescribeStreamSummaryResponse describeStreamSummaryResponse) {
+            this.describeStreamSummaryResponse = describeStreamSummaryResponse;
+        }
+
+        public void setDescribeStreamSummaryRequestValidation(
+                Consumer<DescribeStreamSummaryRequest> describeStreamSummaryRequestValidation) {
+            this.describeStreamSummaryRequestValidation = describeStreamSummaryRequestValidation;
+        }
+
+        @Override
+        public DescribeStreamSummaryResponse describeStreamSummary(
+                DescribeStreamSummaryRequest describeStreamSummaryRequest)
+                throws ResourceNotFoundException, LimitExceededException, InvalidArgumentException,
+                        AccessDeniedException, AwsServiceException, SdkClientException,
+                        KinesisException {
+            describeStreamSummaryRequestValidation.accept(describeStreamSummaryRequest);
+            return describeStreamSummaryResponse;
         }
 
         @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
@@ -32,7 +32,9 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kinesis.model.Record;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,12 +67,24 @@ public class TestUtil {
         return getTestSplit(STREAM_ARN, shardId);
     }
 
+    public static KinesisShardSplit getTestSplit(String shardId, Set<String> parentShards) {
+        return getTestSplit(STREAM_ARN, shardId, parentShards);
+    }
+
     public static KinesisShardSplit getTestSplit(String streamArn, String shardId) {
-        return new KinesisShardSplit(streamArn, shardId, StartingPosition.fromStart());
+        return new KinesisShardSplit(
+                streamArn, shardId, StartingPosition.fromStart(), Collections.emptySet());
+    }
+
+    public static KinesisShardSplit getTestSplit(
+            String streamArn, String shardId, Set<String> parentShards) {
+        return new KinesisShardSplit(
+                streamArn, shardId, StartingPosition.fromStart(), parentShards);
     }
 
     public static KinesisShardSplit getTestSplit(StartingPosition startingPosition) {
-        return new KinesisShardSplit(STREAM_ARN, SHARD_ID, startingPosition);
+        return new KinesisShardSplit(
+                STREAM_ARN, SHARD_ID, startingPosition, Collections.emptySet());
     }
 
     public static ReaderInfo getTestReaderInfo(final int subtaskId) {


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Adding support for parent-child shard ordering when reading from Kinesis streams.
When enabled, source enumerator will assign split that correspond to a shard only when parent shard either finished, expired, or don't exists.

## Verifying this change

Added unit tests.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [x] Serializers have been changed
- [x] New feature has been introduced
  - If yes, how is this documented? JavaDocs, connector documentation will be written in separate task [(FLINK-31989)](https://issues.apache.org/jira/browse/FLINK-31989)
