### PR TITLE
[hotfix] Update NOTICE files to reflect the packaged dependencies

### DIFF
--- a/flink-connector-aws/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -8,12 +8,16 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - software.amazon.ion:ion-java:1.0.2
 - software.amazon.eventstream:eventstream:1.0.1
+- software.amazon.awssdk:checksums-spi:2.26.19
+- software.amazon.awssdk:checksums:2.26.19
 - software.amazon.awssdk:utils:2.26.19
 - software.amazon.awssdk:third-party-jackson-dataformat-cbor:2.26.19
 - software.amazon.awssdk:third-party-jackson-core:2.26.19
 - software.amazon.awssdk:sts:2.26.19
 - software.amazon.awssdk:sdk-core:2.26.19
 - software.amazon.awssdk:regions:2.26.19
+- software.amazon.awssdk:retries-spi:2.26.19
+- software.amazon.awssdk:retries:2.26.19
 - software.amazon.awssdk:protocol-core:2.26.19
 - software.amazon.awssdk:profiles:2.26.19
 - software.amazon.awssdk:netty-nio-client:2.26.19
@@ -21,6 +25,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:kinesis:2.26.19
 - software.amazon.awssdk:json-utils:2.26.19
 - software.amazon.awssdk:http-client-spi:2.26.19
+- software.amazon.awssdk:http-auth-aws:2.26.19
+- software.amazon.awssdk:http-auth-spi:2.26.19
+- software.amazon.awssdk:http-auth:2.26.19
+- software.amazon.awssdk:identity-spi:2.26.19
 - software.amazon.awssdk:endpoints-spi:2.26.19
 - software.amazon.awssdk:aws-query-protocol:2.26.19
 - software.amazon.awssdk:aws-json-protocol:2.26.19
@@ -61,7 +69,7 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:3.21.7
+- com.google.protobuf:protobuf-java:3.25.5
 
 This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).
 

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
@@ -7,17 +7,25 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- software.amazon.awssdk:checksums-spi:2.26.19
+- software.amazon.awssdk:checksums:2.26.19
 - software.amazon.awssdk:utils:2.26.19
 - software.amazon.awssdk:third-party-jackson-core:2.26.19
 - software.amazon.awssdk:sts:2.26.19
 - software.amazon.awssdk:sdk-core:2.26.19
 - software.amazon.awssdk:regions:2.26.19
+- software.amazon.awssdk:retries-spi:2.26.19
+- software.amazon.awssdk:retries:2.26.19
 - software.amazon.awssdk:protocol-core:2.26.19
 - software.amazon.awssdk:profiles:2.26.19
 - software.amazon.awssdk:netty-nio-client:2.26.19
 - software.amazon.awssdk:metrics-spi:2.26.19
 - software.amazon.awssdk:json-utils:2.26.19
 - software.amazon.awssdk:http-client-spi:2.26.19
+- software.amazon.awssdk:http-auth-aws:2.26.19
+- software.amazon.awssdk:http-auth-spi:2.26.19
+- software.amazon.awssdk:http-auth:2.26.19
+- software.amazon.awssdk:identity-spi:2.26.19
 - software.amazon.awssdk:firehose:2.26.19
 - software.amazon.awssdk:endpoints-spi:2.26.19
 - software.amazon.awssdk:aws-query-protocol:2.26.19

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
@@ -7,12 +7,16 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- software.amazon.awssdk:checksums-spi:2.26.19
+- software.amazon.awssdk:checksums:2.26.19
 - software.amazon.awssdk:utils:2.26.19
 - software.amazon.awssdk:third-party-jackson-dataformat-cbor:2.26.19
 - software.amazon.awssdk:third-party-jackson-core:2.26.19
 - software.amazon.awssdk:sts:2.26.19
 - software.amazon.awssdk:sdk-core:2.26.19
 - software.amazon.awssdk:regions:2.26.19
+- software.amazon.awssdk:retries-spi:2.26.19
+- software.amazon.awssdk:retries:2.26.19
 - software.amazon.awssdk:protocol-core:2.26.19
 - software.amazon.awssdk:profiles:2.26.19
 - software.amazon.awssdk:netty-nio-client:2.26.19
@@ -20,6 +24,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:kinesis:2.26.19
 - software.amazon.awssdk:json-utils:2.26.19
 - software.amazon.awssdk:http-client-spi:2.26.19
+- software.amazon.awssdk:http-auth-aws:2.26.19
+- software.amazon.awssdk:http-auth-spi:2.26.19
+- software.amazon.awssdk:http-auth:2.26.19
+- software.amazon.awssdk:identity-spi:2.26.19
 - software.amazon.awssdk:endpoints-spi:2.26.19
 - software.amazon.awssdk:aws-query-protocol:2.26.19
 - software.amazon.awssdk:aws-json-protocol:2.26.19

--- a/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
@@ -7,17 +7,25 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- software.amazon.awssdk:checksums-spi:2.26.19
+- software.amazon.awssdk:checksums:2.26.19
 - software.amazon.awssdk:utils:2.26.19
 - software.amazon.awssdk:third-party-jackson-core:2.26.19
 - software.amazon.awssdk:sts:2.26.19
 - software.amazon.awssdk:sdk-core:2.26.19
 - software.amazon.awssdk:regions:2.26.19
+- software.amazon.awssdk:retries-spi:2.26.19
+- software.amazon.awssdk:retries:2.26.19
 - software.amazon.awssdk:protocol-core:2.26.19
 - software.amazon.awssdk:profiles:2.26.19
 - software.amazon.awssdk:netty-nio-client:2.26.19
 - software.amazon.awssdk:metrics-spi:2.26.19
 - software.amazon.awssdk:json-utils:2.26.19
 - software.amazon.awssdk:http-client-spi:2.26.19
+- software.amazon.awssdk:http-auth-aws:2.26.19
+- software.amazon.awssdk:http-auth-spi:2.26.19
+- software.amazon.awssdk:http-auth:2.26.19
+- software.amazon.awssdk:identity-spi:2.26.19
 - software.amazon.awssdk:endpoints-spi:2.26.19
 - software.amazon.awssdk:dynamodb:2.26.19
 - software.amazon.awssdk:dynamodb-enhanced:2.26.19


### PR DESCRIPTION

## Purpose of the change

Fix `NOTICE` files to reflect the dependencies packaged into the uber jar.

## Verifying this change
Validated using helpful script provided by @dannycranmer 
```
mvn clean install | grep Including | grep -v org.apache.flink | sed -E 's/\S+\s+\S+\s+(\S+).*/\1/' | sed 's/:jar//' | sed 's/.*Including \(.*\) in the shaded jar\./\1/' | sort > /tmp/from.build
cat src/main/resources/META-INF/NOTICE | grep "^\- " | sed 's/- //' | sort > /tmp/from.notice
diff /tmp/from.build /tmp/from.notice
```

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
