### PR TITLE
[FLINK-32324][Connectors/AWS] Implement support for watermark alignment in FLIP-27 sources for KDS and DDB streams

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.STREAM_ARN;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestRecord;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
@@ -226,6 +229,116 @@ class PollingKinesisShardSplitReaderTest {
     @Test
     void testWakeUpIsNoOp() {
         assertThatNoException().isThrownBy(splitReader::wakeUp);
+    }
+
+    @Test
+    void testPauseOrResumeSplits() throws Exception {
+        testStreamProxy.addShards(TEST_SHARD_ID);
+        KinesisShardSplit testSplit = getTestSplit(TEST_SHARD_ID);
+
+        List<Record> expectedRecords =
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"))
+                        .collect(Collectors.toList());
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN,
+                TEST_SHARD_ID,
+                Collections.singletonList(expectedRecords.get(0)));
+        testStreamProxy.addRecords(
+                TestUtil.STREAM_ARN,
+                TEST_SHARD_ID,
+                Collections.singletonList(expectedRecords.get(1)));
+        splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(testSplit)));
+
+        // read data from split
+        RecordsWithSplitIds<Record> records = splitReader.fetch();
+        assertThat(readAllRecords(records)).containsExactlyInAnyOrder(expectedRecords.get(0));
+
+        // pause split
+        splitReader.pauseOrResumeSplits(
+                Collections.singletonList(testSplit), Collections.emptyList());
+        records = splitReader.fetch();
+        // returns incomplete split with no records
+        assertThat(records.finishedSplits()).isEmpty();
+        assertThat(records.nextSplit()).isNull();
+        assertThat(records.nextRecordFromSplit()).isNull();
+
+        // resume split
+        splitReader.pauseOrResumeSplits(
+                Collections.emptyList(), Collections.singletonList(testSplit));
+        records = splitReader.fetch();
+        assertThat(readAllRecords(records)).containsExactlyInAnyOrder(expectedRecords.get(1));
+    }
+
+    @Test
+    void testPauseOrResumeSplitsOnlyPauseReadsFromSpecifiedSplits() throws Exception {
+        KinesisShardSplit testSplit1 = getTestSplit(generateShardId(1));
+        KinesisShardSplit testSplit2 = getTestSplit(generateShardId(2));
+        KinesisShardSplit testSplit3 = getTestSplit(generateShardId(3));
+
+        shardMetricGroupMap.put(
+                testSplit1.splitId(),
+                new KinesisShardMetrics(testSplit1, metricListener.getMetricGroup()));
+        shardMetricGroupMap.put(
+                testSplit2.splitId(),
+                new KinesisShardMetrics(testSplit2, metricListener.getMetricGroup()));
+        shardMetricGroupMap.put(
+                testSplit3.splitId(),
+                new KinesisShardMetrics(testSplit3, metricListener.getMetricGroup()));
+
+        testStreamProxy.addShards(testSplit1.splitId(), testSplit2.splitId(), testSplit3.splitId());
+
+        List<Record> recordsFromSplit1 =
+                Arrays.asList(getTestRecord("split-1-data-1"), getTestRecord("split-1-data-2"));
+        List<Record> recordsFromSplit2 =
+                Arrays.asList(getTestRecord("split-2-data-1"), getTestRecord("split-2-data-2"));
+        List<Record> recordsFromSplit3 =
+                Arrays.asList(getTestRecord("split-3-data-1"), getTestRecord("split-3-data-2"));
+
+        recordsFromSplit1.forEach(
+                record ->
+                        testStreamProxy.addRecords(
+                                STREAM_ARN,
+                                testSplit1.getShardId(),
+                                Collections.singletonList(record)));
+        recordsFromSplit2.forEach(
+                record ->
+                        testStreamProxy.addRecords(
+                                STREAM_ARN,
+                                testSplit2.getShardId(),
+                                Collections.singletonList(record)));
+        recordsFromSplit3.forEach(
+                record ->
+                        testStreamProxy.addRecords(
+                                STREAM_ARN,
+                                testSplit3.getShardId(),
+                                Collections.singletonList(record)));
+
+        splitReader.handleSplitsChanges(
+                new SplitsAddition<>(Arrays.asList(testSplit1, testSplit2, testSplit3)));
+
+        // pause split 1 and split 3
+        splitReader.pauseOrResumeSplits(
+                Arrays.asList(testSplit1, testSplit3), Collections.emptyList());
+
+        // read data from splits and verify that only records from split 2 were fetched by reader
+        List<Record> fetchedRecords = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            RecordsWithSplitIds<Record> records = splitReader.fetch();
+            fetchedRecords.addAll(readAllRecords(records));
+        }
+        assertThat(fetchedRecords).containsExactly(recordsFromSplit2.toArray(new Record[0]));
+
+        // resume split 3
+        splitReader.pauseOrResumeSplits(
+                Collections.emptyList(), Collections.singletonList(testSplit3));
+
+        // read data from splits and verify that only records from split 3 had been read
+        fetchedRecords.clear();
+        for (int i = 0; i < 10; i++) {
+            RecordsWithSplitIds<Record> records = splitReader.fetch();
+            fetchedRecords.addAll(readAllRecords(records));
+        }
+        assertThat(fetchedRecords).containsExactly(recordsFromSplit3.toArray(new Record[0]));
     }
 
     @Test


### PR DESCRIPTION
## Purpose of the change

Add support for watermark alignment to FLIP-27 sources for Kinesis Data Streams and DynamoDB Streams.

## Verifying this change

This change added tests and can be verified as follows:
- *Added unit tests*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented) not applicable 
