### PR TITLE
[hotfix][build] Update Python CI Java version to fix CI

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -39,6 +39,8 @@ jobs:
     strategy:
       matrix:
         flink: [1.20.0]
+        java: [ '11' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}


### PR DESCRIPTION
## Purpose of the change

Specify Java version to 11 to allow CI to run against the latest Flink artefacts.

## Verifying this change

This change is already covered by existing tests, such as Github workflow.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
