### PR TITLE
[hotfix][ci] Update builds to test against 1.19.1

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     strategy:
       matrix:
-        flink: [1.18.1, 1.19.0]
+        flink: [1.18.1, 1.19.1]
         java: [ '8, 11, 17']
     with:
       flink_version: ${{ matrix.flink }}
@@ -38,7 +38,7 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [1.18.1, 1.19.0]
+        flink: [1.18.1, 1.19.1]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}


### PR DESCRIPTION

## Purpose of the change
- Set up builds on PR to test against 1.19.1

## Verifying this change

This change is already covered by Github approval workflow.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
