### PR TITLE
[FLINK-36427] Multiple shard IT cases for KDS source

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReader.java
@@ -129,7 +129,10 @@ public class PollingKinesisShardSplitReader implements SplitReader<Record, Kines
                                 .get(getRecordsResponse.records().size() - 1)
                                 .sequenceNumber()));
 
-        assignedSplits.add(splitState);
+        if (!isComplete) {
+            assignedSplits.add(splitState);
+        }
+
         return new KinesisRecordsWithSplitIds(
                 getRecordsResponse.records().iterator(), splitState.getSplitId(), isComplete);
     }


### PR DESCRIPTION
## Purpose of the change

- Adds integrations test cases for multiple shards in FLIP-27 DataStreams API Kinesis source
- Fixes bug in closing assigned splits

## Verifying this change

This change added tests and can be verified as follows:

- *Added integration tests for end-to-end deployment*