### PR TITLE
[FLINK-36138] Add a message to KinesisStreamsSource null checks

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -97,18 +97,16 @@ public class KinesisStreamsSource<T>
             KinesisShardAssigner kinesisShardAssigner,
             boolean preserveShardOrder) {
         Preconditions.checkNotNull(
-                streamArn,
-                "No stream ARN was supplied to the KinesisStreamsSource builder.");
+                streamArn, "No stream ARN was supplied to the KinesisStreamsSource.");
         Preconditions.checkArgument(!streamArn.isEmpty(), "stream ARN cannot be empty string");
         Preconditions.checkNotNull(
-                sourceConfig,
-                "No source config was supplied to the KinesisStreamsSource builder.");
+                sourceConfig, "No source config was supplied to the KinesisStreamsSource.");
         Preconditions.checkNotNull(
                 deserializationSchema,
-                "No KinesisDeserializationSchema was supplied to the KinesisStreamsSource builder.");
+                "No KinesisDeserializationSchema was supplied to the KinesisStreamsSource.");
         Preconditions.checkNotNull(
                 kinesisShardAssigner,
-                "No KinesisShardAssigner was supplied to the  KinesisStreamsSource builder.");
+                "No KinesisShardAssigner was supplied to the KinesisStreamsSource.");
         this.streamArn = streamArn;
         this.sourceConfig = sourceConfig;
         this.deserializationSchema = deserializationSchema;

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -96,11 +96,19 @@ public class KinesisStreamsSource<T>
             KinesisDeserializationSchema<T> deserializationSchema,
             KinesisShardAssigner kinesisShardAssigner,
             boolean preserveShardOrder) {
-        Preconditions.checkNotNull(streamArn);
+        Preconditions.checkNotNull(
+                streamArn,
+                "No stream ARN was supplied to the KinesisStreamsSource builder.");
         Preconditions.checkArgument(!streamArn.isEmpty(), "stream ARN cannot be empty string");
-        Preconditions.checkNotNull(sourceConfig);
-        Preconditions.checkNotNull(deserializationSchema);
-        Preconditions.checkNotNull(kinesisShardAssigner);
+        Preconditions.checkNotNull(
+                sourceConfig,
+                "No source config was supplied to the KinesisStreamsSource builder.");
+        Preconditions.checkNotNull(
+                deserializationSchema,
+                "No KinesisDeserializationSchema was supplied to the KinesisStreamsSource builder.");
+        Preconditions.checkNotNull(
+                kinesisShardAssigner,
+                "No KinesisShardAssigner was supplied to the  KinesisStreamsSource builder.");
         this.streamArn = streamArn;
         this.sourceConfig = sourceConfig;
         this.deserializationSchema = deserializationSchema;


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Assist users who mistakenly provide null values to the KinesisStreamsSource by indicating which values were null. This enhances usability, as users no longer need to inspect the KinesisStreamsSource code to identify the issue when the specific null value is pointed out.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

- Added the errorMessage parameter to Preconditions.checkNotNull invocations

## Significant changes
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
