### PR TITLE
[FLINK-37918][Connectors/Kinesis] Add GetRecords fetch interval for non-empty records to prevent throttling

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisSourceConfigOptions.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/config/KinesisSourceConfigOptions.java
@@ -92,6 +92,17 @@ public class KinesisSourceConfigOptions {
                     .withDescription(
                             "The interval in milliseconds between fetches with empty records");
 
+    public static final ConfigOption<Duration> SHARD_GET_RECORDS_INTERVAL =
+            ConfigOptions.key("source.shard.get-records.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(250))
+                    .withDescription(
+                            "The interval between each GetRecords request to a Kinesis shard."
+                                    + " Equivalent to SHARD_GETRECORDS_INTERVAL_MILLIS in the legacy"
+                                    + " FlinkKinesisConsumer. Kinesis allows at most 5 GetRecords"
+                                    + " calls per second per shard. The default of 250ms keeps each"
+                                    + " shard safely under this limit.");
+
     public static final ConfigOption<ConsumerLifecycle> EFO_CONSUMER_LIFECYCLE =
             ConfigOptions.key("source.efo.lifecycle")
                     .enumType(ConsumerLifecycle.class)

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/KinesisShardSplitReaderBase.java
@@ -65,6 +65,7 @@ public abstract class KinesisShardSplitReaderBase
     private final Map<String, KinesisShardMetrics> shardMetricGroupMap;
 
     private final long emptyRecordsIntervalMillis;
+    private final long getRecordsIntervalMillis;
 
     private final Map<KinesisShardSplitState, Long> scheduledFetchTimes = new WeakHashMap<>();
 
@@ -75,6 +76,8 @@ public abstract class KinesisShardSplitReaderBase
                 configuration
                         .get(KinesisSourceConfigOptions.READER_EMPTY_RECORDS_FETCH_INTERVAL)
                         .toMillis();
+        this.getRecordsIntervalMillis =
+                configuration.get(KinesisSourceConfigOptions.SHARD_GET_RECORDS_INTERVAL).toMillis();
     }
 
     @Override
@@ -181,11 +184,12 @@ public abstract class KinesisShardSplitReaderBase
     /**
      * Schedules next fetch time, to be called immediately on the result of a fetchRecords() call.
      *
-     * <p>If recordBatch does not contain records, next fetchRecords() is scheduled. Before
-     * scheduled time, fetcher thread will skip fetching (and have small sleep) for the split.
+     * <p>If recordBatch does not contain records, next fetchRecords() is scheduled using the
+     * empty-records interval. Before scheduled time, fetcher thread will skip fetching (and have
+     * small sleep) for the split.
      *
-     * <p>If recordBatch is not empty, next fetchRecords() time is not scheduled resulting in next
-     * fetch on the split is performed at first opportunity.
+     * <p>If recordBatch is not empty, next fetchRecords() is scheduled using the get-records
+     * interval to respect the Kinesis per-shard rate limit of 5 GetRecords calls per second.
      *
      * @param splitState splitState on which the fetchRecords() was called on
      * @param recordBatch recordBatch returned by fetchRecords()
@@ -201,6 +205,10 @@ public abstract class KinesisShardSplitReaderBase
                         splitState.getSplitId(),
                         new Date(scheduledGetRecordTimeMillis).toInstant());
             }
+        } else if (getRecordsIntervalMillis > 0) {
+            long scheduledGetRecordTimeMillis =
+                    System.currentTimeMillis() + getRecordsIntervalMillis;
+            this.scheduledFetchTimes.put(splitState, scheduledGetRecordTimeMillis);
         }
     }
 


### PR DESCRIPTION
## Summary

The FLIP-27 `KinesisStreamsSource` has no delay between `GetRecords` calls when records are returned, causing per-shard rate limit violations (5 calls/sec/shard). This restores the equivalent of the legacy `SHARD_GETRECORDS_INTERVAL_MILLIS` (default 250ms) using the existing `scheduledFetchTimes` mechanism from FLINK-36947.

### Changes
- Add new config option `source.shard.get-records.interval` (default 250ms) in `KinesisSourceConfigOptions`
- Apply the interval in `KinesisShardSplitReaderBase.scheduleNextFetch()` for non-empty record batches

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Validate against a live Kinesis stream that GetRecords calls stay within the 5 calls/sec/shard limit