### PR TITLE
[FLINK-36637] Fix ListShards for large KDS streams

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxy.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxy.java
@@ -76,7 +76,7 @@ public class KinesisStreamProxy implements StreamProxy {
             listShardsResponse =
                     kinesisClient.listShards(
                             ListShardsRequest.builder()
-                                    .streamARN(streamArn)
+                                    .streamARN(nextToken == null ? streamArn : null)
                                     .shardFilter(
                                             nextToken == null
                                                     ? startingPosition.getShardFilter()

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxyTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/proxy/KinesisStreamProxyTest.java
@@ -151,14 +151,14 @@ class KinesisStreamProxyTest {
                                 ListShardItem.builder()
                                         .validation(
                                                 getListShardRequestValidation(
-                                                        STREAM_ARN, null, "next-token-1"))
+                                                        null, null, "next-token-1"))
                                         .shards(expectedShards.subList(1, 2))
                                         .nextToken("next-token-2")
                                         .build(),
                                 ListShardItem.builder()
                                         .validation(
                                                 getListShardRequestValidation(
-                                                        STREAM_ARN, null, "next-token-2"))
+                                                        null, null, "next-token-2"))
                                         .shards(expectedShards.subList(2, 4))
                                         .nextToken(null)
                                         .build())
@@ -461,6 +461,9 @@ class KinesisStreamProxyTest {
                             .nextToken(nextToken)
                             .build();
             assertThat(req).isEqualTo(expectedReq);
+            if (nextToken != null) {
+                assertThat(streamArn).isNull();
+            }
         };
     }
 


### PR DESCRIPTION
## Purpose of the change

Fixes ListShards for Kinesis streams with large number of shards

## Verifying this change

This change is already covered by existing unit tests in `KinesisStreamProxyTest`
