### PR TITLE
[FLINK-36770][Connectors/AWS]  make AWS sink writers use ResultHandler, move flink version to 1.20

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        flink: [1.20-SNAPSHOT]
         java: [ '8, 11, 17']
     uses: ./.github/workflows/common.yml
     with:
@@ -38,7 +38,7 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        flink: [1.20-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     strategy:
       matrix:
-        flink: [1.19.1, 1.20.0]
+        flink: [1.20.0]
         java: [ '8, 11, 17']
     with:
       flink_version: ${{ matrix.flink }}
@@ -38,7 +38,7 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [1.19.0, 1.20.0]
+        flink: [1.20.0]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ under the License.
         <aws.sdkv1.version>1.12.439</aws.sdkv1.version>
         <aws.sdkv2.version>2.26.19</aws.sdkv2.version>
         <netty.version>4.1.86.Final</netty.version>
-        <flink.version>1.19.0</flink.version>
+        <flink.version>1.20.0</flink.version>
         <jackson-bom.version>2.14.3</jackson-bom.version>
         <glue.schema.registry.version>1.1.18</glue.schema.registry.version>
         <guava.version>32.1.3-jre</guava.version>


### PR DESCRIPTION


<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

 - Move `submitRequestEntries` implementation for AWS sinks to use `ResultHandler`
 - Bump flink version to 1.20
 - Adapt pipelines to Flink version change

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing sink unit tests


## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
