### PR TITLE
[hotfix][docs] Fix the typo of syntax for ref link

### DIFF
--- a/docs/content/docs/connectors/datastream/kinesis.md
+++ b/docs/content/docs/connectors/datastream/kinesis.md
@@ -161,7 +161,7 @@ the source does not fail, and will start reading from the earliest possible even
 
 If users want to restore a Flink job from an existing checkpoint or savepoint but want to respect the configured starting position of 
 the stream, users can change the `uid` of the `KinesisStreamsSource` operator to effectively restore this operator without state.
-This is in line with [Flink best practices]({{< ref "docs/ops/production_ready/#set-uuids-for-all-operators" >}}).
+This is in line with [Flink best practices]({{< ref "docs/ops/production_ready#set-uuids-for-all-operators" >}}).
 
 ### Shard Assignment Strategy
 For most use cases, users would prefer a uniform distribution of records across parallel subtasks. This prevents data skew if data is evenly distributed in the Kinesis Data Stream.


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

[hotfix][docs] Fix the typo of syntax for ref link 
for  https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=72232&view=logs&j=c5d67f7d-375d-5407-4743-f9d0c4436a81&t=38411795-40c9-51fa-10b0-bd083cf9f5a5 

## Verifying this change

N.A

## Significant changes

  - If yes, how is this documented? (not applicable / **docs** / JavaDocs / not documented)
