### PR TITLE
[FLINK-37416][BugFix][Connectors/DynamoDB] Fix state inconsistency issue in DDB connector when sending split finished event from reader -> enumerator

### DIFF
--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/enumerator/assigner/UniformShardAssigner.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/enumerator/assigner/UniformShardAssigner.java
@@ -54,7 +54,8 @@ public class UniformShardAssigner implements DynamoDbStreamsShardAssigner {
 
         Preconditions.checkArgument(
                 selectedSubtask != -1,
-                "Expected at least one registered reader. Unable to assign split.");
+                "Expected at least one registered reader. Unable to assign split with id: %s.",
+                split.splitId());
         return selectedSubtask;
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/enumerator/tracker/SplitTracker.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/enumerator/tracker/SplitTracker.java
@@ -333,7 +333,13 @@ public class SplitTracker {
                 || isFinished(split.getParentShardId());
     }
 
-    private boolean isFinished(String splitId) {
+    /**
+     * Provides information whether a split is finished or not.
+     *
+     * @param splitId
+     * @return boolean value indicating if split is finished
+     */
+    public boolean isFinished(String splitId) {
         return finishedSplits.contains(splitId);
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReader.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/reader/DynamoDbStreamsSourceReader.java
@@ -33,9 +33,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.model.Record;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Coordinates the reading from assigned splits. Runs on the TaskManager.
@@ -49,6 +54,8 @@ public class DynamoDbStreamsSourceReader<T>
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamoDbStreamsSourceReader.class);
     private final Map<String, DynamoDbStreamsShardMetrics> shardMetricGroupMap;
+    private final NavigableMap<Long, Set<DynamoDbStreamsShardSplit>> splitFinishedEvents;
+    private long currentCheckpointId;
 
     public DynamoDbStreamsSourceReader(
             SingleThreadFetcherManager<Record, DynamoDbStreamsShardSplit> splitFetcherManager,
@@ -58,10 +65,35 @@ public class DynamoDbStreamsSourceReader<T>
             Map<String, DynamoDbStreamsShardMetrics> shardMetricGroupMap) {
         super(splitFetcherManager, recordEmitter, config, context);
         this.shardMetricGroupMap = shardMetricGroupMap;
+        this.splitFinishedEvents = new TreeMap<>();
+        this.currentCheckpointId = Long.MIN_VALUE;
     }
 
+    /**
+     * We store the finished splits in a map keyed by the checkpoint id.
+     *
+     * @param finishedSplitIds
+     */
     @Override
     protected void onSplitFinished(Map<String, DynamoDbStreamsShardSplitState> finishedSplitIds) {
+        if (finishedSplitIds.isEmpty()) {
+            return;
+        }
+
+        splitFinishedEvents.computeIfAbsent(currentCheckpointId, k -> new HashSet<>());
+        finishedSplitIds.values().stream()
+                .map(
+                        finishedSplit ->
+                                new DynamoDbStreamsShardSplit(
+                                        finishedSplit.getStreamArn(),
+                                        finishedSplit.getShardId(),
+                                        finishedSplit.getNextStartingPosition(),
+                                        finishedSplit
+                                                .getDynamoDbStreamsShardSplit()
+                                                .getParentShardId(),
+                                        true))
+                .forEach(split -> splitFinishedEvents.get(currentCheckpointId).add(split));
+
         context.sendSourceEventToCoordinator(
                 new SplitsFinishedEvent(new HashSet<>(finishedSplitIds.keySet())));
         finishedSplitIds.keySet().forEach(this::unregisterShardMetricGroup);
@@ -80,8 +112,55 @@ public class DynamoDbStreamsSourceReader<T>
 
     @Override
     public void addSplits(List<DynamoDbStreamsShardSplit> splits) {
-        splits.forEach(this::registerShardMetricGroup);
-        super.addSplits(splits);
+        List<DynamoDbStreamsShardSplit> dynamoDbStreamsShardSplits = new ArrayList<>();
+        for (DynamoDbStreamsShardSplit split : splits) {
+            if (split.isFinished()) {
+                // Replay the finished split event.
+                // We don't need to reload the split finished events in buffer back
+                // since if the next checkpoint completes, these would just be removed from the
+                // buffer. If the next checkpoint doesn't complete,
+                // we would go back to the previous checkpointed
+                // state which will again replay these split finished events.
+                context.sendSourceEventToCoordinator(
+                        new SplitsFinishedEvent(Collections.singleton(split.splitId())));
+            } else {
+                dynamoDbStreamsShardSplits.add(split);
+            }
+        }
+        dynamoDbStreamsShardSplits.forEach(this::registerShardMetricGroup);
+        super.addSplits(dynamoDbStreamsShardSplits);
+    }
+
+    /**
+     * At snapshot, we also store the pending finished split ids in the current checkpoint so that
+     * in case we have to restore the reader from state, we also send the finished split ids
+     * otherwise we run a risk of data loss during restarts of the source because of the
+     * SplitsFinishedEvent going missing.
+     *
+     * @param checkpointId
+     * @return
+     */
+    @Override
+    public List<DynamoDbStreamsShardSplit> snapshotState(long checkpointId) {
+        this.currentCheckpointId = checkpointId;
+        List<DynamoDbStreamsShardSplit> splits = new ArrayList<>(super.snapshotState(checkpointId));
+
+        if (!splitFinishedEvents.isEmpty()) {
+            // Add all finished splits to the snapshot
+            splitFinishedEvents.values().forEach(splits::addAll);
+        }
+        return splits;
+    }
+
+    /**
+     * During notifyCheckpointComplete, we should clean up the state of finished splits that are
+     * less than or equal to the checkpoint id.
+     *
+     * @param checkpointId
+     */
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        splitFinishedEvents.headMap(checkpointId, true).clear();
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplit.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplit.java
@@ -40,12 +40,22 @@ public final class DynamoDbStreamsShardSplit implements SourceSplit {
     private final String shardId;
     private final StartingPosition startingPosition;
     private final String parentShardId;
+    private final boolean isFinished;
 
     public DynamoDbStreamsShardSplit(
             String streamArn,
             String shardId,
             StartingPosition startingPosition,
             String parentShardId) {
+        this(streamArn, shardId, startingPosition, parentShardId, false);
+    }
+
+    public DynamoDbStreamsShardSplit(
+            String streamArn,
+            String shardId,
+            StartingPosition startingPosition,
+            String parentShardId,
+            boolean isFinished) {
         checkNotNull(streamArn, "streamArn cannot be null");
         checkNotNull(shardId, "shardId cannot be null");
         checkNotNull(startingPosition, "startingPosition cannot be null");
@@ -54,6 +64,7 @@ public final class DynamoDbStreamsShardSplit implements SourceSplit {
         this.shardId = shardId;
         this.startingPosition = startingPosition;
         this.parentShardId = parentShardId;
+        this.isFinished = isFinished;
     }
 
     @Override
@@ -77,6 +88,10 @@ public final class DynamoDbStreamsShardSplit implements SourceSplit {
         return parentShardId;
     }
 
+    public boolean isFinished() {
+        return isFinished;
+    }
+
     @Override
     public String toString() {
         return "DynamoDbStreamsShardSplit{"
@@ -90,7 +105,10 @@ public final class DynamoDbStreamsShardSplit implements SourceSplit {
                 + startingPosition
                 + ", parentShardId=["
                 + parentShardId
-                + '}';
+                + "]"
+                + ", isFinished="
+                + isFinished
+                + "}";
     }
 
     @Override
@@ -105,11 +123,12 @@ public final class DynamoDbStreamsShardSplit implements SourceSplit {
         return Objects.equals(streamArn, that.streamArn)
                 && Objects.equals(shardId, that.shardId)
                 && Objects.equals(startingPosition, that.startingPosition)
-                && Objects.equals(parentShardId, that.parentShardId);
+                && Objects.equals(parentShardId, that.parentShardId)
+                && Objects.equals(isFinished, that.isFinished);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(streamArn, shardId, startingPosition, parentShardId);
+        return Objects.hash(streamArn, shardId, startingPosition, parentShardId, isFinished);
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplitSerializer.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplitSerializer.java
@@ -29,6 +29,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Serializes and deserializes the {@link DynamoDbStreamsShardSplit}. This class needs to handle
@@ -38,7 +41,8 @@ import java.io.IOException;
 public class DynamoDbStreamsShardSplitSerializer
         implements SimpleVersionedSerializer<DynamoDbStreamsShardSplit> {
 
-    private static final int CURRENT_VERSION = 0;
+    private static final Set<Integer> COMPATIBLE_VERSIONS = new HashSet<>(Arrays.asList(0, 1));
+    private static final int CURRENT_VERSION = 1;
 
     @Override
     public int getVersion() {
@@ -69,6 +73,7 @@ public class DynamoDbStreamsShardSplitSerializer
                 out.writeBoolean(true);
                 out.writeUTF(split.getParentShardId());
             }
+            out.writeBoolean(split.isFinished());
 
             out.flush();
             return baos.toByteArray();
@@ -80,7 +85,7 @@ public class DynamoDbStreamsShardSplitSerializer
             throws IOException {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
                 DataInputStream in = new DataInputStream(bais)) {
-            if (version != getVersion()) {
+            if (!COMPATIBLE_VERSIONS.contains(version)) {
                 throw new VersionMismatchException(
                         "Trying to deserialize DynamoDbStreamsShardSplit serialized with unsupported version "
                                 + version
@@ -105,11 +110,18 @@ public class DynamoDbStreamsShardSplitSerializer
             if (hasParentShardId) {
                 parentShardId = in.readUTF();
             }
+
+            boolean isFinished = false;
+            if (version > 0) {
+                isFinished = in.readBoolean();
+            }
+
             return new DynamoDbStreamsShardSplit(
                     streamArn,
                     shardId,
                     new StartingPosition(shardIteratorType, startingMarker),
-                    parentShardId);
+                    parentShardId,
+                    isFinished);
         }
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/enumerator/DynamoDbStreamsSourceEnumeratorStateSerializerTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/enumerator/DynamoDbStreamsSourceEnumeratorStateSerializerTest.java
@@ -127,8 +127,8 @@ class DynamoDbStreamsSourceEnumeratorStateSerializerTest {
                 .isThrownBy(() -> serializer.deserialize(serializer.getVersion(), serialized))
                 .withMessageContaining(
                         "Trying to deserialize DynamoDbStreamsShardSplit serialized with unsupported version")
-                .withMessageContaining(String.valueOf(serializer.getVersion()))
-                .withMessageContaining(String.valueOf(wrongVersionStateSerializer.getVersion()));
+                .withMessageContaining(String.valueOf(splitSerializer.getVersion()))
+                .withMessageContaining(String.valueOf(wrongVersionSplitSerializer.getVersion()));
     }
 
     @Test

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/enumerator/assigner/UniformShardAssignerTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/enumerator/assigner/UniformShardAssignerTest.java
@@ -106,7 +106,9 @@ class UniformShardAssignerTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> assigner.assign(split, assignerContext))
                 .withMessageContaining(
-                        "Expected at least one registered reader. Unable to assign split.");
+                        String.format(
+                                "Expected at least one registered reader. Unable to assign split with id: %s.",
+                                split.splitId()));
     }
 
     private void createReaderWithAssignedSplits(

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplitTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/source/split/DynamoDbStreamsShardSplitTest.java
@@ -21,6 +21,12 @@ package org.apache.flink.connector.dynamodb.source.split;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 class DynamoDbStreamsShardSplitTest {
@@ -64,5 +70,29 @@ class DynamoDbStreamsShardSplitTest {
     @Test
     void testEquals() {
         EqualsVerifier.forClass(DynamoDbStreamsShardSplit.class).verify();
+    }
+
+    @Test
+    void testFinishedSplitsMapConstructor() {
+        NavigableMap<Long, Set<String>> finishedSplitsMap = new TreeMap<>();
+        Set<String> splits = new HashSet<>();
+        splits.add("split1");
+        splits.add("split2");
+        finishedSplitsMap.put(1L, splits);
+
+        DynamoDbStreamsShardSplit split =
+                new DynamoDbStreamsShardSplit(
+                        STREAM_ARN, SHARD_ID, STARTING_POSITION, PARENT_SHARD_ID, true);
+
+        assertThat(split.isFinished()).isTrue();
+    }
+
+    @Test
+    void testFinishedSplitsMapDefaultEmpty() {
+        DynamoDbStreamsShardSplit split =
+                new DynamoDbStreamsShardSplit(
+                        STREAM_ARN, SHARD_ID, STARTING_POSITION, PARENT_SHARD_ID);
+
+        assertThat(split.isFinished()).isFalse();
     }
 }


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Today Flink does not support distributed consistency of events from subtask (Task Manager) to coordinator (Job Manager) - https://issues.apache.org/jira/browse/FLINK-28639. As a result we have a race condition that can lead to a shard and it's children shards stopped being processed after a job restart.
- A checkpoint started
- Enumerator took a checkpoint (shard was assigned here)
- Enumerator sent checkpoint event to reader
- Before taking reader checkpoint, a SplitFinishedEvent came up in reader
- Reader took checkpoint
- Now, just after checkpoint complete, job restarted


This can lead to a shard lineage getting lost because of a shard being in ASSIGNED state in enumerator and not being part of any task manager state.
This PR changes the behaviour by also checkpointing the finished splits events received in between two checkpoints and on restore, those events again getting replayed.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment*
- *Added unit tests*
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

I manually verified this by running the connector in a local flink cluster which was getting restarted every 10 minutes. I see there is no checkpoint discrepancy and there is no issue in the clusster

I also added UTs for the change

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [x] Serializers have been changed
- [x] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
