### PR TITLE
[hotfix][build] Update Python CI Java version to fix CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        flink: [ 1.20-SNAPSHOT ]
         java: [ '8, 11, 17']
     uses: ./.github/workflows/common.yml
     with:
@@ -38,8 +38,10 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        flink: [ 1.20-SNAPSHOT ]
+        java: [ '11' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}
 

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     strategy:
       matrix:
-        flink: [1.19.1, 1.20.0]
+        flink: [ 1.19.2, 1.20.1 ]
         java: [ '8, 11, 17']
     with:
       flink_version: ${{ matrix.flink }}
@@ -38,7 +38,9 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [1.19.0, 1.20.0]
+        flink: [ 1.19.2, 1.20.1 ]
+        java: [ '11']
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}


### PR DESCRIPTION


## Purpose of the change

Set up the Java version for Python CI to >= JDK 11.

## Verifying this change


This change is already covered by existing tests (Existing CI)

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
