### PR TITLE
[FLINK-36428][Connectors/DynamoDB] DynamoDb Table API Sink fails when null value in the RowData

### DIFF
--- a/docs/content.zh/docs/connectors/table/dynamodb.md
+++ b/docs/content.zh/docs/connectors/table/dynamodb.md
@@ -236,6 +236,13 @@ Connector Options
       <td>Boolean</td>
       <td>Flag used for retrying failed requests. If set any request failure will not be retried and will fail the job.</td>
     </tr>
+    <tr>
+      <td><h5>sink.ignore-nulls</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Determines whether null values should be ignored in the sink. If set to true, null values are excluded from processing.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>

--- a/docs/content/docs/connectors/table/dynamodb.md
+++ b/docs/content/docs/connectors/table/dynamodb.md
@@ -236,6 +236,13 @@ Connector Options
       <td>Boolean</td>
       <td>Flag used for retrying failed requests. If set any request failure will not be retried and will fail the job.</td>
     </tr>
+    <tr>
+      <td><h5>sink.ignore-nulls</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Determines whether null values should be ignored in the sink. If set to true, null values are excluded from processing.</td>
+    </tr>
     </tbody>
     <thead>
     <tr>

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConfiguration.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.FAIL_ON_ERROR;
+import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.IGNORE_NULLS;
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.TABLE_NAME;
 
 /** DynamoDb specific configuration. */
@@ -51,6 +52,10 @@ public class DynamoDbConfiguration {
 
     public boolean getFailOnError() {
         return tableOptions.get(FAIL_ON_ERROR);
+    }
+
+    public boolean getIgnoreNulls() {
+        return tableOptions.get(IGNORE_NULLS);
     }
 
     public Properties getAsyncSinkProperties() {

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConnectorOptions.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbConnectorOptions.java
@@ -46,6 +46,13 @@ public class DynamoDbConnectorOptions {
                     .withDescription(
                             "Determines whether an exception should fail the job, otherwise failed requests are retried.");
 
+    public static final ConfigOption<Boolean> IGNORE_NULLS =
+            ConfigOptions.key("sink.ignore-nulls")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Determines whether null values should be ignored in the sink. If set to true, null values are excluded from processing.");
+
     private DynamoDbConnectorOptions() {
         // private constructor to prevent initialization of static class
     }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSink.java
@@ -48,6 +48,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
 
     private final String tableName;
     private final boolean failOnError;
+    private final boolean ignoreNulls;
     private final Properties dynamoDbClientProperties;
     private final DataType physicalDataType;
     private final Set<String> overwriteByPartitionKeys;
@@ -60,6 +61,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
             @Nullable Long maxTimeInBufferMS,
             String tableName,
             boolean failOnError,
+            boolean ignoreNulls,
             Properties dynamoDbClientProperties,
             DataType physicalDataType,
             Set<String> overwriteByPartitionKeys) {
@@ -71,6 +73,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                 maxTimeInBufferMS);
         this.tableName = tableName;
         this.failOnError = failOnError;
+        this.ignoreNulls = ignoreNulls;
         this.dynamoDbClientProperties = dynamoDbClientProperties;
         this.physicalDataType = physicalDataType;
         this.overwriteByPartitionKeys = overwriteByPartitionKeys;
@@ -89,7 +92,8 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                         .setFailOnError(failOnError)
                         .setOverwriteByPartitionKeys(new ArrayList<>(overwriteByPartitionKeys))
                         .setDynamoDbProperties(dynamoDbClientProperties)
-                        .setElementConverter(new RowDataElementConverter(physicalDataType));
+                        .setElementConverter(
+                                new RowDataElementConverter(physicalDataType, ignoreNulls));
 
         addAsyncOptionsToSinkBuilder(builder);
 
@@ -106,6 +110,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                 maxTimeInBufferMS,
                 tableName,
                 failOnError,
+                ignoreNulls,
                 dynamoDbClientProperties,
                 physicalDataType,
                 overwriteByPartitionKeys);
@@ -133,6 +138,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                     DynamoDbWriteRequest, DynamoDbDynamicTableSinkBuilder> {
         private String tableName;
         private boolean failOnError;
+        private boolean ignoreNulls;
         private Properties dynamoDbClientProperties;
         private DataType physicalDataType;
         private Set<String> overwriteByPartitionKeys;
@@ -144,6 +150,11 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
 
         public DynamoDbDynamicTableSinkBuilder setFailOnError(boolean failOnError) {
             this.failOnError = failOnError;
+            return this;
+        }
+
+        public DynamoDbDynamicTableSinkBuilder setIgnoreNulls(boolean ignoreNulls) {
+            this.ignoreNulls = ignoreNulls;
             return this;
         }
 
@@ -174,6 +185,7 @@ public class DynamoDbDynamicSink extends AsyncDynamicTableSink<DynamoDbWriteRequ
                     getMaxTimeInBufferMS(),
                     tableName,
                     failOnError,
+                    ignoreNulls,
                     dynamoDbClientProperties,
                     physicalDataType,
                     overwriteByPartitionKeys);

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactory.java
@@ -52,6 +52,7 @@ public class DynamoDbDynamicSinkFactory extends AsyncDynamicTableSinkFactory {
                 DynamoDbDynamicSink.builder()
                         .setTableName(dynamoDbConfiguration.getTableName())
                         .setFailOnError(dynamoDbConfiguration.getFailOnError())
+                        .setIgnoreNulls(dynamoDbConfiguration.getIgnoreNulls())
                         .setPhysicalDataType(
                                 catalogTable.getResolvedSchema().toPhysicalRowDataType())
                         .setOverwriteByPartitionKeys(new HashSet<>(catalogTable.getPartitionKeys()))

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataElementConverter.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.DataType;
 @Internal
 public class RowDataElementConverter implements ElementConverter<RowData, DynamoDbWriteRequest> {
 
+    private boolean ignoreNulls = false;
     private final DataType physicalDataType;
     private transient RowDataToAttributeValueConverter rowDataToAttributeValueConverter;
 
@@ -44,11 +45,18 @@ public class RowDataElementConverter implements ElementConverter<RowData, Dynamo
                 new RowDataToAttributeValueConverter(physicalDataType);
     }
 
+    public RowDataElementConverter(DataType physicalDataType, boolean ignoreNulls) {
+        this.ignoreNulls = ignoreNulls;
+        this.physicalDataType = physicalDataType;
+        this.rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(physicalDataType, ignoreNulls);
+    }
+
     @Override
     public DynamoDbWriteRequest apply(RowData element, SinkWriter.Context context) {
         if (rowDataToAttributeValueConverter == null) {
             rowDataToAttributeValueConverter =
-                    new RowDataToAttributeValueConverter(physicalDataType);
+                    new RowDataToAttributeValueConverter(physicalDataType, ignoreNulls);
         }
 
         DynamoDbWriteRequest.Builder builder =

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java
@@ -43,14 +43,21 @@ public class RowDataToAttributeValueConverter {
 
     private final DataType physicalDataType;
     private final TableSchema<RowData> tableSchema;
+    private boolean ignoreNulls = false;
 
     public RowDataToAttributeValueConverter(DataType physicalDataType) {
         this.physicalDataType = physicalDataType;
         this.tableSchema = createTableSchema();
     }
 
+    public RowDataToAttributeValueConverter(DataType physicalDataType, boolean ignoreNulls) {
+        this.physicalDataType = physicalDataType;
+        this.tableSchema = createTableSchema();
+        this.ignoreNulls = ignoreNulls;
+    }
+
     public Map<String, AttributeValue> convertRowData(RowData row) {
-        return tableSchema.itemToMap(row, false);
+        return tableSchema.itemToMap(row, ignoreNulls);
     }
 
     private StaticTableSchema<RowData> createTableSchema() {
@@ -85,7 +92,7 @@ public class RowDataToAttributeValueConverter {
                                         rowData ->
                                                 DataStructureConverters.getConverter(
                                                                 field.getDataType())
-                                                        .toExternal(
+                                                        .toExternalOrNull(
                                                                 fieldGetter.getFieldOrNull(
                                                                         rowData)))
                                 .setter(((rowData, t) -> {})));

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactoryTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/DynamoDbDynamicSinkFactoryTest.java
@@ -47,6 +47,7 @@ import static org.apache.flink.connector.base.table.AsyncSinkConnectorOptions.MA
 import static org.apache.flink.connector.base.table.AsyncSinkConnectorOptions.MAX_IN_FLIGHT_REQUESTS;
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.AWS_REGION;
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.FAIL_ON_ERROR;
+import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.IGNORE_NULLS;
 import static org.apache.flink.connector.dynamodb.table.DynamoDbConnectorOptions.TABLE_NAME;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,7 +138,10 @@ public class DynamoDbDynamicSinkFactoryTest {
     void testGoodTableSinkWithOptionalOptions() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions =
-                defaultSinkOptions().withTableOption(FAIL_ON_ERROR, "true").build();
+                defaultSinkOptions()
+                        .withTableOption(FAIL_ON_ERROR, "true")
+                        .withTableOption(IGNORE_NULLS, "true")
+                        .build();
         List<String> partitionKeys = Collections.singletonList("partition_key");
 
         // Construct actual sink
@@ -153,6 +157,7 @@ public class DynamoDbDynamicSinkFactoryTest {
                                 .setDynamoDbClientProperties(defaultSinkProperties())
                                 .setPhysicalDataType(sinkSchema.toPhysicalRowDataType())
                                 .setFailOnError(true)
+                                .setIgnoreNulls(true)
                                 .build();
 
         assertThat(actualSink).usingRecursiveComparison().isEqualTo(expectedSink);

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverterTest.java
@@ -62,6 +62,19 @@ public class RowDataToAttributeValueConverterTest {
     }
 
     @Test
+    void testCharNull() {
+        String key = "key";
+
+        DataType dataType = DataTypes.ROW(DataTypes.FIELD(key, DataTypes.CHAR(9)));
+        RowDataToAttributeValueConverter rowDataToAttributeValueConverter =
+                new RowDataToAttributeValueConverter(dataType, true);
+        Map<String, AttributeValue> actualResult =
+                rowDataToAttributeValueConverter.convertRowData(createElement(null));
+
+        assertThat(actualResult.isEmpty()).isEqualTo(true);
+    }
+
+    @Test
     void testVarChar() {
         String key = "key";
         String value = "some_var_char";


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Add an option `ignore-nulls` to determine whether to ignore null values, instead of [hardcoding](https://github.com/maoxingda/flink-connector-aws/blob/b681cfcd372a44a34c4e6c868cb8a69d50aac67c/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/table/RowDataToAttributeValueConverter.java#L53) it into the code.

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/178d049d-55f2-4dce-853e-cafdd56f2a08">


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment*
- *Added unit tests*
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [x] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
