### PR TITLE
[hotfix][docs] Explicitly set connector compatibility as string to pr…

### DIFF
--- a/docs/data/dynamodb.yml
+++ b/docs/data/dynamodb.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 5.0.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-dynamodb
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/$full_version/flink-sql-connector-dynamodb-$full_version.jar

--- a/docs/data/firehose.yml
+++ b/docs/data/firehose.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 5.0.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-aws-kinesis-firehose
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/$full_version/flink-sql-connector-aws-kinesis-firehose-$full_version.jar

--- a/docs/data/kinesis.yml
+++ b/docs/data/kinesis.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 5.0.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-kinesis
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/$full_version/flink-sql-connector-kinesis-$full_version.jar

--- a/docs/data/sqs.yml
+++ b/docs/data/sqs.yml
@@ -17,6 +17,6 @@
 ################################################################################
 
 version: 5.0.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-sqs


### PR DESCRIPTION
…event version comparison mismatch

## Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132

## Verifying this change
After fix, the version artifact shows up.
![image](https://github.com/user-attachments/assets/9c000694-b232-41ee-9fae-698f9c8cc5a7)




## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
