### PR TITLE
[FLINK-32097][Connectors/Kinesis]  Implement support for Kinesis deaggregation

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -53,6 +53,11 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.kinesis</groupId>
+            <artifactId>amazon-kinesis-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>arns</artifactId>
         </dependency>

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -33,6 +33,14 @@ under the License.
     <name>Flink : Connectors : AWS : Amazon Kinesis Data Streams Connector v2</name>
     <packaging>jar</packaging>
 
+    <repositories>
+        <!-- used for the kinesis aggregator dependency since it is not available in maven central -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -104,6 +112,15 @@ under the License.
             <artifactId>flink-connector-aws-base</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- the kinesis aggregator dependency since it is not available in maven central -->
+            <!-- look into issue https://github.com/awslabs/kinesis-aggregation/issues/120 -->
+            <groupId>com.github.awslabs.kinesis-aggregation</groupId>
+            <artifactId>amazon-kinesis-aggregator</artifactId>
+            <version>2.0.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -70,9 +70,9 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
-import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.time.Duration;
 import java.util.Map;
@@ -209,7 +209,7 @@ public class KinesisStreamsSource<T>
         return new KinesisStreamsSourceEnumeratorStateSerializer(new KinesisShardSplitSerializer());
     }
 
-    private Supplier<SplitReader<Record, KinesisShardSplit>> getKinesisShardSplitReaderSupplier(
+    private Supplier<SplitReader<KinesisClientRecord, KinesisShardSplit>> getKinesisShardSplitReaderSupplier(
             Configuration sourceConfig, Map<String, KinesisShardMetrics> shardMetricGroupMap) {
         KinesisSourceConfigOptions.ReaderType readerType = sourceConfig.get(READER_TYPE);
         switch (readerType) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
@@ -29,8 +29,8 @@ import org.apache.flink.connector.kinesis.source.split.StartingPosition;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import javax.annotation.Nullable;
 
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,10 +49,10 @@ import static java.util.Collections.singleton;
 /** Base implementation of the SplitReader for reading from KinesisShardSplits. */
 @Internal
 public abstract class KinesisShardSplitReaderBase
-        implements SplitReader<Record, KinesisShardSplit> {
+        implements SplitReader<KinesisClientRecord, KinesisShardSplit> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisShardSplitReaderBase.class);
-    private static final RecordsWithSplitIds<Record> INCOMPLETE_SHARD_EMPTY_RECORDS =
+    private static final RecordsWithSplitIds<KinesisClientRecord> INCOMPLETE_SHARD_EMPTY_RECORDS =
             new KinesisRecordsWithSplitIds(Collections.emptyIterator(), null, false);
 
     private final Deque<KinesisShardSplitState> assignedSplits = new ArrayDeque<>();
@@ -65,7 +64,7 @@ public abstract class KinesisShardSplitReaderBase
     }
 
     @Override
-    public RecordsWithSplitIds<Record> fetch() throws IOException {
+    public RecordsWithSplitIds<KinesisClientRecord> fetch() throws IOException {
         KinesisShardSplitState splitState = assignedSplits.poll();
 
         // When there are no assigned splits, return quickly
@@ -103,7 +102,7 @@ public abstract class KinesisShardSplitReaderBase
                 .get(splitState.getShardId())
                 .setMillisBehindLatest(recordBatch.getMillisBehindLatest());
 
-        if (recordBatch.getRecords().isEmpty()) {
+        if (recordBatch.getDeaggregatedRecords().isEmpty()) {
             if (recordBatch.isCompleted()) {
                 return new KinesisRecordsWithSplitIds(
                         Collections.emptyIterator(), splitState.getSplitId(), true);
@@ -115,12 +114,12 @@ public abstract class KinesisShardSplitReaderBase
         splitState.setNextStartingPosition(
                 StartingPosition.continueFromSequenceNumber(
                         recordBatch
-                                .getRecords()
-                                .get(recordBatch.getRecords().size() - 1)
+                                .getDeaggregatedRecords()
+                                .get(recordBatch.getDeaggregatedRecords().size() - 1)
                                 .sequenceNumber()));
 
         return new KinesisRecordsWithSplitIds(
-                recordBatch.getRecords().iterator(),
+                recordBatch.getDeaggregatedRecords().iterator(),
                 splitState.getSplitId(),
                 recordBatch.isCompleted());
     }
@@ -155,47 +154,18 @@ public abstract class KinesisShardSplitReaderBase
     }
 
     /**
-     * Dataclass to store a batch of Kinesis records with metadata. Used to pass Kinesis records
-     * from the SplitReader implementation to the SplitReaderBase.
-     */
-    @Internal
-    protected static class RecordBatch {
-        private final List<Record> records;
-        private final long millisBehindLatest;
-        private final boolean completed;
-
-        public RecordBatch(List<Record> records, long millisBehindLatest, boolean completed) {
-            this.records = records;
-            this.millisBehindLatest = millisBehindLatest;
-            this.completed = completed;
-        }
-
-        public List<Record> getRecords() {
-            return records;
-        }
-
-        public long getMillisBehindLatest() {
-            return millisBehindLatest;
-        }
-
-        public boolean isCompleted() {
-            return completed;
-        }
-    }
-
-    /**
      * Implementation of {@link RecordsWithSplitIds} for sending Kinesis records from fetcher to the
      * SourceReader.
      */
     @Internal
-    private static class KinesisRecordsWithSplitIds implements RecordsWithSplitIds<Record> {
+    private static class KinesisRecordsWithSplitIds implements RecordsWithSplitIds<KinesisClientRecord> {
 
-        private final Iterator<Record> recordsIterator;
+        private final Iterator<KinesisClientRecord> recordsIterator;
         private final String splitId;
         private final boolean isComplete;
 
         public KinesisRecordsWithSplitIds(
-                Iterator<Record> recordsIterator, String splitId, boolean isComplete) {
+                Iterator<KinesisClientRecord> recordsIterator, String splitId, boolean isComplete) {
             this.recordsIterator = recordsIterator;
             this.splitId = splitId;
             this.isComplete = isComplete;
@@ -209,7 +179,7 @@ public abstract class KinesisShardSplitReaderBase
 
         @Nullable
         @Override
-        public Record nextRecordFromSplit() {
+        public KinesisClientRecord nextRecordFromSplit() {
             return recordsIterator.hasNext() ? recordsIterator.next() : null;
         }
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitter.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsRecordEmitter.java
@@ -26,7 +26,7 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 import org.apache.flink.connector.kinesis.source.split.StartingPosition;
 import org.apache.flink.util.Collector;
 
-import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 /**
  * Emits record from the source into the Flink job graph. This serves as the interface between the
@@ -36,7 +36,7 @@ import software.amazon.awssdk.services.kinesis.model.Record;
  */
 @Internal
 public class KinesisStreamsRecordEmitter<T>
-        implements RecordEmitter<Record, T, KinesisShardSplitState> {
+        implements RecordEmitter<KinesisClientRecord, T, KinesisShardSplitState> {
 
     private final KinesisDeserializationSchema<T> deserializationSchema;
     private final SourceOutputWrapper<T> sourceOutputWrapper = new SourceOutputWrapper<>();
@@ -47,7 +47,7 @@ public class KinesisStreamsRecordEmitter<T>
 
     @Override
     public void emitRecord(
-            Record element, SourceOutput<T> output, KinesisShardSplitState splitState)
+            KinesisClientRecord element, SourceOutput<T> output, KinesisShardSplitState splitState)
             throws Exception {
         sourceOutputWrapper.setSourceOutput(output);
         sourceOutputWrapper.setTimestamp(element.approximateArrivalTimestamp().toEpochMilli());

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReader.java
@@ -31,7 +31,7 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.util.HashSet;
 import java.util.List;
@@ -45,14 +45,14 @@ import java.util.Map;
 @Internal
 public class KinesisStreamsSourceReader<T>
         extends SingleThreadMultiplexSourceReaderBase<
-                Record, T, KinesisShardSplit, KinesisShardSplitState> {
+        KinesisClientRecord, T, KinesisShardSplit, KinesisShardSplitState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisStreamsSourceReader.class);
     private final Map<String, KinesisShardMetrics> shardMetricGroupMap;
 
     public KinesisStreamsSourceReader(
-            SingleThreadFetcherManager<Record, KinesisShardSplit> splitFetcherManager,
-            RecordEmitter<Record, T, KinesisShardSplitState> recordEmitter,
+            SingleThreadFetcherManager<KinesisClientRecord, KinesisShardSplit> splitFetcherManager,
+            RecordEmitter<KinesisClientRecord, T, KinesisShardSplitState> recordEmitter,
             Configuration config,
             SourceReaderContext context,
             Map<String, KinesisShardMetrics> shardMetricGroupMap) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/RecordBatch.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/RecordBatch.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
+
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.AggregatorUtil;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Dataclass to store a batch of Kinesis records with metadata. Used to pass Kinesis records
+ * from the SplitReader implementation to the SplitReaderBase.
+ *
+ * <p>Input records are de-aggregated using KCL 3.x library. It is expected that AWS SDK v2.x messages
+ * are converted to KCL 3.x {@link KinesisClientRecord}.
+ */
+@Internal
+public class RecordBatch {
+    private final List<KinesisClientRecord> deaggregatedRecords;
+    private final long millisBehindLatest;
+    private final boolean completed;
+
+    public RecordBatch(
+            final List<Record> records,
+            final KinesisShardSplit subscribedShard,
+            final long millisBehindLatest,
+            final boolean completed) {
+        this.deaggregatedRecords = deaggregateRecords(records, subscribedShard);
+        this.millisBehindLatest = millisBehindLatest;
+        this.completed = completed;
+    }
+
+    public List<KinesisClientRecord> getDeaggregatedRecords() {
+        return deaggregatedRecords;
+    }
+
+    public long getMillisBehindLatest() {
+        return millisBehindLatest;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    private List<KinesisClientRecord> deaggregateRecords(
+            final List<Record> records,
+            final KinesisShardSplit subscribedShard) {
+        final List<KinesisClientRecord> kinesisClientRecords = records.stream()
+                .map(KinesisClientRecord::fromRecord)
+                .collect(Collectors.toList());
+
+        final String startingHashKey = subscribedShard.getStartingHashKey();
+        final String endingHashKey = subscribedShard.getEndingHashKey();
+
+        return new AggregatorUtil().deaggregate(kinesisClientRecords, startingHashKey, endingHashKey);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/RecordBatch.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/RecordBatch.java
@@ -25,8 +25,8 @@ import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.kinesis.retrieval.AggregatorUtil;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Dataclass to store a batch of Kinesis records with metadata. Used to pass Kinesis records
@@ -66,9 +66,10 @@ public class RecordBatch {
     private List<KinesisClientRecord> deaggregateRecords(
             final List<Record> records,
             final KinesisShardSplit subscribedShard) {
-        final List<KinesisClientRecord> kinesisClientRecords = records.stream()
-                .map(KinesisClientRecord::fromRecord)
-                .collect(Collectors.toList());
+        final List<KinesisClientRecord> kinesisClientRecords = new ArrayList<>();
+        for (Record record : records) {
+            kinesisClientRecords.add(KinesisClientRecord.fromRecord(record));
+        }
 
         final String startingHashKey = subscribedShard.getStartingHashKey();
         final String endingHashKey = subscribedShard.getEndingHashKey();

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSplitReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSplitReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.kinesis.source.metrics.KinesisShardMetrics;
 import org.apache.flink.connector.kinesis.source.proxy.AsyncStreamProxy;
 import org.apache.flink.connector.kinesis.source.reader.KinesisShardSplitReaderBase;
+import org.apache.flink.connector.kinesis.source.reader.RecordBatch;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 
@@ -69,7 +70,11 @@ public class FanOutKinesisShardSplitReader extends KinesisShardSplitReaderBase {
         if (shardCompleted) {
             splitSubscriptions.remove(splitState.getShardId());
         }
-        return new RecordBatch(event.records(), event.millisBehindLatest(), shardCompleted);
+        return new RecordBatch(
+                event.records(),
+                splitState.getKinesisShardSplit(),
+                event.millisBehindLatest(),
+                shardCompleted);
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
@@ -24,6 +24,7 @@ import org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptio
 import org.apache.flink.connector.kinesis.source.metrics.KinesisShardMetrics;
 import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
 import org.apache.flink.connector.kinesis.source.reader.KinesisShardSplitReaderBase;
+import org.apache.flink.connector.kinesis.source.reader.RecordBatch;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
@@ -59,8 +60,12 @@ public class PollingKinesisShardSplitReader extends KinesisShardSplitReaderBase 
                         splitState.getNextStartingPosition(),
                         this.maxRecordsToGet);
         boolean isCompleted = getRecordsResponse.nextShardIterator() == null;
+
         return new RecordBatch(
-                getRecordsResponse.records(), getRecordsResponse.millisBehindLatest(), isCompleted);
+                getRecordsResponse.records(),
+                splitState.getKinesisShardSplit(),
+                getRecordsResponse.millisBehindLatest(),
+                isCompleted);
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchema.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchema.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
 import org.apache.flink.util.Collector;
 
-import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -60,7 +60,7 @@ public interface KinesisDeserializationSchema<T> extends Serializable, ResultTyp
      * @param output the identifier of the shard the record was sent to
      * @throws IOException exception when deserializing record
      */
-    void deserialize(Record record, String stream, String shardId, Collector<T> output)
+    void deserialize(KinesisClientRecord record, String stream, String shardId, Collector<T> output)
             throws IOException;
 
     static <T> KinesisDeserializationSchema<T> of(DeserializationSchema<T> deserializationSchema) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/serialization/KinesisDeserializationSchemaWrapper.java
@@ -22,9 +22,10 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Collector;
 
-import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * A simple wrapper for using the {@link DeserializationSchema} with the {@link
@@ -48,9 +49,14 @@ class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializationSc
     }
 
     @Override
-    public void deserialize(Record record, String stream, String shardId, Collector<T> output)
+    public void deserialize(KinesisClientRecord record, String stream, String shardId, Collector<T> output)
             throws IOException {
-        deserializationSchema.deserialize(record.data().asByteArray(), output);
+        ByteBuffer recordData = record.data();
+
+        byte[] dataBytes = new byte[recordData.remaining()];
+        recordData.get(dataBytes);
+
+        deserializationSchema.deserialize(dataBytes, output);
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -308,12 +307,7 @@ public class KinesisStreamsSourceITCase {
             }
 
             AggRecord aggRecord = recordAggregator.clearAndGet();
-
-            return PutRecordsRequestEntry.builder()
-                    .data(SdkBytes.fromByteArray(aggRecord.toRecordBytes()))
-                    .partitionKey(aggRecord.getPartitionKey())
-                    .explicitHashKey(aggRecord.getExplicitHashKey())
-                    .build();
+            return aggRecord.toPutRecordsRequestEntry();
         }
 
         private void reshard(String streamName) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSourceITCase.java
@@ -11,6 +11,8 @@ import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
+import com.amazonaws.kinesis.agg.AggRecord;
+import com.amazonaws.kinesis.agg.RecordAggregator;
 import com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +43,6 @@ import software.amazon.awssdk.services.kinesis.model.UpdateShardCountRequest;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -118,12 +119,34 @@ public class KinesisStreamsSourceITCase {
     }
 
     @Test
+    void singleShardStreamWithAggregationIsConsumed() throws Exception {
+        new Scenario()
+                .localstackStreamName("single-shard-stream-aggregation")
+                .shardCount(1)
+                .aggregationFactor(10)
+                .withSourceConnectionStreamArn(
+                        "arn:aws:kinesis:ap-southeast-1:000000000000:stream/single-shard-stream-aggregation")
+                .runScenario();
+    }
+
+    @Test
     void multipleShardStreamIsConsumed() throws Exception {
         new Scenario()
                 .localstackStreamName("multiple-shard-stream")
                 .shardCount(4)
                 .withSourceConnectionStreamArn(
                         "arn:aws:kinesis:ap-southeast-1:000000000000:stream/multiple-shard-stream")
+                .runScenario();
+    }
+
+    @Test
+    void multipleShardStreamWithAggregationIsConsumed() throws Exception {
+        new Scenario()
+                .localstackStreamName("multiple-shard-stream-aggregation")
+                .shardCount(4)
+                .aggregationFactor(10)
+                .withSourceConnectionStreamArn(
+                        "arn:aws:kinesis:ap-southeast-1:000000000000:stream/multiple-shard-stream-aggregation")
                 .runScenario();
     }
 
@@ -135,6 +158,18 @@ public class KinesisStreamsSourceITCase {
                 .reshardStream(2)
                 .withSourceConnectionStreamArn(
                         "arn:aws:kinesis:ap-southeast-1:000000000000:stream/resharded-stream")
+                .runScenario();
+    }
+
+    @Test
+    void reshardedStreamWithAggregationIsConsumed() throws Exception {
+        new Scenario()
+                .localstackStreamName("resharded-stream-aggregation")
+                .shardCount(1)
+                .aggregationFactor(10)
+                .reshardStream(2)
+                .withSourceConnectionStreamArn(
+                        "arn:aws:kinesis:ap-southeast-1:000000000000:stream/resharded-stream-aggregation")
                 .runScenario();
     }
 
@@ -152,6 +187,7 @@ public class KinesisStreamsSourceITCase {
 
     private class Scenario {
         private final int expectedElements = 1000;
+        private int aggregationFactor = 1;
         private String localstackStreamName = null;
         private int shardCount = 1;
         private boolean shouldReshardStream = false;
@@ -203,6 +239,11 @@ public class KinesisStreamsSourceITCase {
             return this;
         }
 
+        public Scenario aggregationFactor(int aggregationFactor) {
+            this.aggregationFactor = aggregationFactor;
+            return this;
+        }
+
         private void prepareStream(String streamName) throws Exception {
             final RateLimiter rateLimiter =
                     RateLimiterBuilder.newBuilder()
@@ -242,13 +283,9 @@ public class KinesisStreamsSourceITCase {
 
             for (List<byte[]> partition : Lists.partition(messages, 500)) {
                 List<PutRecordsRequestEntry> entries =
-                        partition.stream()
-                                .map(
-                                        msg ->
-                                                PutRecordsRequestEntry.builder()
-                                                        .partitionKey(UUID.randomUUID().toString())
-                                                        .data(SdkBytes.fromByteArray(msg))
-                                                        .build())
+                        Lists.partition(partition, aggregationFactor)
+                                .stream()
+                                .map(this::createAggregatePutRecordsRequestEntry)
                                 .collect(Collectors.toList());
                 PutRecordsRequest requests =
                         PutRecordsRequest.builder().streamName(streamName).records(entries).build();
@@ -257,6 +294,26 @@ public class KinesisStreamsSourceITCase {
                     LOG.debug("Added record: {}", result.sequenceNumber());
                 }
             }
+        }
+
+        private PutRecordsRequestEntry createAggregatePutRecordsRequestEntry(List<byte[]> messages) {
+            RecordAggregator recordAggregator = new RecordAggregator();
+
+            for (byte[] message : messages) {
+                try {
+                    recordAggregator.addUserRecord("key", message);
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to add record to aggregator", e);
+                }
+            }
+
+            AggRecord aggRecord = recordAggregator.clearAndGet();
+
+            return PutRecordsRequestEntry.builder()
+                    .data(SdkBytes.fromByteArray(aggRecord.toRecordBytes()))
+                    .partitionKey(aggRecord.getPartitionKey())
+                    .explicitHashKey(aggRecord.getExplicitHashKey())
+                    .build();
         }
 
         private void reshard(String streamName) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/PollingKinesisShardSplitReaderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_MAX;
 import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.STREAM_ARN;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.convertToKinesisClientRecord;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestRecord;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
@@ -80,7 +82,7 @@ class PollingKinesisShardSplitReaderTest {
 
     @Test
     void testNoAssignedSplitsHandledGracefully() throws Exception {
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
         assertThat(retrievedRecords.nextSplit()).isNull();
@@ -95,7 +97,7 @@ class PollingKinesisShardSplitReaderTest {
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
         // When fetching records
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         // Then retrieve no records
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
@@ -116,7 +118,7 @@ class PollingKinesisShardSplitReaderTest {
         splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(testSplit)));
 
         // When fetching records
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         // Then retrieve no records and mark split as complete
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
@@ -128,28 +130,30 @@ class PollingKinesisShardSplitReaderTest {
     void testSingleAssignedSplitAllConsumed() throws Exception {
         // Given assigned split with records
         testStreamProxy.addShards(TEST_SHARD_ID);
-        List<Record> expectedRecords =
+        List<Record> inputRecords =
                 Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
                         .collect(Collectors.toList());
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(0)));
+                Collections.singletonList(inputRecords.get(0)));
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(1)));
+                Collections.singletonList(inputRecords.get(1)));
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(2)));
+                Collections.singletonList(inputRecords.get(2)));
         splitReader.handleSplitsChanges(
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
+        List<KinesisClientRecord> expectedRecords = convertToKinesisClientRecord(inputRecords);
+
         // When fetching records
-        List<Record> records = new ArrayList<>();
-        for (int i = 0; i < expectedRecords.size(); i++) {
-            RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        List<KinesisClientRecord> records = new ArrayList<>();
+        for (int i = 0; i < inputRecords.size(); i++) {
+            RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
             records.addAll(readAllRecords(retrievedRecords));
         }
 
@@ -160,28 +164,30 @@ class PollingKinesisShardSplitReaderTest {
     void testMultipleAssignedSplitsAllConsumed() throws Exception {
         // Given assigned split with records
         testStreamProxy.addShards(TEST_SHARD_ID);
-        List<Record> expectedRecords =
+        List<Record> inputRecords =
                 Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
                         .collect(Collectors.toList());
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(0)));
+                Collections.singletonList(inputRecords.get(0)));
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(1)));
+                Collections.singletonList(inputRecords.get(1)));
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(2)));
+                Collections.singletonList(inputRecords.get(2)));
         splitReader.handleSplitsChanges(
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
+        List<KinesisClientRecord> expectedRecords = convertToKinesisClientRecord(inputRecords);
+
         // When records are fetched
-        List<Record> fetchedRecords = new ArrayList<>();
+        List<KinesisClientRecord> fetchedRecords = new ArrayList<>();
         for (int i = 0; i < expectedRecords.size(); i++) {
-            RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+            RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
             fetchedRecords.addAll(readAllRecords(retrievedRecords));
         }
 
@@ -199,7 +205,7 @@ class PollingKinesisShardSplitReaderTest {
         testStreamProxy.setShouldCompleteNextShard(true);
 
         // When fetching records
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         // Returns completed split with no records
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
@@ -211,21 +217,23 @@ class PollingKinesisShardSplitReaderTest {
     void testFinishedSplitsReturned() throws Exception {
         // Given assigned split with records from completed shard
         testStreamProxy.addShards(TEST_SHARD_ID);
-        List<Record> expectedRecords =
+        List<Record> inputRecords =
                 Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
                         .collect(Collectors.toList());
-        testStreamProxy.addRecords(TestUtil.STREAM_ARN, TEST_SHARD_ID, expectedRecords);
+        testStreamProxy.addRecords(TestUtil.STREAM_ARN, TEST_SHARD_ID, inputRecords);
         KinesisShardSplit split = getTestSplit(TEST_SHARD_ID);
         splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
 
         // When fetching records
-        List<Record> fetchedRecords = new ArrayList<>();
+        List<KinesisClientRecord> fetchedRecords = new ArrayList<>();
         testStreamProxy.setShouldCompleteNextShard(true);
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
+
+        List<KinesisClientRecord> expectedRecords = convertToKinesisClientRecord(inputRecords);
 
         // Then records can be read successfully, with finishedSplit returned once all records are
         // completed
-        for (int i = 0; i < expectedRecords.size(); i++) {
+        for (int i = 0; i < inputRecords.size(); i++) {
             assertThat(retrievedRecords.nextSplit()).isEqualTo(split.splitId());
             assertThat(retrievedRecords.finishedSplits()).isEmpty();
             fetchedRecords.add(retrievedRecords.nextRecordFromSplit());
@@ -245,21 +253,23 @@ class PollingKinesisShardSplitReaderTest {
         testStreamProxy.addShards(TEST_SHARD_ID);
         KinesisShardSplit testSplit = getTestSplit(TEST_SHARD_ID);
 
-        List<Record> expectedRecords =
+        List<Record> inputRecords =
                 Stream.of(getTestRecord("data-1"), getTestRecord("data-2"))
                         .collect(Collectors.toList());
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(0)));
+                Collections.singletonList(inputRecords.get(0)));
         testStreamProxy.addRecords(
                 TestUtil.STREAM_ARN,
                 TEST_SHARD_ID,
-                Collections.singletonList(expectedRecords.get(1)));
+                Collections.singletonList(inputRecords.get(1)));
         splitReader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(testSplit)));
 
+        List<KinesisClientRecord> expectedRecords = convertToKinesisClientRecord(inputRecords);
+
         // read data from split
-        RecordsWithSplitIds<Record> records = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> records = splitReader.fetch();
         assertThat(readAllRecords(records)).containsExactlyInAnyOrder(expectedRecords.get(0));
 
         // pause split
@@ -330,12 +340,14 @@ class PollingKinesisShardSplitReaderTest {
                 Arrays.asList(testSplit1, testSplit3), Collections.emptyList());
 
         // read data from splits and verify that only records from split 2 were fetched by reader
-        List<Record> fetchedRecords = new ArrayList<>();
+        List<KinesisClientRecord> fetchedRecords = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            RecordsWithSplitIds<Record> records = splitReader.fetch();
+            RecordsWithSplitIds<KinesisClientRecord> records = splitReader.fetch();
             fetchedRecords.addAll(readAllRecords(records));
         }
-        assertThat(fetchedRecords).containsExactly(recordsFromSplit2.toArray(new Record[0]));
+
+        List<KinesisClientRecord> expectedRecordsFromSplit2 = convertToKinesisClientRecord(recordsFromSplit2);
+        assertThat(fetchedRecords).containsExactlyElementsOf(expectedRecordsFromSplit2);
 
         // resume split 3
         splitReader.pauseOrResumeSplits(
@@ -344,10 +356,12 @@ class PollingKinesisShardSplitReaderTest {
         // read data from splits and verify that only records from split 3 had been read
         fetchedRecords.clear();
         for (int i = 0; i < 10; i++) {
-            RecordsWithSplitIds<Record> records = splitReader.fetch();
+            RecordsWithSplitIds<KinesisClientRecord> records = splitReader.fetch();
             fetchedRecords.addAll(readAllRecords(records));
         }
-        assertThat(fetchedRecords).containsExactly(recordsFromSplit3.toArray(new Record[0]));
+
+        List<KinesisClientRecord> expectedRecordsFromSplit3 = convertToKinesisClientRecord(recordsFromSplit3);
+        assertThat(fetchedRecords).containsExactlyElementsOf(expectedRecordsFromSplit3);
     }
 
     @Test
@@ -388,16 +402,16 @@ class PollingKinesisShardSplitReaderTest {
         splitReader.handleSplitsChanges(
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
-        List<Record> records = new ArrayList<>(readAllRecords(retrievedRecords));
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
+        List<KinesisClientRecord> records = new ArrayList<>(readAllRecords(retrievedRecords));
 
         assertThat(sentRecords.size() > maxRecordsToGet).isTrue();
         assertThat(records.size()).isEqualTo(maxRecordsToGet);
     }
 
-    private List<Record> readAllRecords(RecordsWithSplitIds<Record> recordsWithSplitIds) {
-        List<Record> outputRecords = new ArrayList<>();
-        Record record;
+    private List<KinesisClientRecord> readAllRecords(RecordsWithSplitIds<KinesisClientRecord> recordsWithSplitIds) {
+        List<KinesisClientRecord> outputRecords = new ArrayList<>();
+        KinesisClientRecord record;
         do {
             record = recordsWithSplitIds.nextRecordFromSplit();
             if (record != null) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/RecordBatchTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/RecordBatchTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kinesis.source.reader;
 
 import org.apache.flink.connector.kinesis.source.util.TestUtil;
+
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kinesis.model.Record;
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/RecordBatchTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/RecordBatchTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader;
+
+import com.amazonaws.kinesis.agg.AggRecord;
+import com.amazonaws.kinesis.agg.RecordAggregator;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.Record;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestRecord;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecordBatchTest {
+
+    @Test
+    public void testDeaggregateRecordsPassThrough() {
+        List<Record> records =
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
+                        .collect(Collectors.toList());
+
+        RecordBatch result =
+                new RecordBatch(records, getTestSplit(), 100L, true);
+
+        assertThat(result.getDeaggregatedRecords().size()).isEqualTo(3);
+    }
+
+    @Test
+    public void testDeaggregateRecordsWithAggregatedRecords() {
+        List<Record> records =
+                Stream.of(getTestRecord("data-1"), getTestRecord("data-2"), getTestRecord("data-3"))
+                        .collect(Collectors.toList());
+
+        Record aggregatedRecord = createAggregatedRecord(records);
+
+        RecordBatch result =
+                new RecordBatch(Collections.singletonList(aggregatedRecord), getTestSplit(), 100L, true);
+
+        assertThat(result.getDeaggregatedRecords().size()).isEqualTo(3);
+    }
+
+    @Test
+    public void testGetMillisBehindLatest() {
+        RecordBatch result =
+                new RecordBatch(
+                        Collections.singletonList(getTestRecord("data-1")), getTestSplit(), 100L, true);
+
+        assertThat(result.getMillisBehindLatest()).isEqualTo(100L);
+    }
+
+    @Test
+    public void testIsCompleted() {
+        RecordBatch result =
+                new RecordBatch(
+                        Collections.singletonList(getTestRecord("data-1")), getTestSplit(), 100L, true);
+
+        assertThat(result.isCompleted()).isTrue();
+    }
+
+    private static Record createAggregatedRecord(List<Record> records) {
+        RecordAggregator recordAggregator = new RecordAggregator();
+
+        for (Record record : records) {
+            try {
+                recordAggregator.addUserRecord("key", record.data().asByteArray());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to add record to aggregator", e);
+            }
+        }
+
+        AggRecord aggRecord = recordAggregator.clearAndGet();
+
+        return Record.builder()
+                .data(SdkBytes.fromByteArray(aggRecord.toRecordBytes()))
+                .approximateArrivalTimestamp(Instant.now())
+                .build();
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSplitReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSplitReaderTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.metrics.testutils.MetricListener;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -51,7 +51,7 @@ public class FanOutKinesisShardSplitReaderTest {
     private static final String TEST_SHARD_ID = TestUtil.generateShardId(1);
     private static final Duration TEST_SUBSCRIPTION_TIMEOUT = Duration.ofMillis(1000);
 
-    SplitReader<Record, KinesisShardSplit> splitReader;
+    SplitReader<KinesisClientRecord, KinesisShardSplit> splitReader;
 
     private AsyncStreamProxy testAsyncStreamProxy;
     private Map<String, KinesisShardMetrics> shardMetricGroupMap;
@@ -78,7 +78,7 @@ public class FanOutKinesisShardSplitReaderTest {
                         CONSUMER_ARN,
                         shardMetricGroupMap,
                         TEST_SUBSCRIPTION_TIMEOUT);
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
         assertThat(retrievedRecords.nextSplit()).isNull();
@@ -99,7 +99,7 @@ public class FanOutKinesisShardSplitReaderTest {
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
         // When fetching records
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         // Then retrieve no records
         assertThat(retrievedRecords.nextRecordFromSplit()).isNull();
@@ -122,7 +122,7 @@ public class FanOutKinesisShardSplitReaderTest {
                 new SplitsAddition<>(Collections.singletonList(getTestSplit(TEST_SHARD_ID))));
 
         // When fetching records
-        RecordsWithSplitIds<Record> retrievedRecords = splitReader.fetch();
+        RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = splitReader.fetch();
 
         // Then shard is marked as completed
         // Then retrieve no records and mark split as complete
@@ -169,17 +169,17 @@ public class FanOutKinesisShardSplitReaderTest {
     }
 
     private void consumeAllRecordsFromKinesis(
-            SplitReader<Record, KinesisShardSplit> splitReader, int numRecords) {
+            SplitReader<KinesisClientRecord, KinesisShardSplit> splitReader, int numRecords) {
         consumeRecordsFromKinesis(splitReader, numRecords, true);
     }
 
     private void consumeSomeRecordsFromKinesis(
-            SplitReader<Record, KinesisShardSplit> splitReader, int numRecords) {
+            SplitReader<KinesisClientRecord, KinesisShardSplit> splitReader, int numRecords) {
         consumeRecordsFromKinesis(splitReader, numRecords, false);
     }
 
     private void consumeRecordsFromKinesis(
-            SplitReader<Record, KinesisShardSplit> splitReader,
+            SplitReader<KinesisClientRecord, KinesisShardSplit> splitReader,
             int numRecords,
             boolean checkForShardCompletion) {
         // Set timeout to prevent infinite loop on failure
@@ -187,10 +187,10 @@ public class FanOutKinesisShardSplitReaderTest {
                 Duration.ofSeconds(60),
                 () -> {
                     int numRetrievedRecords = 0;
-                    RecordsWithSplitIds<Record> retrievedRecords = null;
+                    RecordsWithSplitIds<KinesisClientRecord> retrievedRecords = null;
                     while (numRetrievedRecords < numRecords) {
                         retrievedRecords = splitReader.fetch();
-                        List<Record> records = readAllRecords(retrievedRecords);
+                        List<KinesisClientRecord> records = readAllRecords(retrievedRecords);
                         numRetrievedRecords += records.size();
                     }
                     assertThat(numRetrievedRecords).isEqualTo(numRecords);
@@ -206,9 +206,9 @@ public class FanOutKinesisShardSplitReaderTest {
                 "did not receive expected " + numRecords + " records within 10 seconds.");
     }
 
-    private List<Record> readAllRecords(RecordsWithSplitIds<Record> recordsWithSplitIds) {
-        List<Record> outputRecords = new ArrayList<>();
-        Record record;
+    private List<KinesisClientRecord> readAllRecords(RecordsWithSplitIds<KinesisClientRecord> recordsWithSplitIds) {
+        List<KinesisClientRecord> outputRecords = new ArrayList<>();
+        KinesisClientRecord record;
         do {
             record = recordsWithSplitIds.nextRecordFromSplit();
             if (record != null) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/FakeKinesisFanOutBehaviorsFactory.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/FakeKinesisFanOutBehaviorsFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.google.common.collect.Lists.partition;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.kinesis.source.split.StartingPositionUtil.toSdkStartingPosition;
@@ -121,7 +122,11 @@ public class FakeKinesisFanOutBehaviorsFactory {
                     records.add(createRecord(sequenceNumber));
                 }
 
-                eventBuilder.records(records);
+                List<Record> aggregatedRecords = partition(records, aggregationFactor).stream()
+                        .map(TestUtil::createAggregatedRecord)
+                        .collect(Collectors.toList());
+
+                eventBuilder.records(aggregatedRecords);
 
                 String continuation =
                         sequenceNumber.get() < totalRecords

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/util/TestUtil.java
@@ -32,12 +32,15 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kinesis.model.HashKeyRange;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,6 +162,12 @@ public class TestUtil {
                 .data(SdkBytes.fromByteArray(STRING_SCHEMA.serialize(data)))
                 .approximateArrivalTimestamp(Instant.now())
                 .build();
+    }
+
+    public static List<KinesisClientRecord> convertToKinesisClientRecord(List<Record> records) {
+        return records.stream()
+                .map(KinesisClientRecord::fromRecord)
+                .collect(Collectors.toList());
     }
 
     public static void assertMillisBehindLatest(

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,11 @@ under the License.
                 <version>1.14.8</version>
             </dependency>
             <dependency>
+                <groupId>software.amazon.kinesis</groupId>
+                <artifactId>amazon-kinesis-client</artifactId>
+                <version>3.0.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
                 <version>3.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -333,11 +333,6 @@ under the License.
                 <version>3.24.0-GA</version>
             </dependency>
             <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>


### PR DESCRIPTION
## Purpose of the change

This PR implements the Kinesis deaggregation. The implementation was heavily based on the old kinesis connector.

## Verifying this change

This change added tests and can be verified as follows:
- Added integration tests for with record deaggregation
- Added unit tests
- Manually verified by running the Kinesis connector on a local Flink cluster.

## Further ToDos and Follow-ups

Checkpoints do not take into consideration the sequence number of the deaggregated records.

## Brief change log

- 767f576d4295aa6c0ad04ac34ebb183cc57bd0cd Implement record deaggregation using `AggregatorUtil` from the KCL 3.x
- ddcb1a9cf291cd9eab73829925a08da76b2dc107 Implemented tests for `RecordBatch` regarding deaggregation. There was a need for aggregated records to test. So it was used https://github.com/awslabs/kinesis-aggregation to do so. Unfortunatly, it does have a version in the maven repository compatible with KCL 3.x so it was used a workaround.
- fce6d035270509f31fd4cf3d9a13b0737cb985a1 Added integration tests.
- ddcb1a9cf291cd9eab73829925a08da76b2dc107 fce6d035270509f31fd4cf3d9a13b0737cb985a1 Added unit tests.

## Significant changes

- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
