### PR TITLE
[FLINK-36947][Connectors/Kinesis] Fix issue where excessive GetRecords calls are made on idle source causing high CPU utilisation and throttling

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -153,6 +153,12 @@ under the License.
             <artifactId>flink-architecture-tests-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -86,6 +86,8 @@ import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConf
 import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.EFO_DESCRIBE_CONSUMER_RETRY_STRATEGY_MAX_DELAY_OPTION;
 import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.EFO_DESCRIBE_CONSUMER_RETRY_STRATEGY_MIN_DELAY_OPTION;
 import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.READER_TYPE;
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL;
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_INTERVAL;
 
 /**
  * The {@link KinesisStreamsSource} is an exactly-once parallel streaming data source that

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisSourceConfigOptions.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisSourceConfigOptions.java
@@ -79,6 +79,20 @@ public class KinesisSourceConfigOptions {
                     .withDescription(
                             "The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard");
 
+    public static final ConfigOption<Duration> SHARD_GET_RECORDS_INTERVAL =
+            ConfigOptions.key("source.shard.get-records.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(0))
+                    .withDescription(
+                            "The interval in milliseconds between GetRecords calls");
+
+    public static final ConfigOption<Duration> SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL =
+            ConfigOptions.key("source.shard.get-records.idle-source-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(250))
+                    .withDescription(
+                            "The interval in milliseconds between GetRecords calls on an idle source");
+
     public static final ConfigOption<ReaderType> READER_TYPE =
             ConfigOptions.key("source.reader.type")
                     .enumType(ReaderType.class)

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
@@ -132,7 +132,7 @@ public abstract class KinesisShardSplitReaderBase
      * @return RecordBatch containing the fetched records and metadata. Returns null if there are no
      *     records but fetching should be retried at a later time.
      */
-    protected abstract RecordBatch fetchRecords(KinesisShardSplitState splitState);
+    protected abstract RecordBatch fetchRecords(KinesisShardSplitState splitState) throws IOException;
 
     @Override
     public void handleSplitsChanges(SplitsChange<KinesisShardSplit> splitsChanges) {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
@@ -26,9 +26,16 @@ import org.apache.flink.connector.kinesis.source.proxy.StreamProxy;
 import org.apache.flink.connector.kinesis.source.reader.KinesisShardSplitReaderBase;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitState;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 
+import java.io.IOException;
+import java.util.Date;
 import java.util.Map;
+
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL;
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_INTERVAL;
 
 /**
  * An implementation of the KinesisShardSplitReader that periodically polls the Kinesis stream to
@@ -40,6 +47,15 @@ public class PollingKinesisShardSplitReader extends KinesisShardSplitReaderBase 
     private final Configuration configuration;
     private final int maxRecordsToGet;
 
+    private final long getRecordsIntervalMillis;
+
+    private final long idleSourceGetRecordsIntervalMillis;
+
+    private long scheduledGetRecordTimeMillis = 0;
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PollingKinesisShardSplitReader.class);
+
     public PollingKinesisShardSplitReader(
             StreamProxy kinesisProxy,
             Map<String, KinesisShardMetrics> shardMetricGroupMap,
@@ -48,19 +64,49 @@ public class PollingKinesisShardSplitReader extends KinesisShardSplitReaderBase 
         this.kinesis = kinesisProxy;
         this.configuration = configuration;
         this.maxRecordsToGet = configuration.get(KinesisSourceConfigOptions.SHARD_GET_RECORDS_MAX);
+        this.getRecordsIntervalMillis = configuration.get(SHARD_GET_RECORDS_INTERVAL).toMillis();
+        this.idleSourceGetRecordsIntervalMillis = configuration.get(SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL).toMillis();
     }
 
     @Override
-    protected RecordBatch fetchRecords(KinesisShardSplitState splitState) {
+    protected RecordBatch fetchRecords(KinesisShardSplitState splitState) throws IOException {
+        sleepUntilScheduledGetRecordTime();
+
         GetRecordsResponse getRecordsResponse =
                 kinesis.getRecords(
                         splitState.getStreamArn(),
                         splitState.getShardId(),
                         splitState.getNextStartingPosition(),
                         this.maxRecordsToGet);
+
+        scheduleNextGetRecord(getRecordsResponse);
+
         boolean isCompleted = getRecordsResponse.nextShardIterator() == null;
         return new RecordBatch(
                 getRecordsResponse.records(), getRecordsResponse.millisBehindLatest(), isCompleted);
+    }
+
+    private void sleepUntilScheduledGetRecordTime() throws IOException {
+        long millisToNextGetRecord = scheduledGetRecordTimeMillis - System.currentTimeMillis();
+        if (millisToNextGetRecord > 0) {
+            try {
+                Thread.sleep(millisToNextGetRecord);
+            } catch (InterruptedException e) {
+                throw new IOException("Sleep was interrupted while waiting for next scheduled GetRecord ", e);
+            }
+        }
+    }
+
+    private void scheduleNextGetRecord(GetRecordsResponse getRecordsResponse) {
+        if (getRecordsResponse.records().isEmpty()) {
+            scheduledGetRecordTimeMillis = System.currentTimeMillis() + idleSourceGetRecordsIntervalMillis;
+            LOG.info("Got empty list from GetRecords, scheduling next get record to ", new Date(scheduledGetRecordTimeMillis));
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Got empty list from GetRecords, scheduling next get record to ", new Date(scheduledGetRecordTimeMillis));
+            }
+        } else {
+            scheduledGetRecordTimeMillis = System.currentTimeMillis() + getRecordsIntervalMillis;
+        }
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/polling/PollingKinesisShardSplitReader.java
@@ -100,7 +100,6 @@ public class PollingKinesisShardSplitReader extends KinesisShardSplitReaderBase 
     private void scheduleNextGetRecord(GetRecordsResponse getRecordsResponse) {
         if (getRecordsResponse.records().isEmpty()) {
             scheduledGetRecordTimeMillis = System.currentTimeMillis() + idleSourceGetRecordsIntervalMillis;
-            LOG.info("Got empty list from GetRecords, scheduling next get record to ", new Date(scheduledGetRecordTimeMillis));
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Got empty list from GetRecords, scheduling next get record to ", new Date(scheduledGetRecordTimeMillis));
             }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/KinesisStreamsSourceReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.metrics.testutils.MetricListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL;
+import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions.SHARD_GET_RECORDS_INTERVAL;
 import static org.apache.flink.connector.kinesis.source.util.KinesisStreamProxyProvider.getTestStreamProxy;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplit;
 import static org.apache.flink.connector.kinesis.source.util.TestUtil.getTestSplitState;
@@ -60,6 +63,8 @@ class KinesisStreamsSourceReaderTest {
         metricListener = new MetricListener();
         shardMetricGroupMap = new ConcurrentHashMap<>();
         sourceConfig = new Configuration();
+        sourceConfig.set(SHARD_GET_RECORDS_INTERVAL, Duration.ofMillis(0));
+        sourceConfig.set(SHARD_GET_RECORDS_IDLE_SOURCE_INTERVAL, Duration.ofMillis(250));
         StreamProxy testStreamProxy = getTestStreamProxy();
         Supplier<PollingKinesisShardSplitReader> splitReaderSupplier =
                 () ->

--- a/flink-connector-aws/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-aws/flink-connector-dynamodb/pom.xml
@@ -154,7 +154,6 @@ under the License.
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,12 @@ under the License.
                 <artifactId>annotations</artifactId>
                 <version>17.0.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <scope>test</scope>
+                <version>4.3.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose of the change

[FLINK-36947][Connectors/Kinesis] Fix issue where excessive GetRecords calls are made on idle source causing high CPU utilisation and throttling

https://issues.apache.org/jira/browse/FLINK-36947

## Verifying this change

- *Added unit tests*
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [X] New feature has been introduced
  - If yes, how is this documented? (JavaDocs)
