### PR TITLE
[FLINK-37866] Migrate glue schema registry e2e test to use aws-kinesis-streams connector

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -76,10 +76,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Set Maven 3.8.5
+      - name: Set Maven 3.8.6
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.8.5
+          maven-version: 3.8.6
 
       - name: Create cache dirs
         run: mkdir -p ${{ env.FLINK_CACHE_DIR }}

--- a/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/pom.xml
@@ -55,35 +55,14 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <!-- Required for Kinesalite. -->
-                        <!-- Including shaded and non-shaded conf to support test running from Maven and IntelliJ -->
-                        <com.amazonaws.sdk.disableCbor>true</com.amazonaws.sdk.disableCbor>
-                        <com.amazonaws.sdk.disableCertChecking>true</com.amazonaws.sdk.disableCertChecking>
-                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>true</org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>
-                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>true</org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GSRKinesisPubsubClient.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GSRKinesisPubsubClient.java
@@ -17,7 +17,8 @@
 
 package org.apache.flink.glue.schema.registry.test;
 
-import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.kinesis.source.proxy.ListShardsStartingPosition;
 
 import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
@@ -26,61 +27,165 @@ import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDes
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
+import com.google.common.collect.Lists;
 import org.apache.avro.generic.GenericRecord;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.glue.model.DataFormat;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+import software.amazon.awssdk.services.kinesis.model.StreamStatus;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Simple client to publish and retrieve messages, using the AWS Kinesis SDK, Flink Kinesis
  * Connectors and Glue Schema Registry classes.
  */
 public class GSRKinesisPubsubClient {
-    private final KinesisPubsubClient client;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GSRKinesisPubsubClient.class);
+
+    private final KinesisClient kinesisClient;
     private final GlueSchemaRegistrySerializationFacade serializationFacade;
     private final GlueSchemaRegistryDeserializationFacade deserializationFacade;
 
     public GSRKinesisPubsubClient(
-            Properties properties, AwsCredentialsProvider gsrCredentialsProvider) {
-        this.client = new KinesisPubsubClient(properties);
+            KinesisClient kinesisClient, AwsCredentialsProvider gsrCredentialsProvider) {
+        this.kinesisClient = kinesisClient;
         this.serializationFacade = createSerializationFacade(gsrCredentialsProvider);
         this.deserializationFacade = createDeserializationFacade(gsrCredentialsProvider);
     }
 
     public void sendMessage(String schema, String streamName, GenericRecord msg) {
-        UUID schemaVersionId =
-                serializationFacade.getOrRegisterSchemaVersion(
-                        AWSSerializerInput.builder()
-                                .schemaDefinition(schema)
-                                .dataFormat(DataFormat.AVRO.name())
-                                .schemaName(streamName)
-                                .transportName(streamName)
-                                .build());
+        try {
+            UUID schemaVersionId =
+                    serializationFacade.getOrRegisterSchemaVersion(
+                            AWSSerializerInput.builder()
+                                    .schemaDefinition(schema.toString())
+                                    .dataFormat(DataFormat.AVRO.name())
+                                    .schemaName(streamName)
+                                    .transportName(streamName)
+                                    .build());
 
-        client.sendMessage(
-                streamName, serializationFacade.serialize(DataFormat.AVRO, msg, schemaVersionId));
+            sendMessage(
+                    streamName,
+                    serializationFacade.serialize(DataFormat.AVRO, msg, schemaVersionId));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public List<Object> readAllMessages(String streamName) throws Exception {
+    private void sendMessage(String topic, byte[]... messages) {
+        for (List<byte[]> partition : Lists.partition(Arrays.asList(messages), 500)) {
+            List<PutRecordsRequestEntry> entries =
+                    partition.stream()
+                            .map(
+                                    msg ->
+                                            PutRecordsRequestEntry.builder()
+                                                    .partitionKey("fakePartitionKey")
+                                                    .data(SdkBytes.fromByteArray(msg))
+                                                    .build())
+                            .collect(Collectors.toList());
+            PutRecordsRequest requests =
+                    PutRecordsRequest.builder().streamName(topic).records(entries).build();
 
-        return client.readAllMessages(
+            PutRecordsResponse putRecordsResponse = kinesisClient.putRecords(requests);
+            for (PutRecordsResultEntry result : putRecordsResponse.records()) {
+                LOGGER.debug("added record: {}", result.sequenceNumber());
+            }
+        }
+    }
+
+    private <T> List<T> readAllMessages(
+            String streamName, String streamARN, Function<byte[], T> deserialiser) {
+        List<Shard> shards = new ArrayList<>();
+
+        ListShardsResponse listShardsResponse;
+        String nextToken = null;
+        do {
+            listShardsResponse =
+                    kinesisClient.listShards(
+                            ListShardsRequest.builder()
+                                    .streamName(nextToken == null ? streamName : null)
+                                    .shardFilter(
+                                            nextToken == null
+                                                    ? ListShardsStartingPosition.fromStart()
+                                                            .getShardFilter()
+                                                    : null)
+                                    .nextToken(nextToken)
+                                    .build());
+
+            shards.addAll(listShardsResponse.shards());
+            nextToken = listShardsResponse.nextToken();
+        } while (nextToken != null);
+
+        int maxRecordsToFetch = 10;
+        List<T> messages = new ArrayList<>();
+
+        for (Shard shard : shards) {
+            GetShardIteratorResponse getShardIteratorResponse =
+                    kinesisClient.getShardIterator(
+                            GetShardIteratorRequest.builder()
+                                    .shardId(shard.shardId())
+                                    .streamName(streamName)
+                                    .streamARN(streamARN)
+                                    .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                    .build());
+
+            GetRecordsResponse getRecordsResponse =
+                    kinesisClient.getRecords(
+                            GetRecordsRequest.builder()
+                                    .streamARN(streamARN)
+                                    .shardIterator(getShardIteratorResponse.shardIterator())
+                                    .limit(maxRecordsToFetch)
+                                    .build());
+
+            for (Record record : getRecordsResponse.records()) {
+                messages.add(deserialiser.apply(record.data().asByteArray()));
+            }
+        }
+        return messages;
+    }
+
+    public List<Object> readAllMessages(String streamName, String streamARN) {
+        return readAllMessages(
                 streamName,
+                streamARN,
                 bytes ->
                         deserializationFacade.deserialize(
                                 AWSDeserializerInput.builder()
                                         .buffer(ByteBuffer.wrap(bytes))
                                         .transportName(streamName)
                                         .build()));
-    }
-
-    public void createStream(String stream, int shards, Properties props) throws Exception {
-        client.createTopic(stream, shards, props);
     }
 
     private Map<String, Object> getSerDeConfigs() {
@@ -109,5 +214,36 @@ public class GSRKinesisPubsubClient {
                 .credentialProvider(credentialsProvider)
                 .configs(getSerDeConfigs())
                 .build();
+    }
+
+    public void prepareStream(String streamName) throws Exception {
+        final RateLimiter rateLimiter =
+                RateLimiterBuilder.newBuilder()
+                        .withRate(1, SECONDS)
+                        .withConstantThroughput()
+                        .build();
+
+        kinesisClient.createStream(
+                CreateStreamRequest.builder().streamName(streamName).shardCount(2).build());
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        while (!rateLimiter.getWhenReady(() -> streamExists(streamName))) {
+            if (deadline.isOverdue()) {
+                throw new RuntimeException("Failed to create stream within time");
+            }
+        }
+    }
+
+    private boolean streamExists(final String streamName) {
+        try {
+            return kinesisClient
+                            .describeStream(
+                                    DescribeStreamRequest.builder().streamName(streamName).build())
+                            .streamDescription()
+                            .streamStatus()
+                    == StreamStatus.ACTIVE;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/pom.xml
@@ -55,35 +55,14 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <!-- Required for Kinesalite. -->
-                        <!-- Including shaded and non-shaded conf to support test running from Maven and IntelliJ -->
-                        <com.amazonaws.sdk.disableCbor>true</com.amazonaws.sdk.disableCbor>
-                        <com.amazonaws.sdk.disableCertChecking>true</com.amazonaws.sdk.disableCertChecking>
-                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>true</org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor>
-                        <org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>true</org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GSRKinesisPubsubClient.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GSRKinesisPubsubClient.java
@@ -17,67 +17,174 @@
 
 package org.apache.flink.glue.schema.registry.test.json;
 
-import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.kinesis.source.proxy.ListShardsStartingPosition;
 
 import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
+import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.google.common.collect.Lists;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.glue.model.DataFormat;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+import software.amazon.awssdk.services.kinesis.model.StreamStatus;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Simple client to publish and retrieve messages, using the AWS Kinesis SDK, Flink Kinesis
  * Connectors and Glue Schema Registry classes.
  */
 public class GSRKinesisPubsubClient {
-    private final KinesisPubsubClient client;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GSRKinesisPubsubClient.class);
+
+    private final KinesisClient kinesisClient;
     private final GlueSchemaRegistrySerializationFacade serializationFacade;
     private final GlueSchemaRegistryDeserializationFacade deserializationFacade;
 
     public GSRKinesisPubsubClient(
-            Properties properties, AwsCredentialsProvider gsrCredentialsProvider) {
-        this.client = new KinesisPubsubClient(properties);
+            KinesisClient kinesisClient, AwsCredentialsProvider gsrCredentialsProvider) {
+        this.kinesisClient = kinesisClient;
         this.serializationFacade = createSerializationFacade(gsrCredentialsProvider);
         this.deserializationFacade = createDeserializationFacade(gsrCredentialsProvider);
     }
 
-    public void sendMessage(String schema, String streamName, Object msg) {
-        UUID schemaVersionId =
-                serializationFacade.getOrRegisterSchemaVersion(
-                        AWSSerializerInput.builder()
-                                .schemaDefinition(schema)
-                                .dataFormat(DataFormat.JSON.name())
-                                .schemaName(streamName)
-                                .transportName(streamName)
-                                .build());
+    public void sendMessage(String schema, String streamName, JsonDataWithSchema msg) {
+        try {
+            UUID schemaVersionId =
+                    serializationFacade.getOrRegisterSchemaVersion(
+                            AWSSerializerInput.builder()
+                                    .schemaDefinition(schema.toString())
+                                    .dataFormat(DataFormat.JSON.name())
+                                    .schemaName(streamName)
+                                    .transportName(streamName)
+                                    .build());
 
-        client.sendMessage(
-                streamName, serializationFacade.serialize(DataFormat.JSON, msg, schemaVersionId));
+            sendMessage(
+                    streamName,
+                    serializationFacade.serialize(DataFormat.JSON, msg, schemaVersionId));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public List<Object> readAllMessages(String streamName) throws Exception {
-        return client.readAllMessages(
+    private void sendMessage(String topic, byte[]... messages) {
+        for (List<byte[]> partition : Lists.partition(Arrays.asList(messages), 500)) {
+            List<PutRecordsRequestEntry> entries =
+                    partition.stream()
+                            .map(
+                                    msg ->
+                                            PutRecordsRequestEntry.builder()
+                                                    .partitionKey("fakePartitionKey")
+                                                    .data(SdkBytes.fromByteArray(msg))
+                                                    .build())
+                            .collect(Collectors.toList());
+            PutRecordsRequest requests =
+                    PutRecordsRequest.builder().streamName(topic).records(entries).build();
+
+            PutRecordsResponse putRecordsResponse = kinesisClient.putRecords(requests);
+            for (PutRecordsResultEntry result : putRecordsResponse.records()) {
+                LOGGER.debug("added record: {}", result.sequenceNumber());
+            }
+        }
+    }
+
+    private <T> List<T> readAllMessages(
+            String streamName, String streamARN, Function<byte[], T> deserialiser) {
+        List<Shard> shards = new ArrayList<>();
+
+        ListShardsResponse listShardsResponse;
+        String nextToken = null;
+        do {
+            listShardsResponse =
+                    kinesisClient.listShards(
+                            ListShardsRequest.builder()
+                                    .streamName(nextToken == null ? streamName : null)
+                                    .shardFilter(
+                                            nextToken == null
+                                                    ? ListShardsStartingPosition.fromStart()
+                                                            .getShardFilter()
+                                                    : null)
+                                    .nextToken(nextToken)
+                                    .build());
+
+            shards.addAll(listShardsResponse.shards());
+            nextToken = listShardsResponse.nextToken();
+        } while (nextToken != null);
+
+        int maxRecordsToFetch = 10;
+        List<T> messages = new ArrayList<>();
+
+        for (Shard shard : shards) {
+            GetShardIteratorResponse getShardIteratorResponse =
+                    kinesisClient.getShardIterator(
+                            GetShardIteratorRequest.builder()
+                                    .shardId(shard.shardId())
+                                    .streamName(streamName)
+                                    .streamARN(streamARN)
+                                    .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                    .build());
+
+            GetRecordsResponse getRecordsResponse =
+                    kinesisClient.getRecords(
+                            GetRecordsRequest.builder()
+                                    .streamARN(streamARN)
+                                    .shardIterator(getShardIteratorResponse.shardIterator())
+                                    .limit(maxRecordsToFetch)
+                                    .build());
+
+            for (Record record : getRecordsResponse.records()) {
+                messages.add(deserialiser.apply(record.data().asByteArray()));
+            }
+        }
+        return messages;
+    }
+
+    public List<Object> readAllMessages(String streamName, String streamARN) {
+        return readAllMessages(
                 streamName,
+                streamARN,
                 bytes ->
                         deserializationFacade.deserialize(
                                 AWSDeserializerInput.builder()
                                         .buffer(ByteBuffer.wrap(bytes))
                                         .transportName(streamName)
                                         .build()));
-    }
-
-    public void createStream(String stream, int shards, Properties props) throws Exception {
-        client.createTopic(stream, shards, props);
     }
 
     private Map<String, Object> getSerDeConfigs() {
@@ -103,5 +210,36 @@ public class GSRKinesisPubsubClient {
                 .credentialProvider(credentialsProvider)
                 .configs(getSerDeConfigs())
                 .build();
+    }
+
+    public void prepareStream(String streamName) throws Exception {
+        final RateLimiter rateLimiter =
+                RateLimiterBuilder.newBuilder()
+                        .withRate(1, SECONDS)
+                        .withConstantThroughput()
+                        .build();
+
+        kinesisClient.createStream(
+                CreateStreamRequest.builder().streamName(streamName).shardCount(2).build());
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        while (!rateLimiter.getWhenReady(() -> streamExists(streamName))) {
+            if (deadline.isOverdue()) {
+                throw new RuntimeException("Failed to create stream within time");
+            }
+        }
+    }
+
+    private boolean streamExists(final String streamName) {
+        try {
+            return kinesisClient
+                            .describeStream(
+                                    DescribeStreamRequest.builder().streamName(streamName).build())
+                            .streamDescription()
+                            .streamStatus()
+                    == StreamStatus.ACTIVE;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/flink-connector-aws-e2e-tests/pom.xml
+++ b/flink-connector-aws-e2e-tests/pom.xml
@@ -35,6 +35,7 @@ under the License.
 
     <properties>
         <scala.binary.version>2.12</scala.binary.version>
+        <argLine></argLine>
     </properties>
 
     <modules>
@@ -67,6 +68,15 @@ under the License.
 
     <profiles>
         <profile>
+            <id>java-9-plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
+            </properties>
+        </profile>
+        <profile>
             <id>run-end-to-end-tests</id>
             <build>
                 <plugins>
@@ -90,6 +100,7 @@ under the License.
                                         <moduleDir>${project.basedir}</moduleDir>
                                     </systemPropertyVariables>
                                     <excludedGroups>requires-aws-credentials</excludedGroups>
+                                    <argLine>${argLine}</argLine>
                                 </configuration>
                             </execution>
                         </executions>
@@ -121,6 +132,7 @@ under the License.
                                     <systemPropertyVariables>
                                         <moduleDir>${project.basedir}</moduleDir>
                                     </systemPropertyVariables>
+                                    <argLine>${argLine}</argLine>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION


<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

[FLINK-37866] Migrate glue schema registry e2e test to use aws-kinesis-streams connector

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Ran IT Test locally and verified test pass:

```
[INFO] --- maven-surefire-plugin:3.0.0-M5:test (end-to-end-tests) @ flink-formats-json-glue-schema-registry-e2e-tests ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.flink.glue.schema.registry.test.json.GlueSchemaRegistryJsonKinesisITCase
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 56.263 s - in org.apache.flink.glue.schema.registry.test.json.GlueSchemaRegistryJsonKinesisITCase
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

```

```
[INFO] --- maven-surefire-plugin:3.0.0-M5:test (end-to-end-tests) @ flink-formats-avro-glue-schema-registry-e2e-tests ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.flink.glue.schema.registry.test.GlueSchemaRegistryAvroKinesisITCase
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.361 s - in org.apache.flink.glue.schema.registry.test.GlueSchemaRegistryAvroKinesisITCase
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

```

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
