### PR TITLE
[FLINK-31942][Connectors/DynamoDB] Added support for conditional writ…

### DIFF
--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbBeanElementConverter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbBeanElementConverter.java
@@ -25,10 +25,26 @@ import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * A generic {@link ElementConverter} that uses the dynamodb-enhanced client to build a {@link
  * DynamoDbWriteRequest} from a POJO annotated with {@link DynamoDbBean}.
+ *
+ * <p>Supports all three write request types:
+ *
+ * <ul>
+ *   <li>{@link DynamoDbWriteRequestType#PUT} - maps the full POJO to an item
+ *   <li>{@link DynamoDbWriteRequestType#DELETE} - extracts only the primary key from the POJO
+ *   <li>{@link DynamoDbWriteRequestType#UPDATE} - extracts the primary key from the POJO and uses
+ *       the provided update expression
+ * </ul>
+ *
+ * <p>Condition expressions can be set for any type to enable conditional writes via individual API
+ * calls instead of {@code BatchWriteItem}.
  *
  * @param <InputT> The type of the {@link DynamoDbBean} to convert into {@link DynamoDbWriteRequest}
  */
@@ -40,15 +56,43 @@ public class DynamoDbBeanElementConverter<InputT>
 
     private final Class<InputT> recordType;
     private final boolean ignoreNulls;
+    private final DynamoDbWriteRequestType type;
+    private final String updateExpression;
+    private final String conditionExpression;
+    private final Map<String, String> expressionAttributeNames;
+    private final Map<String, AttributeValue> expressionAttributeValues;
     private transient BeanTableSchema<InputT> tableSchema;
+    private transient Collection<String> keyAttributeNames;
 
     public DynamoDbBeanElementConverter(final Class<InputT> recordType) {
         this(recordType, false);
     }
 
     public DynamoDbBeanElementConverter(final Class<InputT> recordType, final boolean ignoreNulls) {
+        this(recordType, ignoreNulls, DynamoDbWriteRequestType.PUT, null, null, null, null);
+    }
+
+    private DynamoDbBeanElementConverter(
+            final Class<InputT> recordType,
+            final boolean ignoreNulls,
+            final DynamoDbWriteRequestType type,
+            final String updateExpression,
+            final String conditionExpression,
+            final Map<String, String> expressionAttributeNames,
+            final Map<String, AttributeValue> expressionAttributeValues) {
         this.recordType = recordType;
         this.ignoreNulls = ignoreNulls;
+        this.type = Preconditions.checkNotNull(type, "Type must not be null");
+        this.updateExpression = updateExpression;
+        this.conditionExpression = conditionExpression;
+        this.expressionAttributeNames = expressionAttributeNames;
+        this.expressionAttributeValues = expressionAttributeValues;
+
+        if (type == DynamoDbWriteRequestType.UPDATE) {
+            Preconditions.checkNotNull(
+                    updateExpression,
+                    "Update expression must not be null for UPDATE requests.");
+        }
 
         // Attempt to create a table schema now to bubble up errors before starting job
         createTableSchema(recordType);
@@ -57,18 +101,106 @@ public class DynamoDbBeanElementConverter<InputT>
     @Override
     public DynamoDbWriteRequest apply(InputT element, SinkWriter.Context context) {
         Preconditions.checkNotNull(tableSchema, "Table schema has not been initialized");
-        return new DynamoDbWriteRequest.Builder()
-                .setType(DynamoDbWriteRequestType.PUT)
-                .setItem(tableSchema.itemToMap(element, ignoreNulls))
-                .build();
+        Map<String, AttributeValue> item =
+                type == DynamoDbWriteRequestType.PUT
+                        ? tableSchema.itemToMap(element, ignoreNulls)
+                        : tableSchema.itemToMap(element, keyAttributeNames);
+        DynamoDbWriteRequest.Builder builder =
+                new DynamoDbWriteRequest.Builder().setType(type).setItem(item);
+        if (updateExpression != null) {
+            builder.setUpdateExpression(updateExpression);
+        }
+        if (conditionExpression != null) {
+            builder.setConditionExpression(conditionExpression);
+        }
+        if (expressionAttributeNames != null) {
+            builder.setExpressionAttributeNames(expressionAttributeNames);
+        }
+        if (expressionAttributeValues != null) {
+            builder.setExpressionAttributeValues(expressionAttributeValues);
+        }
+        return builder.build();
     }
 
     @Override
     public void open(WriterInitContext context) {
         tableSchema = createTableSchema(recordType);
+        // DELETE and UPDATE only need the primary key attributes from the POJO, not the full item.
+        // PUT uses the complete item map.
+        if (type == DynamoDbWriteRequestType.DELETE || type == DynamoDbWriteRequestType.UPDATE) {
+            keyAttributeNames = tableSchema.tableMetadata().primaryKeys();
+        }
     }
 
     private BeanTableSchema<InputT> createTableSchema(final Class<InputT> recordType) {
         return BeanTableSchema.create(recordType);
+    }
+
+    /** Builder for {@link DynamoDbBeanElementConverter}. */
+    public static class ElementConverterBuilder<InputT> {
+        private final Class<InputT> recordType;
+        private boolean ignoreNulls = false;
+        private DynamoDbWriteRequestType type = DynamoDbWriteRequestType.PUT;
+        private String updateExpression;
+        private String conditionExpression;
+        private Map<String, String> expressionAttributeNames;
+        private Map<String, AttributeValue> expressionAttributeValues;
+
+        private ElementConverterBuilder(Class<InputT> recordType) {
+            this.recordType = recordType;
+        }
+
+        public ElementConverterBuilder<InputT> setIgnoreNulls(boolean ignoreNulls) {
+            this.ignoreNulls = ignoreNulls;
+            return this;
+        }
+
+        public ElementConverterBuilder<InputT> setType(DynamoDbWriteRequestType type) {
+            this.type = type;
+            return this;
+        }
+
+        public ElementConverterBuilder<InputT> setUpdateExpression(String updateExpression) {
+            this.updateExpression = updateExpression;
+            return this;
+        }
+
+        public ElementConverterBuilder<InputT> setConditionExpression(String conditionExpression) {
+            this.conditionExpression = conditionExpression;
+            return this;
+        }
+
+        public ElementConverterBuilder<InputT> setExpressionAttributeNames(
+                Map<String, String> expressionAttributeNames) {
+            this.expressionAttributeNames = expressionAttributeNames;
+            return this;
+        }
+
+        public ElementConverterBuilder<InputT> setExpressionAttributeValues(
+                Map<String, AttributeValue> expressionAttributeValues) {
+            this.expressionAttributeValues = expressionAttributeValues;
+            return this;
+        }
+
+        public DynamoDbBeanElementConverter<InputT> build() {
+            Preconditions.checkArgument(
+                    type != DynamoDbWriteRequestType.UPDATE || updateExpression != null,
+                    "updateExpression is required for UPDATE type.");
+            Preconditions.checkArgument(
+                    type == DynamoDbWriteRequestType.UPDATE || updateExpression == null,
+                    "updateExpression is only allowed for UPDATE type.");
+            return new DynamoDbBeanElementConverter<>(
+                    recordType,
+                    ignoreNulls,
+                    type,
+                    updateExpression,
+                    conditionExpression,
+                    expressionAttributeNames,
+                    expressionAttributeValues);
+        }
+    }
+
+    public static <InputT> ElementConverterBuilder<InputT> builder(Class<InputT> recordType) {
+        return new ElementConverterBuilder<>(recordType);
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSink.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSink.java
@@ -75,6 +75,22 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *       single batch takes precedence.
  * </ul>
  *
+ * <p>The sink supports three write request types via {@link DynamoDbWriteRequestType}:
+ *
+ * <ul>
+ *   <li>{@code PUT} - writes a full item using {@code BatchWriteItem} or {@code PutItem} (when a
+ *       condition expression is set)
+ *   <li>{@code DELETE} - deletes an item by key using {@code BatchWriteItem} or {@code DeleteItem}
+ *       (when a condition expression is set)
+ *   <li>{@code UPDATE} - updates specific attributes of an item using {@code UpdateItem}, always
+ *       processed as individual requests since {@code BatchWriteItem} does not support updates
+ * </ul>
+ *
+ * <p>Requests without condition expressions (PUT/DELETE) are sent via {@code BatchWriteItem} for
+ * efficiency. Requests with condition expressions and all UPDATE requests are sent as individual
+ * {@code PutItem}, {@code DeleteItem}, or {@code UpdateItem} calls. Both paths execute
+ * concurrently.
+ *
  * <p>Please see the writer implementation in {@link DynamoDbSinkWriter}
  *
  * @param <InputT> Type of the elements handled by this sink

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriter.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriter.java
@@ -32,6 +32,7 @@ import org.apache.flink.connector.dynamodb.util.PrimaryKeyBuilder;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +40,13 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutRequest;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 import java.util.ArrayList;
@@ -51,6 +55,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonMap;
 import static org.apache.flink.connector.aws.util.AWSCredentialFatalExceptionClassifiers.getInvalidCredentialsExceptionClassifier;
@@ -164,6 +170,59 @@ class DynamoDbSinkWriter<InputT> extends AsyncSinkWriter<InputT, DynamoDbWriteRe
             List<DynamoDbWriteRequest> requestEntries,
             ResultHandler<DynamoDbWriteRequest> resultHandler) {
 
+        List<DynamoDbWriteRequest> batchRequests = new ArrayList<>();
+        List<DynamoDbWriteRequest> singleRequests = new ArrayList<>();
+
+        for (DynamoDbWriteRequest request : requestEntries) {
+            if (isSingleRequest(request)) {
+                singleRequests.add(request);
+            } else {
+                batchRequests.add(request);
+            }
+        }
+
+        // Shared state to collect results from concurrent batch and single paths.
+        // ResultHandler is called exactly once in whenComplete after both paths finish.
+        ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures =
+                new ConcurrentLinkedQueue<>();
+        AtomicReference<Exception> fatalException = new AtomicReference<>();
+
+        CompletableFuture<Void> batchFuture =
+                submitBatchRequests(
+                        batchRequests, retryableFailures, fatalException);
+
+        CompletableFuture<Void> singleFuture =
+                submitSingleRequests(
+                        singleRequests, retryableFailures, fatalException);
+
+        CompletableFuture.allOf(batchFuture, singleFuture)
+                .whenComplete(
+                        (ignored, err) -> {
+                            if (fatalException.get() != null) {
+                                resultHandler.completeExceptionally(fatalException.get());
+                            } else if (!retryableFailures.isEmpty()) {
+                                resultHandler.retryForEntries(
+                                        new ArrayList<>(retryableFailures));
+                            } else {
+                                resultHandler.complete();
+                            }
+                        });
+    }
+
+    private boolean isSingleRequest(DynamoDbWriteRequest request) {
+        return request.getType() == DynamoDbWriteRequestType.UPDATE
+                || request.getConditionExpression() != null;
+    }
+
+    private CompletableFuture<Void> submitBatchRequests(
+            List<DynamoDbWriteRequest> requestEntries,
+            ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures,
+            AtomicReference<Exception> fatalException) {
+
+        if (requestEntries.isEmpty()) {
+            return FutureUtils.completedVoidFuture();
+        }
+
         List<WriteRequest> items = new ArrayList<>();
 
         if (CollectionUtil.isNullOrEmpty(overwriteByPartitionKeys)) {
@@ -181,28 +240,32 @@ class DynamoDbSinkWriter<InputT> extends AsyncSinkWriter<InputT, DynamoDbWriteRe
             items.addAll(container.values());
         }
 
-        CompletableFuture<BatchWriteItemResponse> future =
-                clientProvider
-                        .getClient()
-                        .batchWriteItem(
-                                BatchWriteItemRequest.builder()
-                                        .requestItems(singletonMap(tableName, items))
-                                        .build());
-
-        future.whenComplete(
-                (response, err) -> {
-                    if (err != null) {
-                        handleFullyFailedRequest(err, requestEntries, resultHandler);
-                    } else if (!CollectionUtil.isNullOrEmpty(response.unprocessedItems())) {
-                        handlePartiallyUnprocessedRequest(response, resultHandler);
-                    } else {
-                        resultHandler.complete();
-                    }
-                });
+        return clientProvider
+                .getClient()
+                .batchWriteItem(
+                        BatchWriteItemRequest.builder()
+                                .requestItems(singletonMap(tableName, items))
+                                .build())
+                .handle(
+                        (response, err) -> {
+                            if (err != null) {
+                                handleFullyFailedRequest(
+                                        err,
+                                        requestEntries,
+                                        retryableFailures,
+                                        fatalException);
+                            } else if (!CollectionUtil.isNullOrEmpty(
+                                    response.unprocessedItems())) {
+                                handlePartiallyUnprocessedRequest(
+                                        response, retryableFailures);
+                            }
+                            return null;
+                        });
     }
 
     private void handlePartiallyUnprocessedRequest(
-            BatchWriteItemResponse response, ResultHandler<DynamoDbWriteRequest> resultHandler) {
+            BatchWriteItemResponse response,
+            ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures) {
         List<DynamoDbWriteRequest> unprocessed = new ArrayList<>();
 
         for (WriteRequest writeRequest : response.unprocessedItems().get(tableName)) {
@@ -213,37 +276,95 @@ class DynamoDbSinkWriter<InputT> extends AsyncSinkWriter<InputT, DynamoDbWriteRe
         numRecordsSendErrorsCounter.inc(unprocessed.size());
         numRecordsSendPartialFailure.inc(unprocessed.size());
 
-        resultHandler.retryForEntries(unprocessed);
+        retryableFailures.addAll(unprocessed);
     }
 
     private void handleFullyFailedRequest(
             Throwable err,
             List<DynamoDbWriteRequest> requestEntries,
-            ResultHandler<DynamoDbWriteRequest> resultHandler) {
+            ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures,
+            AtomicReference<Exception> fatalException) {
         LOG.warn(
                 "DynamoDB Sink failed to persist and will retry {} entries.",
                 requestEntries.size(),
                 err);
         numRecordsSendErrorsCounter.inc(requestEntries.size());
 
-        if (isRetryable(err.getCause(), resultHandler)) {
-            resultHandler.retryForEntries(requestEntries);
+        if (isRetryable(err.getCause(), fatalException)) {
+            retryableFailures.addAll(requestEntries);
         }
     }
 
-    private boolean isRetryable(Throwable err, ResultHandler<DynamoDbWriteRequest> resultHandler) {
+    private boolean isRetryable(Throwable err, AtomicReference<Exception> fatalException) {
         // isFatal() is really isNotFatal()
         if (!DYNAMODB_FATAL_EXCEPTION_CLASSIFIER.isFatal(
-                err, resultHandler::completeExceptionally)) {
+                err, ex -> fatalException.compareAndSet(null, ex))) {
             return false;
         }
         if (failOnError) {
-            resultHandler.completeExceptionally(
-                    new DynamoDbSinkException.DynamoDbSinkFailFastException(err));
+            fatalException.compareAndSet(
+                    null, new DynamoDbSinkException.DynamoDbSinkFailFastException(err));
             return false;
         }
 
         return true;
+    }
+
+    private CompletableFuture<Void> submitSingleRequests(
+            List<DynamoDbWriteRequest> singleRequests,
+            ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures,
+            AtomicReference<Exception> fatalException) {
+
+        if (singleRequests.isEmpty()) {
+            return FutureUtils.completedVoidFuture();
+        }
+
+        CompletableFuture<?>[] futures =
+                singleRequests.stream()
+                        .map(
+                                request ->
+                                        submitSingleRequest(request)
+                                                .handle(
+                                                        (response, err) -> {
+                                                            if (err != null) {
+                                                                handleSingleRequestError(
+                                                                        err,
+                                                                        request,
+                                                                        retryableFailures,
+                                                                        fatalException);
+                                                            }
+                                                            return null;
+                                                        }))
+                        .toArray(CompletableFuture[]::new);
+
+        return CompletableFuture.allOf(futures);
+    }
+
+    private CompletableFuture<?> submitSingleRequest(DynamoDbWriteRequest request) {
+        switch (request.getType()) {
+            case PUT:
+                return clientProvider.getClient().putItem(convertToPutItemRequest(request));
+            case DELETE:
+                return clientProvider.getClient().deleteItem(convertToDeleteItemRequest(request));
+            case UPDATE:
+                return clientProvider.getClient().updateItem(convertToUpdateItemRequest(request));
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported DynamoDb Write Request Type: " + request.getType());
+        }
+    }
+
+    private void handleSingleRequestError(
+            Throwable err,
+            DynamoDbWriteRequest request,
+            ConcurrentLinkedQueue<DynamoDbWriteRequest> retryableFailures,
+            AtomicReference<Exception> fatalException) {
+        LOG.warn("DynamoDB Sink single write failed for {} request.", request.getType(), err);
+        numRecordsSendErrorsCounter.inc();
+
+        if (isRetryable(err.getCause(), fatalException)) {
+            retryableFailures.add(request);
+        }
     }
 
     @Override
@@ -290,5 +411,53 @@ class DynamoDbSinkWriter<InputT> extends AsyncSinkWriter<InputT, DynamoDbWriteRe
             throw new IllegalArgumentException(
                     "Unsupported Write Request, consider updating the convertToDynamoDbWriteRequest method");
         }
+    }
+
+    private PutItemRequest convertToPutItemRequest(DynamoDbWriteRequest request) {
+        PutItemRequest.Builder builder =
+                PutItemRequest.builder().tableName(tableName).item(request.getItem());
+        if (request.getConditionExpression() != null) {
+            builder.conditionExpression(request.getConditionExpression());
+        }
+        if (request.getExpressionAttributeNames() != null) {
+            builder.expressionAttributeNames(request.getExpressionAttributeNames());
+        }
+        if (request.getExpressionAttributeValues() != null) {
+            builder.expressionAttributeValues(request.getExpressionAttributeValues());
+        }
+        return builder.build();
+    }
+
+    private DeleteItemRequest convertToDeleteItemRequest(DynamoDbWriteRequest request) {
+        DeleteItemRequest.Builder builder =
+                DeleteItemRequest.builder().tableName(tableName).key(request.getItem());
+        if (request.getConditionExpression() != null) {
+            builder.conditionExpression(request.getConditionExpression());
+        }
+        if (request.getExpressionAttributeNames() != null) {
+            builder.expressionAttributeNames(request.getExpressionAttributeNames());
+        }
+        if (request.getExpressionAttributeValues() != null) {
+            builder.expressionAttributeValues(request.getExpressionAttributeValues());
+        }
+        return builder.build();
+    }
+
+    private UpdateItemRequest convertToUpdateItemRequest(DynamoDbWriteRequest request) {
+        UpdateItemRequest.Builder builder =
+                UpdateItemRequest.builder()
+                        .tableName(tableName)
+                        .key(request.getItem())
+                        .updateExpression(request.getUpdateExpression());
+        if (request.getConditionExpression() != null) {
+            builder.conditionExpression(request.getConditionExpression());
+        }
+        if (request.getExpressionAttributeNames() != null) {
+            builder.expressionAttributeNames(request.getExpressionAttributeNames());
+        }
+        if (request.getExpressionAttributeValues() != null) {
+            builder.expressionAttributeValues(request.getExpressionAttributeValues());
+        }
+        return builder.build();
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequest.java
@@ -28,7 +28,11 @@ import java.util.Map;
 
 /**
  * Represents a single Write Request to DynamoDb. Contains the item to be written as well as the
- * type of the Write Request (PUT/DELETE)
+ * type of the Write Request (PUT/DELETE/UPDATE).
+ *
+ * <p>For PUT requests, {@code item} contains the full item attributes. For DELETE requests, {@code
+ * item} contains the primary key attributes. For UPDATE requests, {@code item} contains the primary
+ * key attributes and the update expression fields must be set.
  */
 @PublicEvolving
 public class DynamoDbWriteRequest implements Serializable {
@@ -37,10 +41,24 @@ public class DynamoDbWriteRequest implements Serializable {
 
     private final Map<String, AttributeValue> item;
     private final DynamoDbWriteRequestType type;
+    private final String updateExpression;
+    private final Map<String, String> expressionAttributeNames;
+    private final Map<String, AttributeValue> expressionAttributeValues;
+    private final String conditionExpression;
 
-    private DynamoDbWriteRequest(Map<String, AttributeValue> item, DynamoDbWriteRequestType type) {
+    private DynamoDbWriteRequest(
+            Map<String, AttributeValue> item,
+            DynamoDbWriteRequestType type,
+            String updateExpression,
+            Map<String, String> expressionAttributeNames,
+            Map<String, AttributeValue> expressionAttributeValues,
+            String conditionExpression) {
         this.item = item;
         this.type = type;
+        this.updateExpression = updateExpression;
+        this.expressionAttributeNames = expressionAttributeNames;
+        this.expressionAttributeValues = expressionAttributeValues;
+        this.conditionExpression = conditionExpression;
     }
 
     public Map<String, AttributeValue> getItem() {
@@ -51,19 +69,54 @@ public class DynamoDbWriteRequest implements Serializable {
         return type;
     }
 
+    public String getUpdateExpression() {
+        return updateExpression;
+    }
+
+    public Map<String, String> getExpressionAttributeNames() {
+        return expressionAttributeNames;
+    }
+
+    public Map<String, AttributeValue> getExpressionAttributeValues() {
+        return expressionAttributeValues;
+    }
+
+    public String getConditionExpression() {
+        return conditionExpression;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
 
     @Override
     public String toString() {
-        return "DynamoDbWriteRequest{" + "item=" + item + ", type=" + type + '}';
+        return "DynamoDbWriteRequest{"
+                + "item="
+                + item
+                + ", type="
+                + type
+                + ", updateExpression='"
+                + updateExpression
+                + '\''
+                + ", expressionAttributeNames="
+                + expressionAttributeNames
+                + ", expressionAttributeValues="
+                + expressionAttributeValues
+                + ", conditionExpression='"
+                + conditionExpression
+                + '\''
+                + '}';
     }
 
     /** Builder for DynamoDbWriteRequest. */
     public static class Builder {
         private Map<String, AttributeValue> item;
         private DynamoDbWriteRequestType type;
+        private String updateExpression;
+        private Map<String, String> expressionAttributeNames;
+        private Map<String, AttributeValue> expressionAttributeValues;
+        private String conditionExpression;
 
         public Builder setItem(Map<String, AttributeValue> item) {
             this.item = item;
@@ -75,12 +128,45 @@ public class DynamoDbWriteRequest implements Serializable {
             return this;
         }
 
+        public Builder setUpdateExpression(String updateExpression) {
+            this.updateExpression = updateExpression;
+            return this;
+        }
+
+        public Builder setExpressionAttributeNames(
+                Map<String, String> expressionAttributeNames) {
+            this.expressionAttributeNames = expressionAttributeNames;
+            return this;
+        }
+
+        public Builder setExpressionAttributeValues(
+                Map<String, AttributeValue> expressionAttributeValues) {
+            this.expressionAttributeValues = expressionAttributeValues;
+            return this;
+        }
+
+        public Builder setConditionExpression(String conditionExpression) {
+            this.conditionExpression = conditionExpression;
+            return this;
+        }
+
         public DynamoDbWriteRequest build() {
             Preconditions.checkNotNull(
-                    item, "No Item was supplied to the " + "DynamoDbWriteRequest builder.");
+                    item, "No Item was supplied to the DynamoDbWriteRequest builder.");
             Preconditions.checkNotNull(
-                    type, "No type was supplied to the " + "DynamoDbWriteRequest builder.");
-            return new DynamoDbWriteRequest(item, type);
+                    type, "No type was supplied to the DynamoDbWriteRequest builder.");
+            if (type == DynamoDbWriteRequestType.UPDATE) {
+                Preconditions.checkNotNull(
+                        updateExpression,
+                        "No updateExpression was supplied for UPDATE DynamoDbWriteRequest.");
+            }
+            return new DynamoDbWriteRequest(
+                    item,
+                    type,
+                    updateExpression,
+                    expressionAttributeNames,
+                    expressionAttributeValues,
+                    conditionExpression);
         }
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequestType.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequestType.java
@@ -26,6 +26,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * <ul>
  *   <li>PUT - Put Request
  *   <li>DELETE - Delete Request
+ *   <li>UPDATE - Update Request
  * </ul>
  */
 @PublicEvolving
@@ -34,7 +35,8 @@ public enum DynamoDbWriteRequestType {
     // Note: Enums have no stable hash code across different JVMs, use toByteValue() for
     // this purpose.
     PUT((byte) 0),
-    DELETE((byte) 1);
+    DELETE((byte) 1),
+    UPDATE((byte) 2);
     private final byte value;
 
     DynamoDbWriteRequestType(byte value) {
@@ -48,6 +50,7 @@ public enum DynamoDbWriteRequestType {
      * <ul>
      *   <li>"0" represents {@link #PUT}.
      *   <li>"1" represents {@link #DELETE}.
+     *   <li>"2" represents {@link #UPDATE}.
      * </ul>
      */
     public byte toByteValue() {
@@ -66,6 +69,8 @@ public enum DynamoDbWriteRequestType {
                 return PUT;
             case 1:
                 return DELETE;
+            case 2:
+                return UPDATE;
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported byte value '" + value + "' for DynamoDb request type.");

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriterStateSerializer.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriterStateSerializer.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.dynamodb.sink;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.dynamodb.util.DynamoDbSerializationUtil;
 
 import java.io.DataInputStream;
@@ -30,6 +31,12 @@ import java.io.IOException;
 @Internal
 public class DynamoDbWriterStateSerializer
         extends AsyncSinkWriterStateSerializer<DynamoDbWriteRequest> {
+
+    // The parent class does not pass the version to deserializeRequestFromStream(),
+    // so we stash it here before calling super.deserialize() and read it back in
+    // deserializeRequestFromStream().
+    private final ThreadLocal<Integer> deserializingVersion =
+            ThreadLocal.withInitial(this::getVersion);
 
     /**
      * Serializes {@link DynamoDbWriteRequest} in form of
@@ -44,11 +51,22 @@ public class DynamoDbWriterStateSerializer
     @Override
     protected DynamoDbWriteRequest deserializeRequestFromStream(
             long requestSize, DataInputStream in) throws IOException {
-        return DynamoDbSerializationUtil.deserializeWriteRequest(in);
+        return DynamoDbSerializationUtil.deserializeWriteRequest(in, deserializingVersion.get());
+    }
+
+    @Override
+    public BufferedRequestState<DynamoDbWriteRequest> deserialize(int version, byte[] serialized)
+            throws IOException {
+        deserializingVersion.set(version);
+        try {
+            return super.deserialize(version, serialized);
+        } finally {
+            deserializingVersion.set(getVersion());
+        }
     }
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtil.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/main/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtil.java
@@ -43,20 +43,112 @@ public class DynamoDbSerializationUtil {
     public static void serializeWriteRequest(
             DynamoDbWriteRequest dynamoDbWriteRequest, DataOutputStream out) throws IOException {
         out.writeByte(dynamoDbWriteRequest.getType().toByteValue());
-        Map<String, AttributeValue> item = dynamoDbWriteRequest.getItem();
-        serializeItem(item, out);
+        serializeItem(dynamoDbWriteRequest.getItem(), out);
+        serializeNullableString(dynamoDbWriteRequest.getUpdateExpression(), out);
+        serializeNullableString(dynamoDbWriteRequest.getConditionExpression(), out);
+        serializeNullableStringMap(dynamoDbWriteRequest.getExpressionAttributeNames(), out);
+        serializeNullableAttributeValueMap(
+                dynamoDbWriteRequest.getExpressionAttributeValues(), out);
     }
 
     public static DynamoDbWriteRequest deserializeWriteRequest(DataInputStream in)
+            throws IOException {
+        return deserializeWriteRequest(in, 2);
+    }
+
+    public static DynamoDbWriteRequest deserializeWriteRequest(DataInputStream in, int version)
             throws IOException {
         int writeRequestType = in.read();
         DynamoDbWriteRequestType dynamoDbWriteRequestType =
                 DynamoDbWriteRequestType.fromByteValue((byte) writeRequestType);
         Map<String, AttributeValue> item = deserializeItem(in);
-        return DynamoDbWriteRequest.builder()
-                .setType(dynamoDbWriteRequestType)
-                .setItem(item)
-                .build();
+
+        DynamoDbWriteRequest.Builder builder =
+                DynamoDbWriteRequest.builder()
+                        .setType(dynamoDbWriteRequestType)
+                        .setItem(item);
+
+        // Version 2 added expression fields for conditional and update writes
+        if (version >= 2) {
+            String updateExpression = deserializeNullableString(in);
+            String conditionExpression = deserializeNullableString(in);
+            Map<String, String> expressionAttributeNames = deserializeNullableStringMap(in);
+            Map<String, AttributeValue> expressionAttributeValues =
+                    deserializeNullableAttributeValueMap(in);
+            if (updateExpression != null) {
+                builder.setUpdateExpression(updateExpression);
+            }
+            if (conditionExpression != null) {
+                builder.setConditionExpression(conditionExpression);
+            }
+            if (expressionAttributeNames != null) {
+                builder.setExpressionAttributeNames(expressionAttributeNames);
+            }
+            if (expressionAttributeValues != null) {
+                builder.setExpressionAttributeValues(expressionAttributeValues);
+            }
+        }
+
+        return builder.build();
+    }
+
+    private static void serializeNullableString(String value, DataOutputStream out)
+            throws IOException {
+        if (value == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeUTF(value);
+        }
+    }
+
+    private static String deserializeNullableString(DataInputStream in) throws IOException {
+        boolean present = in.readBoolean();
+        return present ? in.readUTF() : null;
+    }
+
+    private static void serializeNullableStringMap(Map<String, String> map, DataOutputStream out)
+            throws IOException {
+        if (map == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeInt(map.size());
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                out.writeUTF(entry.getKey());
+                out.writeUTF(entry.getValue());
+            }
+        }
+    }
+
+    private static Map<String, String> deserializeNullableStringMap(DataInputStream in)
+            throws IOException {
+        boolean present = in.readBoolean();
+        if (!present) {
+            return null;
+        }
+        int size = in.readInt();
+        Map<String, String> map = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            map.put(in.readUTF(), in.readUTF());
+        }
+        return map;
+    }
+
+    private static void serializeNullableAttributeValueMap(
+            Map<String, AttributeValue> map, DataOutputStream out) throws IOException {
+        if (map == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            serializeItem(map, out);
+        }
+    }
+
+    private static Map<String, AttributeValue> deserializeNullableAttributeValueMap(
+            DataInputStream in) throws IOException {
+        boolean present = in.readBoolean();
+        return present ? deserializeItem(in) : null;
     }
 
     private static void serializeItem(Map<String, AttributeValue> item, DataOutputStream out)

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbBeanElementConverterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbBeanElementConverterTest.java
@@ -19,11 +19,17 @@
 package org.apache.flink.connector.dynamodb.sink;
 
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.dynamodb.testutils.TestItem;
 import org.apache.flink.connector.dynamodb.util.Order;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.util.Collections;
+
+import static org.apache.flink.connector.dynamodb.sink.DynamoDbWriteRequestType.DELETE;
 import static org.apache.flink.connector.dynamodb.sink.DynamoDbWriteRequestType.PUT;
+import static org.apache.flink.connector.dynamodb.sink.DynamoDbWriteRequestType.UPDATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -87,5 +93,88 @@ class DynamoDbBeanElementConverterTest {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> elementConverter.apply(order, null))
                 .withMessageContaining("Table schema has not been initialized");
+    }
+
+    @Test
+    void testConditionalPutSetsConditionExpression() {
+        ElementConverter<TestItem, DynamoDbWriteRequest> elementConverter =
+                DynamoDbBeanElementConverter.builder(TestItem.class)
+                        .setType(PUT)
+                        .setConditionExpression("attribute_not_exists(pk)")
+                        .setExpressionAttributeNames(Collections.singletonMap("#pk", "pk"))
+                        .build();
+        elementConverter.open(null);
+        TestItem item = new TestItem("1", "a", "data", "0");
+
+        DynamoDbWriteRequest actual = elementConverter.apply(item, null);
+
+        assertThat(actual.getType()).isEqualTo(PUT);
+        assertThat(actual.getConditionExpression()).isEqualTo("attribute_not_exists(pk)");
+        assertThat(actual.getExpressionAttributeNames()).containsEntry("#pk", "pk");
+        assertThat(actual.getItem()).containsKeys("pk", "sk", "payload", "counter");
+    }
+
+    @Test
+    void testDeleteExtractsOnlyKeyAttributes() {
+        ElementConverter<TestItem, DynamoDbWriteRequest> elementConverter =
+                DynamoDbBeanElementConverter.builder(TestItem.class)
+                        .setType(DELETE)
+                        .build();
+        elementConverter.open(null);
+        TestItem item = new TestItem("1", "a", "data", "0");
+
+        DynamoDbWriteRequest actual = elementConverter.apply(item, null);
+
+        assertThat(actual.getType()).isEqualTo(DELETE);
+        assertThat(actual.getItem()).containsOnlyKeys("pk", "sk");
+        assertThat(actual.getItem().get("pk").s()).isEqualTo("1");
+        assertThat(actual.getItem().get("sk").s()).isEqualTo("a");
+    }
+
+    @Test
+    void testUpdateExtractsKeyAndSetsUpdateExpression() {
+        ElementConverter<TestItem, DynamoDbWriteRequest> elementConverter =
+                DynamoDbBeanElementConverter.builder(TestItem.class)
+                        .setType(UPDATE)
+                        .setUpdateExpression("SET #c = :val")
+                        .setExpressionAttributeNames(Collections.singletonMap("#c", "counter"))
+                        .setExpressionAttributeValues(
+                                Collections.singletonMap(
+                                        ":val", AttributeValue.builder().s("42").build()))
+                        .build();
+        elementConverter.open(null);
+        TestItem item = new TestItem("1", "a", "data", "0");
+
+        DynamoDbWriteRequest actual = elementConverter.apply(item, null);
+
+        assertThat(actual.getType()).isEqualTo(UPDATE);
+        assertThat(actual.getUpdateExpression()).isEqualTo("SET #c = :val");
+        assertThat(actual.getItem()).containsOnlyKeys("pk", "sk");
+        assertThat(actual.getExpressionAttributeNames()).containsEntry("#c", "counter");
+        assertThat(actual.getExpressionAttributeValues())
+                .containsEntry(":val", AttributeValue.builder().s("42").build());
+    }
+
+    @Test
+    void testUpdateWithoutUpdateExpressionThrows() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                DynamoDbBeanElementConverter.builder(TestItem.class)
+                                        .setType(UPDATE)
+                                        .build())
+                .withMessageContaining("updateExpression is required for UPDATE type");
+    }
+
+    @Test
+    void testPutWithUpdateExpressionThrows() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                DynamoDbBeanElementConverter.builder(TestItem.class)
+                                        .setType(PUT)
+                                        .setUpdateExpression("SET #a = :val")
+                                        .build())
+                .withMessageContaining("updateExpression is only allowed for UPDATE type");
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkConditionalWriteITCase.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkConditionalWriteITCase.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.dynamodb.sink;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.dynamodb.testutils.DynamoDBHelpers;
+import org.apache.flink.connector.dynamodb.testutils.DynamoDbContainer;
+import org.apache.flink.connector.dynamodb.testutils.TestItem;
+import org.apache.flink.connector.dynamodb.util.DockerImageVersions;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ENDPOINT;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_REGION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.HTTP_PROTOCOL_VERSION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL_CERTIFICATES;
+
+/**
+ * Integration test for batch and single writes in {@link DynamoDbSink} using {@link DynamoDbBeanElementConverter}.
+ */
+@Testcontainers
+@ExtendWith(MiniClusterExtension.class)
+public class DynamoDbSinkConditionalWriteITCase {
+
+    private static final String PARTITION_KEY = "pk";
+    private static final String SORT_KEY = "sk";
+    private static DynamoDBHelpers dynamoDBHelpers;
+    private static String testTableName;
+
+    @Container
+    public static final DynamoDbContainer LOCALSTACK =
+            new DynamoDbContainer(DockerImageName.parse(DockerImageVersions.DYNAMODB))
+                    .withNetwork(Network.newNetwork())
+                    .withNetworkAliases("dynamodb");
+
+    @BeforeEach
+    public void setup() throws URISyntaxException {
+        testTableName = "test_" + UUID.randomUUID().toString().replace("-", "");
+        dynamoDBHelpers = new DynamoDBHelpers(LOCALSTACK.getHostClient());
+    }
+
+    @Test
+    public void testBatchPutWithBeanConverter() throws Exception {
+        dynamoDBHelpers.createTable(testTableName, PARTITION_KEY, SORT_KEY);
+
+        List<TestItem> items =
+                Arrays.asList(
+                        new TestItem("1", "a", "data1", "0"),
+                        new TestItem("2", "b", "data2", "0"));
+
+        StreamExecutionEnvironment env = createEnv();
+        DataStream<TestItem> stream = env.fromCollection(items);
+        stream.sinkTo(buildSink(new DynamoDbBeanElementConverter<>(TestItem.class)));
+        env.execute("Batch PUT via BeanConverter");
+
+        Assertions.assertThat(dynamoDBHelpers.getItemsCount(testTableName)).isEqualTo(2);
+    }
+
+    @Test
+    public void testUpdateWithBeanUpdateConverter() throws Exception {
+        dynamoDBHelpers.createTable(testTableName, PARTITION_KEY, SORT_KEY);
+
+        List<TestItem> items =
+                Arrays.asList(
+                        new TestItem("1", "a", "data1", "0"),
+                        new TestItem("2", "b", "data2", "0"));
+
+        StreamExecutionEnvironment env = createEnv();
+        DataStream<TestItem> putStream = env.fromCollection(items);
+        putStream.sinkTo(buildSink(new DynamoDbBeanElementConverter<>(TestItem.class)));
+        env.execute("Initial PUT");
+
+        Assertions.assertThat(dynamoDBHelpers.getItemsCount(testTableName)).isEqualTo(2);
+
+        Map<String, String> expressionNames = Collections.singletonMap("#c", "counter");
+        Map<String, AttributeValue> expressionValues =
+                Collections.singletonMap(":val", AttributeValue.builder().s("42").build());
+
+        env = createEnv();
+        DataStream<TestItem> updateStream =
+                env.fromCollection(
+                        Collections.singletonList(new TestItem("1", "a", null, null)));
+        updateStream.sinkTo(
+                buildSink(
+                        DynamoDbBeanElementConverter.builder(TestItem.class)
+                                .setType(DynamoDbWriteRequestType.UPDATE)
+                                .setUpdateExpression("SET #c = :val")
+                                .setExpressionAttributeNames(expressionNames)
+                                .setExpressionAttributeValues(expressionValues)
+                                .build()));
+        env.execute("UPDATE via BeanConverter");
+
+        Assertions.assertThat(dynamoDBHelpers.getItemsCount(testTableName)).isEqualTo(2);
+        Assertions.assertThat(
+                        dynamoDBHelpers.containsAttributeValue(testTableName, "counter", "42"))
+                .isTrue();
+    }
+
+    @Test
+    public void testConditionalPutWithBeanConverterPreventsOverwrite() throws Exception {
+        dynamoDBHelpers.createTable(testTableName, PARTITION_KEY, SORT_KEY);
+
+        StreamExecutionEnvironment env = createEnv();
+        DataStream<TestItem> putStream =
+                env.fromCollection(
+                        Collections.singletonList(new TestItem("1", "a", "original", "0")));
+        putStream.sinkTo(buildSink(new DynamoDbBeanElementConverter<>(TestItem.class)));
+        env.execute("Initial PUT");
+
+        Map<String, String> exprNames = new HashMap<>();
+        exprNames.put("#pk", PARTITION_KEY);
+        exprNames.put("#sk", SORT_KEY);
+
+        StreamExecutionEnvironment conditionalEnv = createEnv();
+        DataStream<TestItem> conditionalStream =
+                conditionalEnv.fromCollection(
+                        Collections.singletonList(new TestItem("1", "a", "overwritten", "0")));
+        conditionalStream.sinkTo(
+                buildSink(
+                        DynamoDbBeanElementConverter.builder(TestItem.class)
+                                .setType(DynamoDbWriteRequestType.PUT)
+                                .setConditionExpression(
+                                        "attribute_not_exists(#pk) AND attribute_not_exists(#sk)")
+                                .setExpressionAttributeNames(exprNames)
+                                .build()));
+
+        Assertions.assertThatExceptionOfType(JobExecutionException.class)
+                .isThrownBy(() -> conditionalEnv.execute("Conditional PUT should fail"))
+                .havingCause()
+                .havingCause()
+                .withMessageContaining("conditional check");
+
+        Assertions.assertThat(
+                        dynamoDBHelpers.containsAttributeValue(testTableName, "payload", "original"))
+                .isTrue();
+    }
+
+    @Test
+    public void testConditionalDeleteWithBeanConverter() throws Exception {
+        dynamoDBHelpers.createTable(testTableName, PARTITION_KEY, SORT_KEY);
+
+        List<TestItem> items =
+                Arrays.asList(
+                        new TestItem("1", "a", "keep", "0"),
+                        new TestItem("2", "b", "remove", "0"));
+
+        StreamExecutionEnvironment env = createEnv();
+        DataStream<TestItem> putStream = env.fromCollection(items);
+        putStream.sinkTo(buildSink(new DynamoDbBeanElementConverter<>(TestItem.class)));
+        env.execute("Insert items");
+
+        Assertions.assertThat(dynamoDBHelpers.getItemsCount(testTableName)).isEqualTo(2);
+
+        env = createEnv();
+        DataStream<TestItem> deleteStream =
+                env.fromCollection(
+                        Collections.singletonList(new TestItem("2", "b", null, null)));
+        deleteStream.sinkTo(
+                buildSink(
+                        DynamoDbBeanElementConverter.builder(TestItem.class)
+                                .setType(DynamoDbWriteRequestType.DELETE)
+                                .setConditionExpression("#p = :val")
+                                .setExpressionAttributeNames(
+                                        Collections.singletonMap("#p", "payload"))
+                                .setExpressionAttributeValues(
+                                        Collections.singletonMap(
+                                                ":val",
+                                                AttributeValue.builder()
+                                                        .s("remove")
+                                                        .build()))
+                                .build()));
+        env.execute("Conditional DELETE");
+
+        Assertions.assertThat(dynamoDBHelpers.getItemsCount(testTableName)).isEqualTo(1);
+        Assertions.assertThat(
+                        dynamoDBHelpers.containsAttributeValue(testTableName, "payload", "keep"))
+                .isTrue();
+    }
+
+    private DynamoDbSink<TestItem> buildSink(
+            ElementConverter<TestItem, DynamoDbWriteRequest> converter) {
+        return DynamoDbSink.<TestItem>builder()
+                .setElementConverter(converter)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxInFlightRequests(1)
+                .setMaxBatchSize(25)
+                .setFailOnError(true)
+                .setMaxBufferedRequests(1000)
+                .setTableName(testTableName)
+                .setOverwriteByPartitionKeys(Collections.emptyList())
+                .setDynamoDbProperties(getProperties())
+                .build();
+    }
+
+    private StreamExecutionEnvironment createEnv() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration config = new Configuration();
+        config.set(
+                RestartStrategyOptions.RESTART_STRATEGY,
+                RestartStrategyOptions.RestartStrategyType.NO_RESTART_STRATEGY.getMainValue());
+        env.configure(config);
+        env.setParallelism(1);
+        return env;
+    }
+
+    private Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(AWS_ENDPOINT, LOCALSTACK.getHostEndpointUrl());
+        properties.setProperty(AWS_ACCESS_KEY_ID, LOCALSTACK.getAccessKey());
+        properties.setProperty(AWS_SECRET_ACCESS_KEY, LOCALSTACK.getSecretKey());
+        properties.setProperty(AWS_REGION, LOCALSTACK.getRegion().toString());
+        properties.setProperty(TRUST_ALL_CERTIFICATES, "true");
+        properties.setProperty(HTTP_PROTOCOL_VERSION, "HTTP1_1");
+        return properties;
+    }
+}

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriterTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbSinkWriterTest.java
@@ -31,11 +31,17 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutRequest;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 import software.amazon.awssdk.services.sts.model.StsException;
 
@@ -321,6 +327,235 @@ public class DynamoDbSinkWriterTest {
         assertThat(testAsyncDynamoDbClientProvider.getCloseCount()).isEqualTo(1);
     }
 
+    @Test
+    public void testUpdateRequestUsesUpdateItemApi() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        Map<String, AttributeValue> key = singletonMap(
+                PARTITION_KEY, AttributeValue.builder().s("pk1").build());
+        DynamoDbWriteRequest updateRequest =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.UPDATE)
+                        .setItem(key)
+                        .setUpdateExpression("SET #a = :val")
+                        .setExpressionAttributeNames(singletonMap("#a", "counter"))
+                        .setExpressionAttributeValues(
+                                singletonMap(":val", AttributeValue.builder().n("1").build()))
+                        .build();
+
+        dynamoDbSinkWriter.submitRequestEntries(singletonList(updateRequest), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getUpdateItemRequests()).hasSize(1);
+        assertThat(trackingClient.getUpdateItemRequests().get(0).updateExpression())
+                .isEqualTo("SET #a = :val");
+        assertThat(trackingClient.getRequestHistory()).isEmpty();
+    }
+
+    @Test
+    public void testConditionalPutUsesIndividualPutItemApi() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        DynamoDbWriteRequest conditionalPut =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.PUT)
+                        .setItem(item("pk", "1"))
+                        .setConditionExpression("attribute_not_exists(pk)")
+                        .build();
+
+        dynamoDbSinkWriter.submitRequestEntries(singletonList(conditionalPut), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getPutItemRequests()).hasSize(1);
+        assertThat(trackingClient.getPutItemRequests().get(0).conditionExpression())
+                .isEqualTo("attribute_not_exists(pk)");
+        assertThat(trackingClient.getRequestHistory()).isEmpty();
+    }
+
+    @Test
+    public void testConditionalDeleteUsesIndividualDeleteItemApi() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        DynamoDbWriteRequest conditionalDelete =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.DELETE)
+                        .setItem(item("pk", "1"))
+                        .setConditionExpression("attribute_exists(pk)")
+                        .build();
+
+        dynamoDbSinkWriter.submitRequestEntries(singletonList(conditionalDelete), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getDeleteItemRequests()).hasSize(1);
+        assertThat(trackingClient.getDeleteItemRequests().get(0).conditionExpression())
+                .isEqualTo("attribute_exists(pk)");
+        assertThat(trackingClient.getRequestHistory()).isEmpty();
+    }
+
+    @Test
+    public void testMixedBatchAndSingleRequests() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        Map<String, AttributeValue> key = singletonMap(
+                PARTITION_KEY, AttributeValue.builder().s("pk1").build());
+        List<DynamoDbWriteRequest> inputRequests =
+                Arrays.asList(
+                        sinkPutRequest(item("pk", "1")),
+                        DynamoDbWriteRequest.builder()
+                                .setType(DynamoDbWriteRequestType.UPDATE)
+                                .setItem(key)
+                                .setUpdateExpression("SET #a = :val")
+                                .setExpressionAttributeNames(singletonMap("#a", "counter"))
+                                .setExpressionAttributeValues(
+                                        singletonMap(
+                                                ":val",
+                                                AttributeValue.builder().n("1").build()))
+                                .build());
+
+        dynamoDbSinkWriter.submitRequestEntries(inputRequests, resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getRequestHistory()).hasSize(1);
+        assertThat(trackingClient.getUpdateItemRequests()).hasSize(1);
+    }
+
+    @Test
+    public void testPutWithoutConditionUsesBatchPath() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        dynamoDbSinkWriter.submitRequestEntries(
+                singletonList(sinkPutRequest(item("pk", "1"))), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getRequestHistory()).hasSize(1);
+        assertThat(trackingClient.getPutItemRequests()).isEmpty();
+    }
+
+    @Test
+    public void testDeleteWithoutConditionUsesBatchPath() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient = new TrackingDynamoDbAsyncClient();
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        true, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        dynamoDbSinkWriter.submitRequestEntries(
+                singletonList(sinkDeleteRequest(item("pk", "1"))), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isTrue();
+        assertThat(trackingClient.getRequestHistory()).hasSize(1);
+        assertThat(trackingClient.getDeleteItemRequests()).isEmpty();
+    }
+
+    @Test
+    public void testConditionalCheckFailedOnSingleRequestIsNonRetryable() throws Exception {
+        TrackingDynamoDbAsyncClient trackingClient =
+                new TrackingDynamoDbAsyncClient() {
+                    @Override
+                    public CompletableFuture<PutItemResponse> putItem(
+                            PutItemRequest putItemRequest) {
+                        CompletableFuture<PutItemResponse> future = new CompletableFuture<>();
+                        future.completeExceptionally(
+                                DynamoDbException.builder()
+                                        .cause(
+                                                ConditionalCheckFailedException.builder()
+                                                        .build())
+                                        .build());
+                        return future;
+                    }
+                };
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        false, Collections.emptyList(), () -> trackingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        DynamoDbWriteRequest conditionalPut =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.PUT)
+                        .setItem(item("pk", "1"))
+                        .setConditionExpression("attribute_not_exists(pk)")
+                        .build();
+
+        dynamoDbSinkWriter.submitRequestEntries(singletonList(conditionalPut), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isFalse();
+        assertThat(resultHandler.getRetryEntries()).isEmpty();
+        assertThat(resultHandler.getException()).isNotNull();
+    }
+
+    @Test
+    public void testMixedBatchAndSingleRetryableExceptionRetriesBoth() throws Exception {
+        TrackingDynamoDbAsyncClient failingClient =
+                new TrackingDynamoDbAsyncClient() {
+                    @Override
+                    public CompletableFuture<BatchWriteItemResponse> batchWriteItem(
+                            BatchWriteItemRequest batchWriteItemRequest) {
+                        CompletableFuture<BatchWriteItemResponse> future =
+                                new CompletableFuture<>();
+                        future.completeExceptionally(
+                                DynamoDbException.builder()
+                                        .cause(getGenericRetryableException().get())
+                                        .build());
+                        return future;
+                    }
+
+                    @Override
+                    public CompletableFuture<UpdateItemResponse> updateItem(
+                            UpdateItemRequest updateItemRequest) {
+                        CompletableFuture<UpdateItemResponse> future = new CompletableFuture<>();
+                        future.completeExceptionally(
+                                DynamoDbException.builder()
+                                        .cause(getGenericRetryableException().get())
+                                        .build());
+                        return future;
+                    }
+                };
+        DynamoDbSinkWriter<Map<String, AttributeValue>> dynamoDbSinkWriter =
+                getDefaultSinkWriter(
+                        false, Collections.emptyList(), () -> failingClient);
+        TestingResultHandler resultHandler = new TestingResultHandler();
+
+        Map<String, AttributeValue> key =
+                singletonMap(PARTITION_KEY, AttributeValue.builder().s("pk1").build());
+        DynamoDbWriteRequest batchPut = sinkPutRequest(item("pk", "1"));
+        DynamoDbWriteRequest updateRequest =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.UPDATE)
+                        .setItem(key)
+                        .setUpdateExpression("SET #a = :val")
+                        .setExpressionAttributeNames(singletonMap("#a", "counter"))
+                        .setExpressionAttributeValues(
+                                singletonMap(":val", AttributeValue.builder().n("1").build()))
+                        .build();
+
+        dynamoDbSinkWriter.submitRequestEntries(
+                Arrays.asList(batchPut, updateRequest), resultHandler);
+
+        assertThat(resultHandler.isComplete()).isFalse();
+        assertThat(resultHandler.getRetryEntries())
+                .containsExactlyInAnyOrder(batchPut, updateRequest);
+    }
+
     private void assertThatRequestsAreNotRetried(
             boolean failOnError, Optional<Exception> exceptionToThrow) throws IOException {
         ThrowingDynamoDbAsyncClient<Exception> throwingDynamoDbAsyncClient =
@@ -507,6 +742,9 @@ public class DynamoDbSinkWriterTest {
     private static class TrackingDynamoDbAsyncClient implements DynamoDbAsyncClient {
 
         private List<List<WriteRequest>> requestHistory = new ArrayList<>();
+        private List<PutItemRequest> putItemRequests = new ArrayList<>();
+        private List<DeleteItemRequest> deleteItemRequests = new ArrayList<>();
+        private List<UpdateItemRequest> updateItemRequests = new ArrayList<>();
 
         @Override
         public String serviceName() {
@@ -524,12 +762,44 @@ public class DynamoDbSinkWriterTest {
         }
 
         @Override
+        public CompletableFuture<PutItemResponse> putItem(PutItemRequest putItemRequest) {
+            putItemRequests.add(putItemRequest);
+            return CompletableFuture.completedFuture(PutItemResponse.builder().build());
+        }
+
+        @Override
+        public CompletableFuture<DeleteItemResponse> deleteItem(
+                DeleteItemRequest deleteItemRequest) {
+            deleteItemRequests.add(deleteItemRequest);
+            return CompletableFuture.completedFuture(DeleteItemResponse.builder().build());
+        }
+
+        @Override
+        public CompletableFuture<UpdateItemResponse> updateItem(
+                UpdateItemRequest updateItemRequest) {
+            updateItemRequests.add(updateItemRequest);
+            return CompletableFuture.completedFuture(UpdateItemResponse.builder().build());
+        }
+
+        @Override
         public DynamoDbServiceClientConfiguration serviceClientConfiguration() {
             return DynamoDbServiceClientConfiguration.builder().build();
         }
 
         public List<List<WriteRequest>> getRequestHistory() {
             return requestHistory;
+        }
+
+        public List<PutItemRequest> getPutItemRequests() {
+            return putItemRequests;
+        }
+
+        public List<DeleteItemRequest> getDeleteItemRequests() {
+            return deleteItemRequests;
+        }
+
+        public List<UpdateItemRequest> getUpdateItemRequests() {
+            return updateItemRequests;
         }
     }
 

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequestTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriteRequestTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DynamoDbWriteRequestTest {
 
@@ -44,6 +45,62 @@ class DynamoDbWriteRequestTest {
                         "If this test fails the DynamoDB AWS SDK may have changed. "
                                 + "We need to check this, and update the DynamoDbWriterStateSerializer if required.")
                 .hasSize(11);
+    }
+
+    @Test
+    public void testUpdateRequiresUpdateExpression() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(
+                        () ->
+                                DynamoDbWriteRequest.builder()
+                                        .setType(DynamoDbWriteRequestType.UPDATE)
+                                        .setItem(
+                                                singletonMap(
+                                                        "pk",
+                                                        AttributeValue.builder()
+                                                                .s("1")
+                                                                .build()))
+                                        .build())
+                .withMessageContaining("updateExpression");
+    }
+
+    @Test
+    public void testUpdateBuildsWithAllFields() {
+        DynamoDbWriteRequest request =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.UPDATE)
+                        .setItem(
+                                singletonMap(
+                                        "pk", AttributeValue.builder().s("1").build()))
+                        .setUpdateExpression("SET #c = :val")
+                        .setConditionExpression("attribute_exists(pk)")
+                        .setExpressionAttributeNames(singletonMap("#c", "counter"))
+                        .setExpressionAttributeValues(
+                                singletonMap(
+                                        ":val", AttributeValue.builder().n("1").build()))
+                        .build();
+
+        assertThat(request.getType()).isEqualTo(DynamoDbWriteRequestType.UPDATE);
+        assertThat(request.getUpdateExpression()).isEqualTo("SET #c = :val");
+        assertThat(request.getConditionExpression()).isEqualTo("attribute_exists(pk)");
+        assertThat(request.getExpressionAttributeNames()).containsEntry("#c", "counter");
+        assertThat(request.getExpressionAttributeValues()).containsKey(":val");
+    }
+
+    @Test
+    public void testPutBuildsWithConditionExpression() {
+        DynamoDbWriteRequest request =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.PUT)
+                        .setItem(
+                                singletonMap(
+                                        "pk", AttributeValue.builder().s("1").build()))
+                        .setConditionExpression("attribute_not_exists(pk)")
+                        .build();
+
+        assertThat(request.getType()).isEqualTo(DynamoDbWriteRequestType.PUT);
+        assertThat(request.getConditionExpression()).isEqualTo("attribute_not_exists(pk)");
+        assertThat(request.getUpdateExpression()).isNull();
     }
 
     @Test

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriterStateSerializerTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/sink/DynamoDbWriterStateSerializerTest.java
@@ -18,14 +18,19 @@
 
 package org.apache.flink.connector.dynamodb.sink;
 
+import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
+import org.apache.flink.connector.dynamodb.util.DynamoDbSerializationUtil;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
 
 import static java.util.Collections.singletonMap;
 import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
@@ -53,18 +58,117 @@ public class DynamoDbWriterStateSerializerTest {
 
         DynamoDbWriterStateSerializer serializer = new DynamoDbWriterStateSerializer();
         BufferedRequestState<DynamoDbWriteRequest> actualState =
-                serializer.deserialize(1, serializer.serialize(expectedState));
+                serializer.deserialize(
+                        serializer.getVersion(), serializer.serialize(expectedState));
 
         assertThat(actualState).usingRecursiveComparison().isEqualTo(expectedState);
     }
 
     @Test
+    public void testSerializeAndDeserializeUpdateRequest() throws IOException {
+        Map<String, AttributeValue> key =
+                singletonMap("pk", AttributeValue.builder().s("key1").build());
+        DynamoDbWriteRequest updateRequest =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.UPDATE)
+                        .setItem(key)
+                        .setUpdateExpression("SET #c = :val")
+                        .setExpressionAttributeNames(singletonMap("#c", "counter"))
+                        .setExpressionAttributeValues(
+                                singletonMap(":val", AttributeValue.builder().n("1").build()))
+                        .build();
+
+        BufferedRequestState<DynamoDbWriteRequest> expectedState =
+                new BufferedRequestState<>(
+                        Collections.singletonList(new RequestEntryWrapper<>(updateRequest, 100)));
+
+        DynamoDbWriterStateSerializer serializer = new DynamoDbWriterStateSerializer();
+        BufferedRequestState<DynamoDbWriteRequest> actualState =
+                serializer.deserialize(
+                        serializer.getVersion(), serializer.serialize(expectedState));
+
+        assertThat(actualState).usingRecursiveComparison().isEqualTo(expectedState);
+    }
+
+    @Test
+    public void testSerializeAndDeserializeConditionalPut() throws IOException {
+        DynamoDbWriteRequest conditionalPut =
+                DynamoDbWriteRequest.builder()
+                        .setType(DynamoDbWriteRequestType.PUT)
+                        .setItem(singletonMap("pk", AttributeValue.builder().s("key1").build()))
+                        .setConditionExpression("attribute_not_exists(pk)")
+                        .setExpressionAttributeNames(singletonMap("#pk", "pk"))
+                        .build();
+
+        BufferedRequestState<DynamoDbWriteRequest> expectedState =
+                new BufferedRequestState<>(
+                        Collections.singletonList(new RequestEntryWrapper<>(conditionalPut, 100)));
+
+        DynamoDbWriterStateSerializer serializer = new DynamoDbWriterStateSerializer();
+        BufferedRequestState<DynamoDbWriteRequest> actualState =
+                serializer.deserialize(
+                        serializer.getVersion(), serializer.serialize(expectedState));
+
+        assertThat(actualState).usingRecursiveComparison().isEqualTo(expectedState);
+    }
+
+    @Test
+    public void testDeserializeVersion1State() throws IOException {
+        BufferedRequestState<DynamoDbWriteRequest> v1State =
+                getTestState(ELEMENT_CONVERTER, this::getRequestSize);
+
+        DynamoDbWriterStateSerializerV1 v1Serializer = new DynamoDbWriterStateSerializerV1();
+        byte[] v1Bytes = v1Serializer.serialize(v1State);
+
+        DynamoDbWriterStateSerializer v2Serializer = new DynamoDbWriterStateSerializer();
+        BufferedRequestState<DynamoDbWriteRequest> actualState =
+                v2Serializer.deserialize(1, v1Bytes);
+
+        assertThat(actualState).usingRecursiveComparison().isEqualTo(v1State);
+    }
+
+    @Test
     public void testVersion() {
         DynamoDbWriterStateSerializer serializer = new DynamoDbWriterStateSerializer();
-        assertThat(serializer.getVersion()).isEqualTo(1);
+        assertThat(serializer.getVersion()).isEqualTo(2);
     }
 
     private int getRequestSize(DynamoDbWriteRequest requestEntry) {
         return requestEntry.getItem().toString().getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    /**
+     * Simulates version 1 serializer that only writes type + item (no expression fields). Used to
+     * test backward compatibility of the version 2 deserializer.
+     */
+    private static class DynamoDbWriterStateSerializerV1
+            extends AsyncSinkWriterStateSerializer<DynamoDbWriteRequest> {
+
+        @Override
+        protected void serializeRequestToStream(
+                DynamoDbWriteRequest request, java.io.DataOutputStream out)
+                throws IOException {
+            // V1 format: only type byte + item map (no expression fields)
+            out.writeByte(request.getType().toByteValue());
+            // Write item map: size + entries (key + attribute value)
+            Map<String, AttributeValue> item = request.getItem();
+            out.writeInt(item.size());
+            for (Map.Entry<String, AttributeValue> entry : item.entrySet()) {
+                out.writeUTF(entry.getKey());
+                out.writeByte(0);
+                out.writeUTF(entry.getValue().s());
+            }
+        }
+
+        @Override
+        protected DynamoDbWriteRequest deserializeRequestFromStream(
+                long requestSize, java.io.DataInputStream in) throws IOException {
+            return DynamoDbSerializationUtil.deserializeWriteRequest(in, 1);
+        }
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
     }
 }

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/testutils/TestItem.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/testutils/TestItem.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.dynamodb.testutils;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+/** A test DynamoDbBean with partition key, sort key and payload attributes. */
+@DynamoDbBean
+public class TestItem {
+
+    private String pk;
+    private String sk;
+    private String payload;
+    private String counter;
+
+    public TestItem() {}
+
+    public TestItem(String pk, String sk, String payload, String counter) {
+        this.pk = pk;
+        this.sk = sk;
+        this.payload = payload;
+        this.counter = counter;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getCounter() {
+        return counter;
+    }
+
+    public void setCounter(String counter) {
+        this.counter = counter;
+    }
+}

--- a/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtilTest.java
+++ b/flink-connector-aws/flink-connector-dynamodb/src/test/java/org/apache/flink/connector/dynamodb/util/DynamoDbSerializationUtilTest.java
@@ -128,6 +128,51 @@ public class DynamoDbSerializationUtilTest {
     }
 
     @Test
+    public void testUpdateWithAllFieldsSerializeDeserialize() throws IOException {
+        final Map<String, AttributeValue> key = new HashMap<>();
+        key.put("pk", AttributeValue.builder().s("key1").build());
+        key.put("sk", AttributeValue.builder().s("sort1").build());
+
+        DynamoDbWriteRequest dynamoDbWriteRequest =
+                DynamoDbWriteRequest.builder()
+                        .setItem(key)
+                        .setType(DynamoDbWriteRequestType.UPDATE)
+                        .setUpdateExpression("SET #c = #c + :inc, #u = :ts")
+                        .setConditionExpression("attribute_exists(pk)")
+                        .setExpressionAttributeNames(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("#c", "counter");
+                                        put("#u", "updatedAt");
+                                    }
+                                })
+                        .setExpressionAttributeValues(
+                                new HashMap<String, AttributeValue>() {
+                                    {
+                                        put(":inc", AttributeValue.builder().n("1").build());
+                                        put(":ts", AttributeValue.builder().s("2026-03-28").build());
+                                    }
+                                })
+                        .build();
+
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(outputStream)) {
+            DynamoDbSerializationUtil.serializeWriteRequest(dynamoDbWriteRequest, out);
+            serialized = outputStream.toByteArray();
+        }
+
+        try (InputStream inputStream = new ByteArrayInputStream(serialized);
+                DataInputStream dataInputStream = new DataInputStream(inputStream)) {
+            DynamoDbWriteRequest deserializedWriteRequest =
+                    DynamoDbSerializationUtil.deserializeWriteRequest(dataInputStream);
+            assertThat(deserializedWriteRequest)
+                    .usingRecursiveComparison()
+                    .isEqualTo(dynamoDbWriteRequest);
+        }
+    }
+
+    @Test
     public void testSerializeEmptyAttributeValueThrowsException() {
         final Map<String, AttributeValue> item = new HashMap<>();
         item.put("empty", AttributeValue.builder().build());


### PR DESCRIPTION
## Purpose of the change

Implements support for conditional writes in the DynamoDB connector: [FLINK-31942](https://issues.apache.org/jira/browse/FLINK-31942)

The DynamoDB sink currently only uses the BatchWriteItem API, which does not support conditional writes or update expressions. This change adds support for individual PutItem, UpdateItem, and DeleteItem API calls alongside the existing batch path, enabling:

- Conditional writes via `conditionExpression` on PUT, DELETE, and UPDATE requests
- Update expressions via `updateExpression` for partial item updates
- Concurrent execution of batch and single-item paths for mixed workloads

Requests without conditions (PUT/DELETE) continue to use `BatchWriteItem` for efficiency. Requests with conditions and all UPDATE requests are sent as individual API calls. Both paths execute concurrently with results collected into shared thread-safe state and `ResultHandler` called exactly once after both paths complete.

## Verifying this change

This change added tests and can be verified as follows:

**Unit tests (`DynamoDbSinkWriterTest`):**
- Batch-only, single-only, and mixed batch+single request paths
- Retryable and non-retryable error scenarios for both paths
- `ConditionalCheckFailedException` on the single-request path verified as non-retryable
- Plain PUT and DELETE without conditions verified to route through `BatchWriteItem`
- Mixed batch+single with concurrent fatal/retryable errors

**Unit tests (`DynamoDbBeanElementConverterTest`):**
- Conditional PUT with condition expression and expression attribute names
- DELETE extracts only primary key attributes from POJO
- UPDATE extracts primary key and sets update expression
- Builder validation: `updateExpression` required for UPDATE, rejected for PUT/DELETE

**Unit tests (`DynamoDbWriteRequestTest`):**
- Builder validation: UPDATE requires `updateExpression`
- Builder constructs requests with all expression fields
- PUT with `conditionExpression` and null `updateExpression`

**Serialization tests (`DynamoDbSerializationUtilTest`, `DynamoDbWriterStateSerializerTest`):**
- Roundtrip serialization of UPDATE requests with all fields populated
- Roundtrip serialization of conditional PUT requests
- All-fields-populated roundtrip (`updateExpression` + `conditionExpression` + `expressionAttributeNames` + `expressionAttributeValues`)
- Backward compatibility: version 1 checkpoint bytes deserialized correctly by version 2 serializer

**Integration tests (`DynamoDbSinkConditionalWriteITCase`):**
- Batch PUT via `DynamoDbBeanElementConverter` against DynamoDB Local
- UPDATE via builder with `DynamoDbWriteRequestType.UPDATE`
- Conditional PUT preventing overwrite (`attribute_not_exists`) — verifies `ConditionalCheckFailedException` fails the job and original data is unchanged
- Conditional DELETE only deleting items matching condition

## Significant changes

### Public API changes

- **`DynamoDbWriteRequestType`**: added `UPDATE` enum value (`(byte) 2`)
- **`DynamoDbWriteRequest`**: added optional fields `updateExpression`, `conditionExpression`, `expressionAttributeNames`, `expressionAttributeValues` with corresponding builder methods. Existing constructors and builder usage unchanged.
- **`DynamoDbBeanElementConverter`**: added `builder(Class)` static method and `ElementConverterBuilder` for configuring type, update/condition expressions. Existing public constructors `(Class)` and `(Class, boolean)` unchanged. Multi-arg constructors made private — new features available only via builder.
- **`DynamoDbSink`** Javadoc updated to document the three write request types and batch vs single execution model.

### Serializer changes

- `DynamoDbWriterStateSerializer` version bumped from 1 to 2
- `DynamoDbSerializationUtil` serializes/deserializes the four new expression fields using boolean presence flags for nullable values
- Version 1 checkpoints (without expression fields) deserialize correctly with the version 2 serializer — full backward compatibility verified by test
- Version is passed from `DynamoDbWriterStateSerializer.deserialize(int version, byte[])` to `DynamoDbSerializationUtil.deserializeWriteRequest(in, version)` via a `ThreadLocal` field, since the parent class `AsyncSinkWriterStateSerializer` does not forward the version to `deserializeRequestFromStream()`. This is a workaround — see follow-up discussion about adding version support to the base class.

### Checklist

- [ ] Dependencies have been added or upgraded
- [x] Public API has been changed (any class annotated with `@Public(Evolving)`)
- [x] Serializers have been changed
- [x] New feature has been introduced
  - Documented via Javadoc: `DynamoDbSink` class-level Javadoc describes the three write request types (PUT/DELETE/UPDATE) and batch vs single execution model. `DynamoDbBeanElementConverter` Javadoc documents the supported types and builder usage. `DynamoDbWriteRequest` Javadoc explains the semantics of `item` field per request type.