### PR TITLE
[FLINK-39540][Connectors/Kinesis][6.x] Addressed bugs for EFO subscriptions when they are completed

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -331,7 +331,6 @@ public class FanOutKinesisShardSubscription {
         public void onComplete() {
             LOG.info("Subscription complete - {} ({})", shardId, consumerArn);
             cancel();
-            activateSubscription();
         }
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -107,7 +107,8 @@ public class FanOutKinesisShardSubscription {
                 shardId,
                 startingPosition,
                 consumerArn);
-        if (shardSubscriber != null && shardSubscriber.getSubscriptionState() == SubscriptionState.SUBSCRIBED) {
+        if (shardSubscriber != null
+                && shardSubscriber.getSubscriptionState() == SubscriptionState.SUBSCRIBED) {
             LOG.warn("Skipping activation of subscription since it is already active.");
             return;
         }
@@ -235,23 +236,30 @@ public class FanOutKinesisShardSubscription {
             throw new KinesisStreamsSourceException(
                     "Subscription encountered unrecoverable exception.", throwable);
         }
-        final SubscriptionState state = Optional.ofNullable(shardSubscriber)
-                .map(FanOutShardSubscriber::getSubscriptionState)
-                .orElse(SubscriptionState.NOT_STARTED);
+        final SubscriptionState state =
+                Optional.ofNullable(shardSubscriber)
+                        .map(FanOutShardSubscriber::getSubscriptionState)
+                        .orElse(SubscriptionState.NOT_STARTED);
 
         switch (state) {
             case NOT_STARTED:
-                LOG.debug("Subscription to shard {} for consumer {} is not yet active. Skipping.",
-                        shardId, consumerArn);
+                LOG.debug(
+                        "Subscription to shard {} for consumer {} is not yet active. Skipping.",
+                        shardId,
+                        consumerArn);
                 return null;
             case COMPLETED:
                 if (shardSubscriber.isShardEndReached()) {
-                    LOG.info("Subscription reached SHARD_END for shard {} for consumer {}.",
-                            shardId, consumerArn);
+                    LOG.info(
+                            "Subscription reached SHARD_END for shard {} for consumer {}.",
+                            shardId,
+                            consumerArn);
                     return null;
                 }
-                LOG.info("Subscription expired to shard {} for consumer {}. Restarting.",
-                        shardId, consumerArn);
+                LOG.info(
+                        "Subscription expired to shard {} for consumer {}. Restarting.",
+                        shardId,
+                        consumerArn);
                 activateSubscription();
                 return null;
             case SUBSCRIBED:
@@ -279,6 +287,7 @@ public class FanOutKinesisShardSubscription {
 
         /**
          * Fetch the state that the subscriber is in.
+         *
          * @return Subscription state for the subscriber.
          */
         public SubscriptionState getSubscriptionState() {
@@ -287,6 +296,7 @@ public class FanOutKinesisShardSubscription {
 
         /**
          * Boolean whether this subscriber has reached the end of a shard.
+         *
          * @return True if ShardEnd. false otherwise.
          */
         public boolean isShardEndReached() {
@@ -373,9 +383,7 @@ public class FanOutKinesisShardSubscription {
         }
     }
 
-    /**
-     * States that the {@code FanOutShardSubscriber} may be in.
-     */
+    /** States that the {@code FanOutShardSubscriber} may be in. */
     private enum SubscriptionState {
         NOT_STARTED,
         SUBSCRIBED,

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -80,7 +80,6 @@ public class FanOutKinesisShardSubscription {
     // Queue is meant for eager retrieval of records from the Kinesis stream. We will always have 2
     // record batches available on next read.
     private final BlockingQueue<SubscribeToShardEvent> eventQueue = new LinkedBlockingQueue<>(2);
-    private final AtomicBoolean subscriptionActive = new AtomicBoolean(false);
     private final AtomicReference<Throwable> subscriptionException = new AtomicReference<>();
 
     // Store the current starting position for this subscription. Will be updated each time new
@@ -108,7 +107,7 @@ public class FanOutKinesisShardSubscription {
                 shardId,
                 startingPosition,
                 consumerArn);
-        if (subscriptionActive.get()) {
+        if (shardSubscriber != null && shardSubscriber.getSubscriptionState() == SubscriptionState.SUBSCRIBED) {
             LOG.warn("Skipping activation of subscription since it is already active.");
             return;
         }
@@ -166,9 +165,9 @@ public class FanOutKinesisShardSubscription {
                                     shardId,
                                     startingPosition,
                                     consumerArn);
-                            subscriptionActive.set(true);
                             // Request first batch of records.
                             shardSubscriber.requestRecords();
+
                         } else {
                             String errorMessage =
                                     "Timeout when subscribing to shard "
@@ -237,11 +236,25 @@ public class FanOutKinesisShardSubscription {
                     "Subscription encountered unrecoverable exception.", throwable);
         }
 
-        if (!subscriptionActive.get()) {
+        if (shardSubscriber == null || shardSubscriber.getSubscriptionState() == SubscriptionState.NOT_STARTED) {
             LOG.debug(
                     "Subscription to shard {} for consumer {} is not yet active. Skipping.",
                     shardId,
                     consumerArn);
+            return null;
+        } else if (shardSubscriber.getSubscriptionState() == SubscriptionState.COMPLETED &&
+                shardSubscriber.reachedShardEnd.get()) {
+            LOG.info("Subscription reached SHARD_END for shard {} for consumer {}. No more records coming in.",
+                    shardId,
+                    consumerArn);
+            return null;
+        } else if (shardSubscriber.getSubscriptionState() == SubscriptionState.COMPLETED &&
+                !shardSubscriber.reachedShardEnd.get()) {
+            LOG.info("Subscription expired to shard {} for consumer {} but we have not reached SHARD_END. " +
+                            "Restarting subscription.",
+                    shardId,
+                    consumerArn);
+            activateSubscription();
             return null;
         }
 
@@ -254,11 +267,18 @@ public class FanOutKinesisShardSubscription {
      */
     private class FanOutShardSubscriber implements Subscriber<SubscribeToShardEventStream> {
         private final CountDownLatch subscriptionLatch;
-
         private Subscription subscription;
+
+        private final AtomicReference<SubscriptionState> subscriptionState =
+                new AtomicReference<>(SubscriptionState.NOT_STARTED);
+        private final AtomicBoolean reachedShardEnd = new AtomicBoolean(false);
 
         private FanOutShardSubscriber(CountDownLatch subscriptionLatch) {
             this.subscriptionLatch = subscriptionLatch;
+        }
+
+        public SubscriptionState getSubscriptionState() {
+            return subscriptionState.get();
         }
 
         public void requestRecords() {
@@ -266,14 +286,15 @@ public class FanOutKinesisShardSubscription {
         }
 
         public void cancel() {
-            if (!subscriptionActive.get()) {
+            if (this.subscriptionState.get() == SubscriptionState.COMPLETED) {
                 LOG.warn("Trying to cancel inactive subscription. Ignoring.");
                 return;
             }
-            subscriptionActive.set(false);
+
             if (subscription != null) {
                 subscription.cancel();
             }
+            this.subscriptionState.set(SubscriptionState.COMPLETED);
         }
 
         @Override
@@ -284,6 +305,7 @@ public class FanOutKinesisShardSubscription {
                     startingPosition,
                     consumerArn);
             this.subscription = subscription;
+            this.subscriptionState.set(SubscriptionState.SUBSCRIBED);
             subscriptionLatch.countDown();
         }
 
@@ -299,6 +321,11 @@ public class FanOutKinesisShardSubscription {
                                         event.getClass().getSimpleName(),
                                         event);
                                 eventQueue.put(event);
+
+                                if (event.continuationSequenceNumber() == null) {
+                                    reachedShardEnd.set(true);
+                                    return;
+                                }
 
                                 // Update the starting position in case we have to recreate the
                                 // subscription
@@ -330,6 +357,13 @@ public class FanOutKinesisShardSubscription {
         @Override
         public void onComplete() {
             LOG.info("Subscription complete - {} ({})", shardId, consumerArn);
+            this.subscriptionState.set(SubscriptionState.COMPLETED);
         }
+    }
+
+    private enum SubscriptionState {
+        NOT_STARTED,
+        SUBSCRIBED,
+        COMPLETED
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -330,7 +330,6 @@ public class FanOutKinesisShardSubscription {
         @Override
         public void onComplete() {
             LOG.info("Subscription complete - {} ({})", shardId, consumerArn);
-            cancel();
         }
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -235,30 +235,30 @@ public class FanOutKinesisShardSubscription {
             throw new KinesisStreamsSourceException(
                     "Subscription encountered unrecoverable exception.", throwable);
         }
+        final SubscriptionState state = Optional.ofNullable(shardSubscriber)
+                .map(FanOutShardSubscriber::getSubscriptionState)
+                .orElse(SubscriptionState.NOT_STARTED);
 
-        if (shardSubscriber == null || shardSubscriber.getSubscriptionState() == SubscriptionState.NOT_STARTED) {
-            LOG.debug(
-                    "Subscription to shard {} for consumer {} is not yet active. Skipping.",
-                    shardId,
-                    consumerArn);
-            return null;
-        } else if (shardSubscriber.getSubscriptionState() == SubscriptionState.COMPLETED &&
-                shardSubscriber.reachedShardEnd.get()) {
-            LOG.info("Subscription reached SHARD_END for shard {} for consumer {}. No more records coming in.",
-                    shardId,
-                    consumerArn);
-            return null;
-        } else if (shardSubscriber.getSubscriptionState() == SubscriptionState.COMPLETED &&
-                !shardSubscriber.reachedShardEnd.get()) {
-            LOG.info("Subscription expired to shard {} for consumer {} but we have not reached SHARD_END. " +
-                            "Restarting subscription.",
-                    shardId,
-                    consumerArn);
-            activateSubscription();
-            return null;
+        switch (state) {
+            case NOT_STARTED:
+                LOG.debug("Subscription to shard {} for consumer {} is not yet active. Skipping.",
+                        shardId, consumerArn);
+                return null;
+            case COMPLETED:
+                if (shardSubscriber.isShardEndReached()) {
+                    LOG.info("Subscription reached SHARD_END for shard {} for consumer {}.",
+                            shardId, consumerArn);
+                    return null;
+                }
+                LOG.info("Subscription expired to shard {} for consumer {}. Restarting.",
+                        shardId, consumerArn);
+                activateSubscription();
+                return null;
+            case SUBSCRIBED:
+                return eventQueue.poll();
+            default:
+                throw new IllegalStateException("Unknown subscription state: " + state);
         }
-
-        return eventQueue.poll();
     }
 
     /**
@@ -271,14 +271,26 @@ public class FanOutKinesisShardSubscription {
 
         private final AtomicReference<SubscriptionState> subscriptionState =
                 new AtomicReference<>(SubscriptionState.NOT_STARTED);
-        private final AtomicBoolean reachedShardEnd = new AtomicBoolean(false);
+        private final AtomicBoolean isShardEnd = new AtomicBoolean(false);
 
         private FanOutShardSubscriber(CountDownLatch subscriptionLatch) {
             this.subscriptionLatch = subscriptionLatch;
         }
 
+        /**
+         * Fetch the state that the subscriber is in.
+         * @return Subscription state for the subscriber.
+         */
         public SubscriptionState getSubscriptionState() {
             return subscriptionState.get();
+        }
+
+        /**
+         * Boolean whether this subscriber has reached the end of a shard.
+         * @return True if ShardEnd. false otherwise.
+         */
+        public boolean isShardEndReached() {
+            return isShardEnd.get();
         }
 
         public void requestRecords() {
@@ -323,7 +335,7 @@ public class FanOutKinesisShardSubscription {
                                 eventQueue.put(event);
 
                                 if (event.continuationSequenceNumber() == null) {
-                                    reachedShardEnd.set(true);
+                                    isShardEnd.set(true);
                                     return;
                                 }
 
@@ -361,6 +373,9 @@ public class FanOutKinesisShardSubscription {
         }
     }
 
+    /**
+     * States that the {@code FanOutShardSubscriber} may be in.
+     */
     private enum SubscriptionState {
         NOT_STARTED,
         SUBSCRIBED,

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
@@ -177,7 +177,8 @@ class FanOutKinesisShardSubscriptionTest {
                                                         new Subscription() {
                                                             @Override
                                                             public void request(long n) {
-                                                                // Complete without sending any events (simulates 5-min expiry)
+                                                                // Complete without sending any
+                                                                // events (simulates 5-min expiry)
                                                                 subscriber.onComplete();
                                                             }
 
@@ -237,7 +238,8 @@ class FanOutKinesisShardSubscriptionTest {
                                                             public void request(long n) {
                                                                 if (!sent) {
                                                                     sent = true;
-                                                                    // Send event with null continuation (shard end)
+                                                                    // Send event with null
+                                                                    // continuation (shard end)
                                                                     subscriber.onNext(
                                                                             SubscribeToShardEvent
                                                                                     .builder()

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
@@ -156,7 +156,7 @@ class FanOutKinesisShardSubscriptionTest {
     }
 
     @Test
-    void testOnCompleteDoesNotResubscribe() throws Exception {
+    void testExpiredSubscriptionResubscribes() throws Exception {
         AtomicInteger subscribeCount = new AtomicInteger(0);
         AsyncStreamProxy proxy =
                 new AsyncStreamProxy() {
@@ -177,6 +177,7 @@ class FanOutKinesisShardSubscriptionTest {
                                                         new Subscription() {
                                                             @Override
                                                             public void request(long n) {
+                                                                // Complete without sending any events (simulates 5-min expiry)
                                                                 subscriber.onComplete();
                                                             }
 
@@ -201,14 +202,84 @@ class FanOutKinesisShardSubscriptionTest {
                         SUBSCRIPTION_TIMEOUT);
 
         subscription.activateSubscription();
-
-        // Wait for the async subscription to activate and complete
         Thread.sleep(500);
 
-        // Verify subscribeToShard was called exactly once - onComplete must not re-subscribe
-        assertThat(subscribeCount.get()).isEqualTo(1);
+        // nextEvent() should detect COMPLETED without shard-end and trigger resubscription
+        subscription.nextEvent();
+        Thread.sleep(500);
 
-        // Subscription should be inactive after onComplete
+        assertThat(subscribeCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void testShardEndDoesNotResubscribe() throws Exception {
+        AtomicInteger subscribeCount = new AtomicInteger(0);
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        subscribeCount.incrementAndGet();
+                        return CompletableFuture.supplyAsync(
+                                () -> {
+                                    responseHandler.responseReceived(
+                                            SubscribeToShardResponse.builder().build());
+                                    responseHandler.onEventStream(
+                                            subscriber -> {
+                                                subscriber.onSubscribe(
+                                                        new Subscription() {
+                                                            private boolean sent = false;
+
+                                                            @Override
+                                                            public void request(long n) {
+                                                                if (!sent) {
+                                                                    sent = true;
+                                                                    // Send event with null continuation (shard end)
+                                                                    subscriber.onNext(
+                                                                            SubscribeToShardEvent
+                                                                                    .builder()
+                                                                                    .millisBehindLatest(
+                                                                                            0L)
+                                                                                    .continuationSequenceNumber(
+                                                                                            null)
+                                                                                    .build());
+                                                                } else {
+                                                                    subscriber.onComplete();
+                                                                }
+                                                            }
+
+                                                            @Override
+                                                            public void cancel() {}
+                                                        });
+                                            });
+                                    return null;
+                                });
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+        Thread.sleep(500);
+
+        // Drain the shard-end event from the queue
+        subscription.nextEvent();
+        Thread.sleep(500);
+
+        // Should not have resubscribed — shard has ended
+        assertThat(subscribeCount.get()).isEqualTo(1);
         assertThat(subscription.nextEvent()).isNull();
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
@@ -60,7 +60,7 @@ class FanOutKinesisShardSubscriptionTest {
     }
 
     @Test
-    void testResourceNotFoundExceptionThrown() throws Exception {
+    void testResourceNotFoundExceptionThrown() {
         AsyncStreamProxy proxy =
                 FakeKinesisFanOutBehaviorsFactory.resourceNotFoundWhenObtainingSubscription();
         FanOutKinesisShardSubscription subscription =

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader.fanout;
+
+import org.apache.flink.connector.kinesis.source.exception.KinesisStreamsSourceException;
+import org.apache.flink.connector.kinesis.source.proxy.AsyncStreamProxy;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+import org.apache.flink.connector.kinesis.source.util.FakeKinesisFanOutBehaviorsFactory;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponse;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.CONSUMER_ARN;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link FanOutKinesisShardSubscription}. */
+class FanOutKinesisShardSubscriptionTest {
+
+    private static final String TEST_SHARD_ID = generateShardId(1);
+    private static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    void testNextEventReturnsNullBeforeActivation() {
+        AsyncStreamProxy proxy = FakeKinesisFanOutBehaviorsFactory.boundedShard().build();
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        assertThat(subscription.nextEvent()).isNull();
+    }
+
+    @Test
+    void testResourceNotFoundExceptionThrown() throws Exception {
+        AsyncStreamProxy proxy =
+                FakeKinesisFanOutBehaviorsFactory.resourceNotFoundWhenObtainingSubscription();
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+
+        // Poll until exception surfaces
+        assertThatThrownBy(
+                        () -> {
+                            for (int i = 0; i < 200; i++) {
+                                subscription.nextEvent();
+                                Thread.sleep(50);
+                            }
+                        })
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void testUnrecoverableExceptionWrappedInSourceException() throws Exception {
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        responseHandler.exceptionOccurred(
+                                new IllegalStateException("unrecoverable"));
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+
+        assertThatThrownBy(
+                        () -> {
+                            for (int i = 0; i < 200; i++) {
+                                subscription.nextEvent();
+                                Thread.sleep(50);
+                            }
+                        })
+                .isInstanceOf(KinesisStreamsSourceException.class)
+                .hasMessageContaining("unrecoverable");
+    }
+
+    @Test
+    void testSubscriptionTimeoutTerminatesSubscription() throws Exception {
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        return new CompletableFuture<>();
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        Duration.ofMillis(200));
+
+        subscription.activateSubscription();
+
+        // Wait for timeout to trigger, then poll - should recover
+        Thread.sleep(500);
+        SubscribeToShardEvent event = subscription.nextEvent();
+        assertThat(event).isNull();
+    }
+
+    @Test
+    void testOnCompleteDoesNotResubscribe() throws Exception {
+        AtomicInteger subscribeCount = new AtomicInteger(0);
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        subscribeCount.incrementAndGet();
+                        return CompletableFuture.supplyAsync(
+                                () -> {
+                                    responseHandler.responseReceived(
+                                            SubscribeToShardResponse.builder().build());
+                                    responseHandler.onEventStream(
+                                            subscriber -> {
+                                                subscriber.onSubscribe(
+                                                        new Subscription() {
+                                                            @Override
+                                                            public void request(long n) {
+                                                                subscriber.onComplete();
+                                                            }
+
+                                                            @Override
+                                                            public void cancel() {}
+                                                        });
+                                            });
+                                    return null;
+                                });
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+
+        // Wait for the async subscription to activate and complete
+        Thread.sleep(500);
+
+        // Verify subscribeToShard was called exactly once - onComplete must not re-subscribe
+        assertThat(subscribeCount.get()).isEqualTo(1);
+
+        // Subscription should be inactive after onComplete
+        assertThat(subscription.nextEvent()).isNull();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
## Purpose of the change
- https://issues.apache.org/jira/browse/FLINK-39540

Address a bug in the Kinesis Flink Connector that would cause Enhanced Fan Out (EFO) customers to continously experience ``IllegalArgumentException`` when their stream is resharded. This occurs due to the subscription being restarted when it should be completed and cleaned up.

Example of error:
```
[aws-java-sdk-NettyEventLoop-31-1] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Subscription complete - shardId-000000002053 (arn:aws:kinesis:us-east-1:123456:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121)
[aws-java-sdk-NettyEventLoop-31-1] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Activating subscription to shard shardId-000000002053 with starting position StartingPosition{shardIteratorType=AFTER_SEQUENCE_NUMBER, startingMarker=null} for consumer arn:aws:kinesis:us-east-1:123456:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121.
[aws-java-sdk-NettyEventLoop-31-1] ERROR software.amazon.awssdk.utils.async.FlatteningSubscriber - Unexpected exception encountered that violates the reactive streams specification. Attempting to terminate gracefully.
java.lang.IllegalArgumentException: Invalid StartingPosition. When ShardIteratorType is AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER, startingMarker must be a String.
        at org.apache.flink.util.Preconditions.checkArgument(Preconditions.java:138)
        at org.apache.flink.connector.kinesis.source.split.StartingPositionUtil.toSdkStartingPosition(StartingPositionUtil.java:65)
        at org.apache.flink.connector.kinesis.source.proxy.KinesisAsyncStreamProxy.subscribeToShard(KinesisAsyncStreamProxy.java:56)
        at org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription.activateSubscription(FanOutKinesisShardSubscription.java:137)
        at org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription$FanOutShardSubscriber.onComplete(FanOutKinesisShardSubscription.java:334)
        at software.amazon.awssdk.utils.async.DelegatingSubscriber.onComplete(DelegatingSubscriber.java:47)
...
```

## Verifying this change
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

After making the change, i 1. re-ran my flink application, 2. resharded my stream. Afterwards verified that subscriptions were being shut down without issues:

```
[aws-java-sdk-NettyEventLoop-31-9] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Subscription complete - shardId-000000002825 (arn:aws:kinesis:us-east-1:123456:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121)
[aws-java-sdk-NettyEventLoop-31-5] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Subscription complete - shardId-000000002828 (arn:aws:kinesis:us-east-1:123456:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121)
[aws-java-sdk-NettyEventLoop-31-18] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Subscription complete - shardId-000000002822 (arn:aws:kinesis:us-east-1:123456:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121)
```


## Significant changes
N/A - Not a significant change
