### PR TITLE
[FLINK-39098] Bump testcontainers to 1.21.4 for Docker API compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
         <junit5.version>5.8.1</junit5.version>
         <assertj.version>3.21.0</assertj.version>
         <archunit.version>0.22.0</archunit.version>
-        <testcontainers.version>1.17.2</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <mockito.version>3.12.4</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <kotlin.version>1.7.10</kotlin.version>


### PR DESCRIPTION
## Purpose of the change

Bumps `testcontainers` from `1.17.2` to `1.21.4` to resolve Docker API compatibility issues (FLINK-39098 / #232).

Testcontainers 1.17.2 was released in June 2022 and does not support newer Docker API versions. Version 1.21.4 includes fixes for Docker Desktop compatibility and newer Docker Engine versions.

## Verifying this change

This change is already covered by existing tests. All integration tests that exercise testcontainers pass:

- `flink-connector-dynamodb` — DynamoDB integration tests via LocalStack container
- `flink-connector-aws-kinesis-streams` — Kinesis Streams integration tests via LocalStack container
- `flink-connector-aws-kinesis-firehose` — Kinesis Firehose integration tests via LocalStack container
- `flink-connector-sqs` — SQS unit tests
- Full `mvn verify` passes across all 20 modules (tested with Docker Desktop 25.0.3 on macOS ARM64)

## Significant changes
- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)