### PR TITLE
[FLINK-37968] Bump Netty version to v4.1.122.Final

### DIFF
--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-firehose/src/main/resources/META-INF/NOTICE
@@ -37,16 +37,16 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:arns:2.26.19
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
-- io.netty:netty-transport:4.1.86.Final
-- io.netty:netty-transport-native-unix-common:4.1.86.Final
-- io.netty:netty-transport-classes-epoll:4.1.86.Final
-- io.netty:netty-resolver:4.1.86.Final
-- io.netty:netty-handler:4.1.86.Final
-- io.netty:netty-common:4.1.86.Final
-- io.netty:netty-codec:4.1.86.Final
-- io.netty:netty-codec-http:4.1.86.Final
-- io.netty:netty-codec-http2:4.1.86.Final
-- io.netty:netty-buffer:4.1.86.Final
+- io.netty:netty-transport:4.1.122.Final
+- io.netty:netty-transport-native-unix-common:4.1.122.Final
+- io.netty:netty-transport-classes-epoll:4.1.122.Final
+- io.netty:netty-resolver:4.1.122.Final
+- io.netty:netty-handler:4.1.122.Final
+- io.netty:netty-common:4.1.122.Final
+- io.netty:netty-codec:4.1.122.Final
+- io.netty:netty-codec-http:4.1.122.Final
+- io.netty:netty-codec-http2:4.1.122.Final
+- io.netty:netty-buffer:4.1.122.Final
 - commons-logging:commons-logging:1.1.3
 
 This project bundles the following dependencies under the MIT-0 license (https://spdx.org/licenses/MIT-0.html).

--- a/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-aws-kinesis-streams/src/main/resources/META-INF/NOTICE
@@ -39,16 +39,16 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:annotations:2.26.19
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
-- io.netty:netty-transport:4.1.86.Final
-- io.netty:netty-transport-native-unix-common:4.1.86.Final
-- io.netty:netty-transport-classes-epoll:4.1.86.Final
-- io.netty:netty-resolver:4.1.86.Final
-- io.netty:netty-handler:4.1.86.Final
-- io.netty:netty-common:4.1.86.Final
-- io.netty:netty-codec:4.1.86.Final
-- io.netty:netty-codec-http:4.1.86.Final
-- io.netty:netty-codec-http2:4.1.86.Final
-- io.netty:netty-buffer:4.1.86.Final
+- io.netty:netty-transport:4.1.122.Final
+- io.netty:netty-transport-native-unix-common:4.1.122.Final
+- io.netty:netty-transport-classes-epoll:4.1.122.Final
+- io.netty:netty-resolver:4.1.122.Final
+- io.netty:netty-handler:4.1.122.Final
+- io.netty:netty-common:4.1.122.Final
+- io.netty:netty-codec:4.1.122.Final
+- io.netty:netty-codec-http:4.1.122.Final
+- io.netty:netty-codec-http2:4.1.122.Final
+- io.netty:netty-buffer:4.1.122.Final
 - commons-logging:commons-logging:1.1.3
 
 

--- a/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-aws/flink-sql-connector-dynamodb/src/main/resources/META-INF/NOTICE
@@ -38,16 +38,16 @@ This project bundles the following dependencies under the Apache Software Licens
 - software.amazon.awssdk:annotations:2.26.19
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
-- io.netty:netty-transport:4.1.86.Final
-- io.netty:netty-transport-native-unix-common:4.1.86.Final
-- io.netty:netty-transport-classes-epoll:4.1.86.Final
-- io.netty:netty-resolver:4.1.86.Final
-- io.netty:netty-handler:4.1.86.Final
-- io.netty:netty-common:4.1.86.Final
-- io.netty:netty-codec:4.1.86.Final
-- io.netty:netty-codec-http:4.1.86.Final
-- io.netty:netty-codec-http2:4.1.86.Final
-- io.netty:netty-buffer:4.1.86.Final
+- io.netty:netty-transport:4.1.122.Final
+- io.netty:netty-transport-native-unix-common:4.1.122.Final
+- io.netty:netty-transport-classes-epoll:4.1.122.Final
+- io.netty:netty-resolver:4.1.122.Final
+- io.netty:netty-handler:4.1.122.Final
+- io.netty:netty-common:4.1.122.Final
+- io.netty:netty-codec:4.1.122.Final
+- io.netty:netty-codec-http:4.1.122.Final
+- io.netty:netty-codec-http2:4.1.122.Final
+- io.netty:netty-buffer:4.1.122.Final
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.15
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
 
     <properties>
         <aws.sdkv2.version>2.26.19</aws.sdkv2.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.122.Final</netty.version>
         <flink.version>2.0.0</flink.version>
         <jackson-bom.version>2.14.3</jackson-bom.version>
         <glue.schema.registry.version>1.1.18</glue.schema.registry.version>


### PR DESCRIPTION
## Purpose of the change
Bump Netty version to v4.1.122.Final

## Verifying this change
This change is already covered by existing tests.

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
