### PR TITLE
[FLINK-35500][Connectors/DynamoDB] DynamoDb Table API Sink fails to delete elements due to key not found

### DIFF
--- a/docs/content/docs/connectors/table/dynamodb.md
+++ b/docs/content/docs/connectors/table/dynamodb.md
@@ -303,6 +303,46 @@ WITH (
 );
 ```
 
+## Specifying Primary Key For Deletes
+
+The DynamoDB sink supports Delete requests to DynamoDB, but AWS requires that a Dynamo Delete request contain **only** the key field(s), or else the Delete request will fail with `DynamoDbException: The provided key element does not match the schema`.
+Thus, if a Changelog stream being is being written to DynamoDB that contains DELETEs, you must specify the `PRIMARY KEY` on the table.
+This `PRIMARY KEY` specified for the Flink SQL Table must match the actual Primary Key of the DynamoDB table - so it must be either just the Partition Key, or in case of a composite primary key, it must be the Partition Key and Sort Key.
+
+Example For Partition Key as only Primary Key:
+```sql
+CREATE TABLE DynamoDbTable (
+  `user_id` BIGINT,
+  `item_id` BIGINT,
+  `category_id` BIGINT,
+  `behavior` STRING,
+  PRIMARY KEY (user_id) NOT ENFORCED
+) 
+WITH (
+  'connector' = 'dynamodb',
+  'table-name' = 'user_behavior',
+  'aws.region' = 'us-east-2'
+);
+```
+
+Example For Partition Key and Sort Key as Composite Primary Key:
+```sql
+CREATE TABLE DynamoDbTable (
+  `user_id` BIGINT,
+  `item_id` BIGINT,
+  `category_id` BIGINT,
+  `behavior` STRING,
+  PRIMARY KEY (user_id, item_id) NOT ENFORCED
+) 
+WITH (
+  'connector' = 'dynamodb',
+  'table-name' = 'user_behavior',
+  'aws.region' = 'us-east-2'
+);
+```
+
+Note that this Primary Key functionality, specified by `PRIMARY KEY`, can be used alongside the Sink Partitioning mentioned above via `PARTITIONED BY` to dedeuplicate data and support DELETEs.
+
 ## Notice
 
 The current implementation of the DynamoDB SQL connector is write-only and doesn't provide an implementation for source queries.

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
@@ -51,6 +51,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
     private final Properties dynamoDbClientProperties;
     private final DataType physicalDataType;
     private final Set<String> overwriteByPartitionKeys;
+    private final Set<String> primaryKeys;
 
     protected DynamoDbDynamicSink(
             @Nullable Integer maxBatchSize,
@@ -62,7 +63,8 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
             boolean failOnError,
             Properties dynamoDbClientProperties,
             DataType physicalDataType,
-            Set<String> overwriteByPartitionKeys) {
+            Set<String> overwriteByPartitionKeys,
+            Set<String> primaryKeys) {
         super(
                 maxBatchSize,
                 maxInFlightRequests,
@@ -74,6 +76,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
         this.dynamoDbClientProperties = dynamoDbClientProperties;
         this.physicalDataType = physicalDataType;
         this.overwriteByPartitionKeys = overwriteByPartitionKeys;
+        this.primaryKeys = primaryKeys;
     }
 
     @Override
@@ -89,7 +92,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                         .setFailOnError(failOnError)
                         .setOverwriteByPartitionKeys(new ArrayList<>(overwriteByPartitionKeys))
                         .setDynamoDbProperties(dynamoDbClientProperties)
-                        .setElementConverter(new RowDataElementConverter(physicalDataType));
+                        .setElementConverter(new RowDataElementConverter(physicalDataType, primaryKeys));
 
         addAsyncOptionsToSinkBuilder(builder);
 
@@ -108,7 +111,8 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                 failOnError,
                 dynamoDbClientProperties,
                 physicalDataType,
-                overwriteByPartitionKeys);
+                overwriteByPartitionKeys,
+                primaryKeys);
     }
 
     @Override
@@ -136,6 +140,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
         private Properties dynamoDbClientProperties;
         private DataType physicalDataType;
         private Set<String> overwriteByPartitionKeys;
+        private Set<String> primaryKeys;
 
         public DynamoDbDynamicTableSinkBuilder setTableName(String tableName) {
             this.tableName = tableName;
@@ -164,6 +169,11 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
             return this;
         }
 
+        public DynamoDbDynamicTableSinkBuilder setPrimaryKeys(Set<String> primaryKeys) {
+            this.primaryKeys = primaryKeys;
+            return this;
+        }
+
         @Override
         public AsyncDynamicTableSink<DynamoDbWriteRequest> build() {
             return new DynamoDbDynamicSink(
@@ -176,7 +186,8 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                     failOnError,
                     dynamoDbClientProperties,
                     physicalDataType,
-                    overwriteByPartitionKeys);
+                    overwriteByPartitionKeys,
+                    primaryKeys);
         }
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
@@ -92,7 +92,8 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                         .setFailOnError(failOnError)
                         .setOverwriteByPartitionKeys(new ArrayList<>(overwriteByPartitionKeys))
                         .setDynamoDbProperties(dynamoDbClientProperties)
-                        .setElementConverter(new RowDataElementConverter(physicalDataType, primaryKeys));
+                        .setElementConverter(
+                                new RowDataElementConverter(physicalDataType, primaryKeys));
 
         addAsyncOptionsToSinkBuilder(builder);
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
@@ -58,8 +58,15 @@ public class DynamoDbDynamicSinkFactory extends AsyncDynamicTableSinkFactory {
                         .setDynamoDbClientProperties(
                                 dynamoDbConfiguration.getSinkClientProperties());
 
-        if (catalogTable.getResolvedSchema().getPrimaryKey().isPresent()){
-            builder = builder.setPrimaryKeys(new HashSet<>(catalogTable.getResolvedSchema().getPrimaryKey().get().getColumns()));
+        if (catalogTable.getResolvedSchema().getPrimaryKey().isPresent()) {
+            builder =
+                    builder.setPrimaryKeys(
+                            new HashSet<>(
+                                    catalogTable
+                                            .getResolvedSchema()
+                                            .getPrimaryKey()
+                                            .get()
+                                            .getColumns()));
         }
 
         addAsyncOptionsToBuilder(dynamoDbConfiguration.getAsyncSinkProperties(), builder);

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
@@ -58,6 +58,10 @@ public class DynamoDbDynamicSinkFactory extends AsyncDynamicTableSinkFactory {
                         .setDynamoDbClientProperties(
                                 dynamoDbConfiguration.getSinkClientProperties());
 
+        if (catalogTable.getResolvedSchema().getPrimaryKey().isPresent()){
+            builder = builder.setPrimaryKeys(new HashSet<>(catalogTable.getResolvedSchema().getPrimaryKey().get().getColumns()));
+        }
+
         addAsyncOptionsToBuilder(dynamoDbConfiguration.getAsyncSinkProperties(), builder);
 
         return builder.build();

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverter.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
+import java.util.Set;
+
 /**
  * Implementation of an {@link ElementConverter} for the DynamoDb Table sink. The element converter
  * maps the Flink internal type of {@link RowData} to a {@link DynamoDbWriteRequest} to be used by
@@ -36,19 +38,21 @@ import org.apache.flink.table.types.DataType;
 public class RowDataElementConverter implements ElementConverter<RowData, DynamoDbWriteRequest> {
 
     private final DataType physicalDataType;
+    private final Set<String> primaryKeys;
     private transient RowDataToAttributeValueConverter rowDataToAttributeValueConverter;
 
-    public RowDataElementConverter(DataType physicalDataType) {
+    public RowDataElementConverter(DataType physicalDataType, Set<String> primaryKeys) {
         this.physicalDataType = physicalDataType;
+        this.primaryKeys = primaryKeys;
         this.rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(physicalDataType);
+                new RowDataToAttributeValueConverter(physicalDataType, primaryKeys);
     }
 
     @Override
     public DynamoDbWriteRequest apply(RowData element, SinkWriter.Context context) {
         if (rowDataToAttributeValueConverter == null) {
             rowDataToAttributeValueConverter =
-                    new RowDataToAttributeValueConverter(physicalDataType);
+                    new RowDataToAttributeValueConverter(physicalDataType, primaryKeys);
         }
 
         DynamoDbWriteRequest.Builder builder =

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
@@ -21,10 +21,12 @@ package org.apache.flink.connector.dynamodb.table;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.dynamodb.table.converter.ArrayAttributeConverterProvider;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.types.RowKind;
 
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
@@ -32,8 +34,10 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.table.data.RowData.createFieldGetter;
 
@@ -43,14 +47,35 @@ public class RowDataToAttributeValueConverter {
 
     private final DataType physicalDataType;
     private final TableSchema<RowData> tableSchema;
+    private final Set<String> primaryKeys;
 
-    public RowDataToAttributeValueConverter(DataType physicalDataType) {
+    public RowDataToAttributeValueConverter(DataType physicalDataType, Set<String> primaryKeys) {
         this.physicalDataType = physicalDataType;
+        this.primaryKeys = primaryKeys;
         this.tableSchema = createTableSchema();
     }
 
     public Map<String, AttributeValue> convertRowData(RowData row) {
-        return tableSchema.itemToMap(row, false);
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap = tableSchema.itemToMap(row, false);
+
+        // In case of DELETE, only the primary key field(s) should be sent in the request
+        // In order to accomplish this, we need PRIMARY KEY fields to have been set in Table definition.
+        if (row.getRowKind() == RowKind.DELETE){
+                if (primaryKeys == null || primaryKeys.isEmpty()) {
+                        throw new TableException("PRIMARY KEY on Table must be set for DynamoDB DELETE operation");
+                }
+                Map<String, AttributeValue> pkOnlyMap = new HashMap<String, AttributeValue>();
+                for (String key : primaryKeys) {
+                        AttributeValue value = itemMap.get(key);
+                        pkOnlyMap.put(key, value);
+                }
+                return pkOnlyMap;
+        }
+        else {
+                return itemMap;
+        }
+
     }
 
     private StaticTableSchema<RowData> createTableSchema() {

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
@@ -51,9 +51,7 @@ public class RowDataToAttributeValueConverter {
     private final Set<String> primaryKeys;
 
     public RowDataToAttributeValueConverter(DataType physicalDataType) {
-        this.physicalDataType = physicalDataType;
-        this.primaryKeys = Collections.emptySet();
-        this.tableSchema = createTableSchema();
+        this(physicalDataType, Collections.emptySet());
     }
 
     public RowDataToAttributeValueConverter(DataType physicalDataType, Set<String> primaryKeys) {

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
@@ -60,22 +60,22 @@ public class RowDataToAttributeValueConverter {
         itemMap = tableSchema.itemToMap(row, false);
 
         // In case of DELETE, only the primary key field(s) should be sent in the request
-        // In order to accomplish this, we need PRIMARY KEY fields to have been set in Table definition.
-        if (row.getRowKind() == RowKind.DELETE){
-                if (primaryKeys == null || primaryKeys.isEmpty()) {
-                        throw new TableException("PRIMARY KEY on Table must be set for DynamoDB DELETE operation");
-                }
-                Map<String, AttributeValue> pkOnlyMap = new HashMap<String, AttributeValue>();
-                for (String key : primaryKeys) {
-                        AttributeValue value = itemMap.get(key);
-                        pkOnlyMap.put(key, value);
-                }
-                return pkOnlyMap;
+        // In order to accomplish this, we need PRIMARY KEY fields to have been set in Table
+        // definition.
+        if (row.getRowKind() == RowKind.DELETE) {
+            if (primaryKeys == null || primaryKeys.isEmpty()) {
+                throw new TableException(
+                        "PRIMARY KEY on Table must be set for DynamoDB DELETE operation");
+            }
+            Map<String, AttributeValue> pkOnlyMap = new HashMap<String, AttributeValue>();
+            for (String key : primaryKeys) {
+                AttributeValue value = itemMap.get(key);
+                pkOnlyMap.put(key, value);
+            }
+            return pkOnlyMap;
+        } else {
+            return itemMap;
         }
-        else {
-                return itemMap;
-        }
-
     }
 
     private StaticTableSchema<RowData> createTableSchema() {

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,12 @@ public class RowDataToAttributeValueConverter {
     private final DataType physicalDataType;
     private final TableSchema<RowData> tableSchema;
     private final Set<String> primaryKeys;
+
+    public RowDataToAttributeValueConverter(DataType physicalDataType) {
+        this.physicalDataType = physicalDataType;
+        this.primaryKeys = Collections.emptySet();
+        this.tableSchema = createTableSchema();
+    }
 
     public RowDataToAttributeValueConverter(DataType physicalDataType, Set<String> primaryKeys) {
         this.physicalDataType = physicalDataType;

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverterTest.java
@@ -53,7 +53,8 @@ public class RowDataElementConverterTest {
     private static final RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
             new RowDataToAttributeValueConverter(DATA_TYPE, null);
 
-    private static final Set<String> primaryKeys = new HashSet<>(Collections.singletonList("partition_key"));
+    private static final Set<String> primaryKeys =
+            new HashSet<>(Collections.singletonList("partition_key"));
     private static final RowDataElementConverter elementConverterWithPK =
             new RowDataElementConverter(DATA_TYPE, primaryKeys);
     private static final RowDataToAttributeValueConverter rowDataToAttributeValueConverterWithPK =

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverterTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,8 +52,7 @@ public class RowDataElementConverterTest {
     private static final RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
             new RowDataToAttributeValueConverter(DATA_TYPE, null);
 
-    private static final Set<String> primaryKeys =
-            new HashSet<>(Collections.singletonList("partition_key"));
+    private static final Set<String> primaryKeys = Collections.singleton("partition_key");
     private static final RowDataElementConverter elementConverterWithPK =
             new RowDataElementConverter(DATA_TYPE, primaryKeys);
     private static final RowDataToAttributeValueConverter rowDataToAttributeValueConverterWithPK =

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -34,7 +35,11 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -51,7 +56,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.CHAR(9)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -68,7 +73,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.VARCHAR(13)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -85,7 +90,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -102,7 +107,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.BOOLEAN()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -118,7 +123,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.DECIMAL(5, 4)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(DecimalData.fromBigDecimal(value, 5, 4)));
@@ -135,7 +140,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.TINYINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -151,7 +156,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.SMALLINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -167,7 +172,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.INT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -183,7 +188,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.BIGINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -199,7 +204,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.FLOAT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -215,7 +220,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.DOUBLE()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -231,7 +236,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.TIMESTAMP()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(TimestampData.fromLocalDateTime(value)));
@@ -249,7 +254,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.STRING())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, StringData::fromString));
@@ -274,7 +279,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.BOOLEAN())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -302,7 +307,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.DECIMAL(1, 0))));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, d -> DecimalData.fromBigDecimal(d, 1, 0)));
@@ -331,7 +336,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TINYINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -359,7 +364,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.SMALLINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -386,7 +391,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.INT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -414,7 +419,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.BIGINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -441,7 +446,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.FLOAT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -469,7 +474,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.DOUBLE())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -497,7 +502,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TIMESTAMP())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, TimestampData::fromLocalDateTime));
@@ -526,7 +531,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TIMESTAMP_LTZ())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType);
+                new RowDataToAttributeValueConverter(dataType, null);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, TimestampData::fromInstant));
@@ -547,9 +552,129 @@ public class RowDataToAttributeValueConverterTest {
         assertThat(actualResult).containsAllEntriesOf(expectedResult);
     }
 
+    @Test
+    void testDeleteOnlyPrimaryKey() {
+        String key = "key";
+        String value = "some_string";
+        String otherField = "other_field";
+        String otherValue = "other_value";
+        Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
+
+        // Create a Row with two fields - "key" and "otherField".  "key" is the single primary key.
+        // For a Delete request, only "key" should be included in the expectedResult, and not "otherField".
+        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(dataType, primaryKeys);
+        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        rowData.setRowKind(RowKind.DELETE);
+
+        Map<String, AttributeValue> actualResult =
+                rowDataToAttributeValueConverter.convertRowData(rowData);
+        Map<String, AttributeValue> expectedResult =
+                singletonMap(key, AttributeValue.builder().s(value).build());
+
+        assertThat(actualResult).containsAllEntriesOf(expectedResult);
+        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+    }
+
+    @Test
+    void testDeleteOnlyPrimaryKeys() {
+        String key = "key";
+        String value = "some_string";
+        String additionalKey = "additional_key";
+        String additionalValue = "additional_value";
+        String otherField = "other_field";
+        String otherValue = "other_value";
+        Set<String> primaryKeys = new HashSet<>();
+        primaryKeys.add(key);
+        primaryKeys.add(additionalKey);
+
+        // Create a Row with three fields - "key", "additional_key", and "otherField".
+        // "key" and "additional_key" make up the composite primary key.
+        // For a Delete request, only "key" and "additional_key" should be included in the expectedResult, and not "otherField".
+        DataType dataType = DataTypes.ROW(
+                DataTypes.FIELD(key, DataTypes.STRING()),
+                DataTypes.FIELD(additionalKey, DataTypes.STRING()),
+                DataTypes.FIELD(otherField, DataTypes.STRING()));
+        RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(dataType, primaryKeys);
+        RowData rowData = createElementWithMultipleFields(
+                StringData.fromString(value), StringData.fromString(additionalValue), StringData.fromString(otherValue));
+        rowData.setRowKind(RowKind.DELETE);
+
+        Map<String, AttributeValue> actualResult =
+                rowDataToAttributeValueConverter.convertRowData(rowData);
+        Map<String, AttributeValue> expectedResult = new HashMap<>();
+        expectedResult.put(key, AttributeValue.builder().s(value).build());
+        expectedResult.put(additionalKey, AttributeValue.builder().s(additionalValue).build());
+
+        assertThat(actualResult).containsAllEntriesOf(expectedResult);
+        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+    }
+
+    @Test
+    void testPKIgnoredForInsert() {
+        String key = "key";
+        String value = "some_string";
+        String otherField = "other_field";
+        String otherValue = "other_value";
+        Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
+
+        // Create a Row with two fields - "key" and "otherField".  "key" is the primary key.
+        // For an Insert request, all fields should be included regardless of the Primary Key.
+        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(dataType, primaryKeys);
+        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        rowData.setRowKind(RowKind.INSERT);
+
+        Map<String, AttributeValue> actualResult =
+                rowDataToAttributeValueConverter.convertRowData(rowData);
+        Map<String, AttributeValue> expectedResult = new HashMap<>();
+        expectedResult.put(key, AttributeValue.builder().s(value).build());
+        expectedResult.put(otherField, AttributeValue.builder().s(otherValue).build());
+
+        assertThat(actualResult).containsAllEntriesOf(expectedResult);
+        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+    }
+
+    @Test
+    void testPKIgnoredForUpdateAfter() {
+        String key = "key";
+        String value = "some_string";
+        String otherField = "other_field";
+        String otherValue = "other_value";
+        Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
+
+        // Create a Row with two fields - "key" and "otherField".  "key" is the primary key.
+        // For an UPDATE_BEFORE request, all fields should be included regardless of the Primary Key.
+        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(dataType, primaryKeys);
+        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        rowData.setRowKind(RowKind.UPDATE_AFTER);
+
+        Map<String, AttributeValue> actualResult =
+                rowDataToAttributeValueConverter.convertRowData(rowData);
+        Map<String, AttributeValue> expectedResult = new HashMap<>();
+        expectedResult.put(key, AttributeValue.builder().s(value).build());
+        expectedResult.put(otherField, AttributeValue.builder().s(otherValue).build());
+
+        assertThat(actualResult).containsAllEntriesOf(expectedResult);
+        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+    }
+
     private RowData createElement(Object value) {
         GenericRowData element = new GenericRowData(1);
         element.setField(0, value);
+        return element;
+    }
+
+    private RowData createElementWithMultipleFields(Object... values) {
+        GenericRowData element = new GenericRowData(values.length);
+        for (int i = 0; i < values.length; i++) {
+            element.setField(i, values[i]);
+        }
         return element;
     }
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
@@ -561,11 +561,17 @@ public class RowDataToAttributeValueConverterTest {
         Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
 
         // Create a Row with two fields - "key" and "otherField".  "key" is the single primary key.
-        // For a Delete request, only "key" should be included in the expectedResult, and not "otherField".
-        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        // For a Delete request, only "key" should be included in the expectedResult, and not
+        // "otherField".
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(key, DataTypes.STRING()),
+                        DataTypes.FIELD(otherField, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
                 new RowDataToAttributeValueConverter(dataType, primaryKeys);
-        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        RowData rowData =
+                createElementWithMultipleFields(
+                        StringData.fromString(value), StringData.fromString(otherValue));
         rowData.setRowKind(RowKind.DELETE);
 
         Map<String, AttributeValue> actualResult =
@@ -591,15 +597,20 @@ public class RowDataToAttributeValueConverterTest {
 
         // Create a Row with three fields - "key", "additional_key", and "otherField".
         // "key" and "additional_key" make up the composite primary key.
-        // For a Delete request, only "key" and "additional_key" should be included in the expectedResult, and not "otherField".
-        DataType dataType = DataTypes.ROW(
-                DataTypes.FIELD(key, DataTypes.STRING()),
-                DataTypes.FIELD(additionalKey, DataTypes.STRING()),
-                DataTypes.FIELD(otherField, DataTypes.STRING()));
+        // For a Delete request, only "key" and "additional_key" should be included in the
+        // expectedResult, and not "otherField".
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(key, DataTypes.STRING()),
+                        DataTypes.FIELD(additionalKey, DataTypes.STRING()),
+                        DataTypes.FIELD(otherField, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
                 new RowDataToAttributeValueConverter(dataType, primaryKeys);
-        RowData rowData = createElementWithMultipleFields(
-                StringData.fromString(value), StringData.fromString(additionalValue), StringData.fromString(otherValue));
+        RowData rowData =
+                createElementWithMultipleFields(
+                        StringData.fromString(value),
+                        StringData.fromString(additionalValue),
+                        StringData.fromString(otherValue));
         rowData.setRowKind(RowKind.DELETE);
 
         Map<String, AttributeValue> actualResult =
@@ -622,10 +633,15 @@ public class RowDataToAttributeValueConverterTest {
 
         // Create a Row with two fields - "key" and "otherField".  "key" is the primary key.
         // For an Insert request, all fields should be included regardless of the Primary Key.
-        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(key, DataTypes.STRING()),
+                        DataTypes.FIELD(otherField, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
                 new RowDataToAttributeValueConverter(dataType, primaryKeys);
-        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        RowData rowData =
+                createElementWithMultipleFields(
+                        StringData.fromString(value), StringData.fromString(otherValue));
         rowData.setRowKind(RowKind.INSERT);
 
         Map<String, AttributeValue> actualResult =
@@ -647,11 +663,17 @@ public class RowDataToAttributeValueConverterTest {
         Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
 
         // Create a Row with two fields - "key" and "otherField".  "key" is the primary key.
-        // For an UPDATE_BEFORE request, all fields should be included regardless of the Primary Key.
-        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()), DataTypes.FIELD(otherField, DataTypes.STRING()));
+        // For an UPDATE_BEFORE request, all fields should be included regardless of the Primary
+        // Key.
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(key, DataTypes.STRING()),
+                        DataTypes.FIELD(otherField, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
                 new RowDataToAttributeValueConverter(dataType, primaryKeys);
-        RowData rowData = createElementWithMultipleFields(StringData.fromString(value), StringData.fromString(otherValue));
+        RowData rowData =
+                createElementWithMultipleFields(
+                        StringData.fromString(value), StringData.fromString(otherValue));
         rowData.setRowKind(RowKind.UPDATE_AFTER);
 
         Map<String, AttributeValue> actualResult =

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
@@ -58,7 +58,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.CHAR(9)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -75,7 +75,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.VARCHAR(13)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -92,7 +92,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.STRING()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(StringData.fromString(value)));
@@ -109,7 +109,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.BOOLEAN()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -125,7 +125,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.DECIMAL(5, 4)));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(DecimalData.fromBigDecimal(value, 5, 4)));
@@ -142,7 +142,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.TINYINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -158,7 +158,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.SMALLINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -174,7 +174,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.INT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -190,7 +190,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.BIGINT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -206,7 +206,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.FLOAT()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -222,7 +222,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.DOUBLE()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createElement(value));
         Map<String, AttributeValue> expectedResult =
@@ -238,7 +238,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.TIMESTAMP()));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createElement(TimestampData.fromLocalDateTime(value)));
@@ -256,7 +256,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.STRING())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, StringData::fromString));
@@ -281,7 +281,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.BOOLEAN())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -309,7 +309,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.DECIMAL(1, 0))));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, d -> DecimalData.fromBigDecimal(d, 1, 0)));
@@ -338,7 +338,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TINYINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -366,7 +366,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.SMALLINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -393,7 +393,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.INT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -421,7 +421,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.BIGINT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -448,7 +448,7 @@ public class RowDataToAttributeValueConverterTest {
 
         DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.FLOAT())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -476,7 +476,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.DOUBLE())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(createArray(value, t -> t));
         Map<String, AttributeValue> expectedResult =
@@ -504,7 +504,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TIMESTAMP())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, TimestampData::fromLocalDateTime));
@@ -533,7 +533,7 @@ public class RowDataToAttributeValueConverterTest {
         DataType dataType =
                 DataTypes.ROW(DataTypes.FIELD(key, DataTypes.ARRAY(DataTypes.TIMESTAMP_LTZ())));
         RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
-                new RowDataToAttributeValueConverter(dataType, null);
+                new RowDataToAttributeValueConverter(dataType);
         Map<String, AttributeValue> actualResult =
                 rowDataToAttributeValueConverter.convertRowData(
                         createArray(value, TimestampData::fromInstant));
@@ -607,8 +607,7 @@ public class RowDataToAttributeValueConverterTest {
         Map<String, AttributeValue> expectedResult =
                 singletonMap(key, AttributeValue.builder().s(value).build());
 
-        assertThat(actualResult).containsAllEntriesOf(expectedResult);
-        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+        assertThat(actualResult).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
 
     @Test
@@ -647,8 +646,7 @@ public class RowDataToAttributeValueConverterTest {
         expectedResult.put(key, AttributeValue.builder().s(value).build());
         expectedResult.put(additionalKey, AttributeValue.builder().s(additionalValue).build());
 
-        assertThat(actualResult).containsAllEntriesOf(expectedResult);
-        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+        assertThat(actualResult).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
 
     @Test
@@ -678,8 +676,7 @@ public class RowDataToAttributeValueConverterTest {
         expectedResult.put(key, AttributeValue.builder().s(value).build());
         expectedResult.put(otherField, AttributeValue.builder().s(otherValue).build());
 
-        assertThat(actualResult).containsAllEntriesOf(expectedResult);
-        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+        assertThat(actualResult).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
 
     @Test
@@ -688,7 +685,7 @@ public class RowDataToAttributeValueConverterTest {
         String value = "some_string";
         String otherField = "other_field";
         String otherValue = "other_value";
-        Set<String> primaryKeys = new HashSet<>(Collections.singletonList(key));
+        Set<String> primaryKeys = Collections.singleton(key);
 
         // Create a Row with two fields - "key" and "otherField".  "key" is the primary key.
         // For an UPDATE_BEFORE request, all fields should be included regardless of the Primary
@@ -710,8 +707,7 @@ public class RowDataToAttributeValueConverterTest {
         expectedResult.put(key, AttributeValue.builder().s(value).build());
         expectedResult.put(otherField, AttributeValue.builder().s(otherValue).build());
 
-        assertThat(actualResult).containsAllEntriesOf(expectedResult);
-        assertThat(expectedResult).containsAllEntriesOf(actualResult);
+        assertThat(actualResult).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
 
     private RowData createElement(Object value) {

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
@@ -574,9 +574,11 @@ public class RowDataToAttributeValueConverterTest {
                         StringData.fromString(value), StringData.fromString(otherValue));
         rowData.setRowKind(RowKind.DELETE);
 
-        assertThrows(TableException.class, () -> {
-                rowDataToAttributeValueConverter.convertRowData(rowData);
-        });
+        assertThrows(
+                TableException.class,
+                () -> {
+                    rowDataToAttributeValueConverter.convertRowData(rowData);
+                });
     }
 
     void testDeleteOnlyPrimaryKey() {


### PR DESCRIPTION
## Purpose of the change

When `DynamoDbSink` is used with CDC sources, it fails to process DELETE records and throws
```
    org.apache.flink.connector.dynamodb.shaded.software.amazon.awssdk.services.dynamodb.model.DynamoDbException: The provided key element does not match the schema
```

This is due to `DynamoDbSinkWriter` passing the whole DynamoDb Item as key instead of the constructed primary key alone.

## Verifying this change
This change added tests and can be verified as follows:
- Added tests to `RowDataToAttributeValueConverterTest.java`:
  - `testDeleteOnlyPrimaryKey` - Ensures that for a `DELETE` request, only the (single) PK field is included
  - `testDeleteOnlyPrimaryKeys` - Ensures that for a `DELETE` request with a composite PK, both PK fields are included.
  - `testPKIgnoredForInsert` - Ensures that PK is ignored when an `INSERT` request is done, and all fields continue to be included as they have been in the past.
  - `testPKIgnoredForUpdateAfter` - Ensures that PK is ignored when an `UPDATE_AFTER` request is done, and all fields continue to be included as they have been in the past.

- Ran manual tests following the steps noted in https://issues.apache.org/jira/browse/FLINK-35500 under "Steps To Reproduce".   Running the SQL statement as described in Step 6 now properly runs a DELETE in DynamoDB.

 
## Significant changes
Previously, the `PRIMARY KEY` field had no significance for a DynamoDB Sink via Table API.   Now, the `PRIMARY KEY` is required when processing a CDC stream that contains `DELETES`.    This is not a 'breaking change' because the previous behavior for processing a CDC stream containing `DELETES` was already a failure (`The provided key element does not match the schema`).  This change now provides a clear exception informing users to specify a Primary Key to avoid that failure.   To clarify this change, the PR contains updates to the Connector documentation.