### PR TITLE
[FLINK-31986][Connectors/Kinesis] Setup integration tests for FLIP-27 Kinesis source

### DIFF
--- a/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
+++ b/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
@@ -297,9 +297,8 @@ public class AWSGeneralUtil {
         return createAsyncHttpClient(configProperties, NettyNioAsyncHttpClient.builder());
     }
 
-    public static SdkAsyncHttpClient createAsyncHttpClient(
-            final Properties configProperties,
-            final NettyNioAsyncHttpClient.Builder httpClientBuilder) {
+    @VisibleForTesting
+    static AttributeMap getSdkHttpConfigurationOptions(final Properties configProperties) {
         final AttributeMap.Builder clientConfiguration =
                 AttributeMap.builder().put(SdkHttpConfigurationOption.TCP_KEEPALIVE, true);
 
@@ -335,7 +334,15 @@ public class AWSGeneralUtil {
                         protocol ->
                                 clientConfiguration.put(
                                         SdkHttpConfigurationOption.PROTOCOL, protocol));
-        return createAsyncHttpClient(clientConfiguration.build(), httpClientBuilder);
+
+        return clientConfiguration.build();
+    }
+
+    public static SdkAsyncHttpClient createAsyncHttpClient(
+            final Properties configProperties,
+            final NettyNioAsyncHttpClient.Builder httpClientBuilder) {
+        return createAsyncHttpClient(
+                getSdkHttpConfigurationOptions(configProperties), httpClientBuilder);
     }
 
     public static SdkAsyncHttpClient createAsyncHttpClient(
@@ -353,6 +360,12 @@ public class AWSGeneralUtil {
                                 .initialWindowSize(INITIAL_WINDOW_SIZE_BYTES)
                                 .build());
         return httpClientBuilder.buildWithDefaults(config.merge(HTTP_CLIENT_DEFAULTS));
+    }
+
+    public static SdkHttpClient createSyncHttpClient(
+            final Properties configProperties, final ApacheHttpClient.Builder httpClientBuilder) {
+        return createSyncHttpClient(
+                getSdkHttpConfigurationOptions(configProperties), httpClientBuilder);
     }
 
     public static SdkHttpClient createSyncHttpClient(

--- a/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/testutils/AWSServicesTestUtils.java
+++ b/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/testutils/AWSServicesTestUtils.java
@@ -115,7 +115,11 @@ public class AWSServicesTestUtils {
     }
 
     public static void createIAMRole(IamClient iam, String roleName) {
-        CreateRoleRequest request = CreateRoleRequest.builder().roleName(roleName).build();
+        CreateRoleRequest request =
+                CreateRoleRequest.builder()
+                        .roleName(roleName)
+                        .assumeRolePolicyDocument("{}")
+                        .build();
 
         iam.createRole(request);
     }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -123,6 +123,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -57,7 +57,6 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
-import software.amazon.awssdk.utils.AttributeMap;
 
 import java.time.Duration;
 import java.util.Map;
@@ -193,10 +192,6 @@ public class KinesisStreamsSource<T>
     }
 
     private KinesisStreamProxy createKinesisStreamProxy(Configuration consumerConfig) {
-        SdkHttpClient httpClient =
-                AWSGeneralUtil.createSyncHttpClient(
-                        AttributeMap.builder().build(), ApacheHttpClient.builder());
-
         String region =
                 AWSGeneralUtil.getRegionFromArn(streamArn)
                         .orElseThrow(
@@ -218,6 +213,10 @@ public class KinesisStreamsSource<T>
                                         sourceConfig.get(
                                                 AWSConfigOptions
                                                         .RETRY_STRATEGY_MAX_ATTEMPTS_OPTION)));
+
+        SdkHttpClient httpClient =
+                AWSGeneralUtil.createSyncHttpClient(
+                        kinesisClientProperties, ApacheHttpClient.builder());
 
         AWSGeneralUtil.validateAwsCredentials(kinesisClientProperties);
         KinesisClient kinesisClient =

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
@@ -1,0 +1,220 @@
+package org.apache.flink.connector.kinesis.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
+import org.apache.flink.connector.aws.testutils.LocalstackContainer;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
+import software.amazon.awssdk.services.kinesis.model.StreamStatus;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ENDPOINT;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_REGION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.HTTP_PROTOCOL_VERSION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL_CERTIFICATES;
+
+/** IT cases for using {@code KinesisStreamsSource} using a localstack container. */
+@Testcontainers
+@ExtendWith(MiniClusterExtension.class)
+public class KinesisStreamsSourceITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KinesisStreamsSourceITCase.class);
+    private static final String LOCALSTACK_DOCKER_IMAGE_VERSION = "localstack/localstack:3.7.2";
+
+    @Container
+    private static final LocalstackContainer MOCK_KINESIS_CONTAINER =
+            new LocalstackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE_VERSION));
+
+    private StreamExecutionEnvironment env;
+    private SdkHttpClient httpClient;
+    private KinesisClient kinesisClient;
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        httpClient = AWSServicesTestUtils.createHttpClient();
+        kinesisClient =
+                AWSServicesTestUtils.createAwsSyncClient(
+                        MOCK_KINESIS_CONTAINER.getEndpoint(), httpClient, KinesisClient.builder());
+    }
+
+    @AfterEach
+    void teardown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        AWSGeneralUtil.closeResources(httpClient, kinesisClient);
+    }
+
+    @Test
+    void nonExistentStreamShouldResultInFailure() {
+        Assertions.assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(
+                        () ->
+                                new Scenario()
+                                        .localstackStreamName("stream-exists")
+                                        .withSourceConnectionStreamArn(
+                                                "arn:aws:kinesis:ap-southeast-1:000000000000:stream/stream-not-exists")
+                                        .runScenario())
+                .withStackTraceContaining(
+                        "Stream arn arn:aws:kinesis:ap-southeast-1:000000000000:stream/stream-not-exists not found");
+    }
+
+    @Test
+    void validStreamIsConsumed() throws Exception {
+        new Scenario()
+                .localstackStreamName("valid-stream")
+                .withSourceConnectionStreamArn(
+                        "arn:aws:kinesis:ap-southeast-1:000000000000:stream/valid-stream")
+                .runScenario();
+    }
+
+    private Configuration getDefaultConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.setString(AWS_ENDPOINT, MOCK_KINESIS_CONTAINER.getEndpoint());
+        configuration.setString(AWS_ACCESS_KEY_ID, "accessKeyId");
+        configuration.setString(AWS_SECRET_ACCESS_KEY, "secretAccessKey");
+        configuration.setString(AWS_REGION, Region.AP_SOUTHEAST_1.toString());
+        configuration.setString(TRUST_ALL_CERTIFICATES, "true");
+        configuration.setString(HTTP_PROTOCOL_VERSION, "HTTP1_1");
+        return configuration;
+    }
+
+    private class Scenario {
+        private final int expectedElements = 1000;
+        private String localstackStreamName = null;
+        private String sourceConnectionStreamArn;
+        private final Configuration configuration =
+                KinesisStreamsSourceITCase.this.getDefaultConfiguration();
+
+        public void runScenario() throws Exception {
+            if (localstackStreamName != null) {
+                prepareStream(localstackStreamName);
+            }
+
+            putRecords(localstackStreamName, expectedElements);
+
+            KinesisStreamsSource<String> kdsSource =
+                    KinesisStreamsSource.<String>builder()
+                            .setStreamArn(sourceConnectionStreamArn)
+                            .setSourceConfig(configuration)
+                            .setDeserializationSchema(new SimpleStringSchema())
+                            .build();
+
+            List<String> result =
+                    env.fromSource(kdsSource, WatermarkStrategy.noWatermarks(), "Kinesis source")
+                            .returns(TypeInformation.of(String.class))
+                            .executeAndCollect(expectedElements);
+
+            Assertions.assertThat(result.size()).isEqualTo(expectedElements);
+        }
+
+        public Scenario withSourceConnectionStreamArn(String sourceConnectionStreamArn) {
+            this.sourceConnectionStreamArn = sourceConnectionStreamArn;
+            return this;
+        }
+
+        public Scenario localstackStreamName(String localstackStreamName) {
+            this.localstackStreamName = localstackStreamName;
+            return this;
+        }
+
+        private void prepareStream(String streamName) throws Exception {
+            final RateLimiter rateLimiter =
+                    RateLimiterBuilder.newBuilder()
+                            .withRate(1, SECONDS)
+                            .withConstantThroughput()
+                            .build();
+
+            kinesisClient.createStream(
+                    CreateStreamRequest.builder().streamName(streamName).shardCount(1).build());
+
+            Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+            while (!rateLimiter.getWhenReady(() -> streamExists(streamName))) {
+                if (deadline.isOverdue()) {
+                    throw new RuntimeException("Failed to create stream within time");
+                }
+            }
+        }
+
+        private void putRecords(String streamName, int numRecords) {
+            List<byte[]> messages =
+                    IntStream.range(0, numRecords)
+                            .mapToObj(String::valueOf)
+                            .map(String::getBytes)
+                            .collect(Collectors.toList());
+
+            for (List<byte[]> partition : Lists.partition(messages, 500)) {
+                List<PutRecordsRequestEntry> entries =
+                        partition.stream()
+                                .map(
+                                        msg ->
+                                                PutRecordsRequestEntry.builder()
+                                                        .partitionKey("fakePartitionKey")
+                                                        .data(SdkBytes.fromByteArray(msg))
+                                                        .build())
+                                .collect(Collectors.toList());
+                PutRecordsRequest requests =
+                        PutRecordsRequest.builder().streamName(streamName).records(entries).build();
+                PutRecordsResponse putRecordResult = kinesisClient.putRecords(requests);
+                for (PutRecordsResultEntry result : putRecordResult.records()) {
+                    LOG.debug("Added record: {}", result.sequenceNumber());
+                }
+            }
+        }
+
+        private boolean streamExists(final String streamName) {
+            try {
+                return kinesisClient
+                                .describeStream(
+                                        DescribeStreamRequest.builder()
+                                                .streamName(streamName)
+                                                .build())
+                                .streamDescription()
+                                .streamStatus()
+                        == StreamStatus.ACTIVE;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Sets up Integrations tests for the FLIP-27 DataStreams API Kinesis source

## Verifying this change

This change added tests and can be verified as follows:

- *Added integration tests for end-to-end deployment*
- *Added unit tests*
