### PR TITLE
[FLINK-36229][Connectors/AWS] Port SingleThreadMultiplexSourceReaderB…

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kinesis.source.event.SplitsFinishedEvent;
 import org.apache.flink.connector.kinesis.source.metrics.KinesisShardMetrics;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
@@ -53,13 +51,12 @@ public class KinesisStreamsSourceReader<T>
     private final Map<String, KinesisShardMetrics> shardMetricGroupMap;
 
     public KinesisStreamsSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue,
             SingleThreadFetcherManager<Record, KinesisShardSplit> splitFetcherManager,
             RecordEmitter<Record, T, KinesisShardSplitState> recordEmitter,
             Configuration config,
             SourceReaderContext context,
             Map<String, KinesisShardMetrics> shardMetricGroupMap) {
-        super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+        super(splitFetcherManager, recordEmitter, config, context);
         this.shardMetricGroupMap = shardMetricGroupMap;
     }
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
@@ -20,9 +20,7 @@ package org.apache.flink.connector.kinesis.source.reader;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kinesis.source.event.SplitsFinishedEvent;
 import org.apache.flink.connector.kinesis.source.metrics.KinesisShardMetrics;
 import org.apache.flink.connector.kinesis.source.model.TestData;
@@ -36,7 +34,6 @@ import org.apache.flink.metrics.testutils.MetricListener;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.kinesis.model.Record;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,17 +61,13 @@ class KinesisStreamsSourceReaderTest {
         Supplier<PollingKinesisShardSplitReader> splitReaderSupplier =
                 () -> new PollingKinesisShardSplitReader(testStreamProxy, shardMetricGroupMap);
 
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
-
         testingReaderContext =
                 KinesisContextProvider.KinesisTestingContext.getKinesisTestingContext(
                         metricListener);
         sourceReader =
                 new KinesisStreamsSourceReader<>(
-                        elementsQueue,
                         new SingleThreadFetcherManager<>(
-                                elementsQueue, splitReaderSupplier::get, new Configuration()),
+                                splitReaderSupplier::get, new Configuration()),
                         new KinesisStreamsRecordEmitter<>(null),
                         new Configuration(),
                         testingReaderContext,

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReader.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReader.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.dynamodb.source.enumerator.event.SplitsFinishedEvent;
 import org.apache.flink.connector.dynamodb.source.metrics.DynamoDbStreamsShardMetrics;
 import org.apache.flink.connector.dynamodb.source.split.DynamoDbStreamsShardSplit;
@@ -53,13 +51,12 @@ public class DynamoDbStreamsSourceReader<T>
     private final Map<String, DynamoDbStreamsShardMetrics> shardMetricGroupMap;
 
     public DynamoDbStreamsSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue,
             SingleThreadFetcherManager<Record, DynamoDbStreamsShardSplit> splitFetcherManager,
             RecordEmitter<Record, T, DynamoDbStreamsShardSplitState> recordEmitter,
             Configuration config,
             SourceReaderContext context,
             Map<String, DynamoDbStreamsShardMetrics> shardMetricGroupMap) {
-        super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+        super(splitFetcherManager, recordEmitter, config, context);
         this.shardMetricGroupMap = shardMetricGroupMap;
     }
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReaderTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReaderTest.java
@@ -20,9 +20,7 @@ package org.apache.flink.connector.dynamodb.source.reader;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.dynamodb.source.enumerator.event.SplitsFinishedEvent;
 import org.apache.flink.connector.dynamodb.source.metrics.DynamoDbStreamsShardMetrics;
 import org.apache.flink.connector.dynamodb.source.proxy.StreamProxy;
@@ -36,7 +34,6 @@ import org.apache.flink.runtime.operators.testutils.TestData;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.dynamodb.model.Record;
 
 import java.util.Collections;
 import java.util.List;
@@ -67,16 +64,12 @@ class DynamoDbStreamsSourceReaderTest {
                         new PollingDynamoDbStreamsShardSplitReader(
                                 testStreamProxy, shardMetricGroupMap);
 
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<Record>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
-
         testingReaderContext =
                 DynamoDbStreamsContextProvider.DynamoDbStreamsTestingContext
                         .getDynamoDbStreamsTestingContext(metricListener);
         sourceReader =
                 new DynamoDbStreamsSourceReader<>(
-                        elementsQueue,
-                        new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                        new SingleThreadFetcherManager<>(splitReaderSupplier::get),
                         new DynamoDbStreamsRecordEmitter<>(null),
                         new Configuration(),
                         testingReaderContext,


### PR DESCRIPTION
…ase to new undeprecated interfaces

## Purpose of the change
Update the interfaces used for `SingleThreadMultiplexSourceReaderBase` and `SingleThreadFetcherManager` to the undeprecated interfaces. The new interface has been available since 1.18, and old interfaces were deprecated since 1.19.

## Verifying this change
This change is trivial, no-op, with no difference in expected functionality.
This functionality is already covered by existing tests, such as unit test.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
