### PR TITLE
[FLINK-34023][Connectors/Kinesis] Expose configuration of sink client retries

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseConfigConstants.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseConfigConstants.java
@@ -29,4 +29,7 @@ public class KinesisFirehoseConfigConstants {
     /** Firehose identifier for user agent prefix. */
     public static final String FIREHOSE_CLIENT_USER_AGENT_PREFIX =
             "aws.firehose.client.user-agent-prefix";
+
+    public static final String FIREHOSE_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS =
+            "aws.firehose.client.retry-strategy.max-attempts";
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
@@ -78,7 +78,8 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 httpClient,
                 FirehoseAsyncClient.builder(),
                 KinesisFirehoseConfigConstants.BASE_FIREHOSE_USER_AGENT_PREFIX_FORMAT,
-                KinesisFirehoseConfigConstants.FIREHOSE_CLIENT_USER_AGENT_PREFIX);
+                KinesisFirehoseConfigConstants.FIREHOSE_CLIENT_USER_AGENT_PREFIX,
+                KinesisFirehoseConfigConstants.FIREHOSE_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
     }
 
     private static final AWSExceptionHandler FIREHOSE_EXCEPTION_HANDLER =

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsConfigConstants.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsConfigConstants.java
@@ -29,4 +29,7 @@ public class KinesisStreamsConfigConstants {
     /** Kinesis identifier for user agent prefix. */
     public static final String KINESIS_CLIENT_USER_AGENT_PREFIX =
             "aws.kinesis.client.user-agent-prefix";
+
+    public static final String KINESIS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS =
+            "aws.kinesis.client.retry-strategy.max-attempts";
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
@@ -180,7 +180,8 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
                 httpClient,
                 KinesisAsyncClient.builder(),
                 KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,
-                KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX);
+                KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
+                KinesisStreamsConfigConstants.KINESIS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
     }
 
     private static RateLimitingStrategy buildRateLimitingStrategy(

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -207,7 +207,8 @@ public class KinesisStreamsSource<T>
                         httpClient,
                         KinesisClient.builder(),
                         KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,
-                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX);
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
         return new KinesisStreamProxy(kinesisClient, httpClient);
     }
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbConfigConstants.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbConfigConstants.java
@@ -29,4 +29,7 @@ public class DynamoDbConfigConstants {
     /** DynamoDb identifier for user agent prefix. */
     public static final String DYNAMODB_CLIENT_USER_AGENT_PREFIX =
             "aws.dynamodb.client.user-agent-prefix";
+
+    public static final String DYNAMODB_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS =
+            "aws.dynamodb.client.retry-strategy.max-attempts";
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/client/DynamoDbAsyncClientProvider.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/client/DynamoDbAsyncClientProvider.java
@@ -70,6 +70,7 @@ public class DynamoDbAsyncClientProvider implements SdkClientProvider<DynamoDbAs
                 httpClient,
                 DynamoDbAsyncClient.builder(),
                 DynamoDbConfigConstants.BASE_DYNAMODB_USER_AGENT_PREFIX_FORMAT,
-                DynamoDbConfigConstants.DYNAMODB_CLIENT_USER_AGENT_PREFIX);
+                DynamoDbConfigConstants.DYNAMODB_CLIENT_USER_AGENT_PREFIX,
+                DynamoDbConfigConstants.DYNAMODB_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/DynamoDbStreamsSource.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/DynamoDbStreamsSource.java
@@ -199,7 +199,9 @@ public class DynamoDbStreamsSource<T>
                         DynamoDbStreamsClient.builder(),
                         DynamodbStreamsSourceConfigConstants
                                 .BASE_DDB_STREAMS_USER_AGENT_PREFIX_FORMAT,
-                        DynamodbStreamsSourceConfigConstants.DDB_STREAMS_CLIENT_USER_AGENT_PREFIX);
+                        DynamodbStreamsSourceConfigConstants.DDB_STREAMS_CLIENT_USER_AGENT_PREFIX,
+                        DynamodbStreamsSourceConfigConstants
+                                .DDB_STREAMS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
         return new DynamoDbStreamsProxy(dynamoDbStreamsClient, httpClient);
     }
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/config/DynamodbStreamsSourceConfigConstants.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/config/DynamodbStreamsSourceConfigConstants.java
@@ -49,4 +49,7 @@ public class DynamodbStreamsSourceConfigConstants {
     /** DynamoDb Streams identifier for user agent prefix. */
     public static final String DDB_STREAMS_CLIENT_USER_AGENT_PREFIX =
             "aws.dynamodbstreams.client.user-agent-prefix";
+
+    public static final String DDB_STREAMS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS =
+            "aws.dynamodbstreams.client.retry-strategy.max-attempts";
 }

--- a/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Factory.java
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Factory.java
@@ -74,7 +74,8 @@ public class KinesisProxyV2Factory {
                         asyncHttpClient,
                         KinesisAsyncClient.builder(),
                         KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,
-                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX);
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
 
         return new KinesisProxyAsyncV2(asyncClient, asyncHttpClient, configuration);
     }
@@ -108,7 +109,8 @@ public class KinesisProxyV2Factory {
                         httpClient,
                         KinesisClient.builder(),
                         KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,
-                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX);
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
+                        KinesisStreamsConfigConstants.KINESIS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS);
 
         return new KinesisProxySyncV2(client, httpClient, configuration, BACKOFF);
     }

--- a/flink-connector-aws/flink-connector-sqs/src/main/java/org/apache/flink/connector/sqs/sink/SqsConfigConstants.java
+++ b/flink-connector-aws/flink-connector-sqs/src/main/java/org/apache/flink/connector/sqs/sink/SqsConfigConstants.java
@@ -36,4 +36,11 @@ public class SqsConfigConstants {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("SQS identifier for user agent prefix.");
+
+    public static final ConfigOption<Integer> SQS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS =
+            ConfigOptions.key("aws.sqs.client.retry-strategy.max-attempts")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum number of attempts that the retry strategy will allow.");
 }

--- a/flink-connector-aws/flink-connector-sqs/src/main/java/org/apache/flink/connector/sqs/sink/client/SqsAsyncClientProvider.java
+++ b/flink-connector-aws/flink-connector-sqs/src/main/java/org/apache/flink/connector/sqs/sink/client/SqsAsyncClientProvider.java
@@ -59,6 +59,7 @@ public class SqsAsyncClientProvider implements SdkClientProvider<SqsAsyncClient>
                 httpClient,
                 SqsAsyncClient.builder(),
                 SqsConfigConstants.BASE_SQS_USER_AGENT_PREFIX_FORMAT.key(),
-                SqsConfigConstants.SQS_CLIENT_USER_AGENT_PREFIX.key());
+                SqsConfigConstants.SQS_CLIENT_USER_AGENT_PREFIX.key(),
+                SqsConfigConstants.SQS_CLIENT_RETRY_STRATEGY_MAX_ATTEMPTS.key());
     }
 }


### PR DESCRIPTION
## Purpose of the change

- Expose configuration of sink client retries. 
- The consumer side already exposes client retry configuration like [flink.shard.getrecords.maxretries](https://nightlies.apache.org/flink/flink-docs-stable/api/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.html#SHARD_GETRECORDS_RETRIES) but the sink producer side currently lacks similar config for PutRecords.
- The AWS SDK has deprecated RetryPolicy in favour of RetryStrategy, meaning that the old "num-retries" config is being replaced with "max-attempts" (which includes the initial attempt)
- This PR exposes the most important max-attempt config, but not the complete retry strategy, since representing all the various types of (jittered, linear, exponential etc) strategies with universal config keys is non-trivial.

## Verifying this change

- *Modified existing unit tests*
- *Added unit tests*


## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [X] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented): **not documented**
