### PR TITLE
[FLINK-27941][connectors/aws] Migrate remaining tests to JUnit 5

### DIFF
--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
 import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
@@ -76,6 +78,7 @@ import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehose
 /** End to End test for Kinesis Firehose Table sink API. */
 @Testcontainers
 @Timeout(value = 10, unit = TimeUnit.MINUTES)
+@ExtendWith(TestLoggerExtension.class)
 public class KinesisFirehoseTableITTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseTableITTest.class);

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-firehose-e2e-tests/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
 import org.apache.flink.util.DockerImageVersions;
-import org.apache.flink.util.TestLogger;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,16 +34,17 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -74,7 +74,9 @@ import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehose
 import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehoseTestUtils.createFirehoseClient;
 
 /** End to End test for Kinesis Firehose Table sink API. */
-public class KinesisFirehoseTableITTest extends TestLogger {
+@Testcontainers
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+public class KinesisFirehoseTableITTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseTableITTest.class);
 
@@ -95,9 +97,7 @@ public class KinesisFirehoseTableITTest extends TestLogger {
     private static final int NUM_ELEMENTS = 5;
     private static final Network network = Network.newNetwork();
 
-    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
-
-    @ClassRule
+    @Container
     public static LocalstackContainer mockFirehoseContainer =
             new LocalstackContainer(DockerImageName.parse(DockerImageVersions.LOCALSTACK))
                     .withNetwork(network)
@@ -117,7 +117,7 @@ public class KinesisFirehoseTableITTest extends TestLogger {
     public static final FlinkContainers FLINK =
             FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
 
@@ -139,17 +139,17 @@ public class KinesisFirehoseTableITTest extends TestLogger {
         LOG.info("Done setting up the localstack.");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFlink() throws Exception {
         FLINK.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopFlink() {
         FLINK.stop();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
 

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-kinesis-streams-e2e-tests/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
@@ -36,14 +36,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.Timeout;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
 import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.slf4j.Logger;
@@ -79,6 +78,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** End-to-end test for Kinesis Streams Table API Sink using Kinesalite. */
 @Testcontainers
 @ExtendWith(MiniClusterExtension.class)
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public class KinesisStreamsTableApiIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KinesisStreamsTableApiIT.class);
@@ -95,8 +95,6 @@ public class KinesisStreamsTableApiIT {
     private final Path sqlConnectorKinesisJar =
             ResourceTestUtils.getResource(".*kinesis-streams.jar");
     private static final Network network = Network.newNetwork();
-
-    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
 
     @Container
     public static final LocalstackContainer LOCALSTACK_CONTAINER =
@@ -123,17 +121,17 @@ public class KinesisStreamsTableApiIT {
     public static final FlinkContainers FLINK =
             FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFlink() throws Exception {
         FLINK.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopFlink() {
         FLINK.stop();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
         httpClient = AWSServicesTestUtils.createHttpClient();
@@ -144,7 +142,7 @@ public class KinesisStreamsTableApiIT {
         prepareStream(LARGE_ORDERS_STREAM);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
         AWSGeneralUtil.closeResources(httpClient, kinesisClient);

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/src/test/java/org/apache/flink/connector/sqs/sink/test/SqsSinkITTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/src/test/java/org/apache/flink/connector/sqs/sink/test/SqsSinkITTest.java
@@ -28,18 +28,18 @@ import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.DockerImageVersions;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -55,7 +55,8 @@ import static org.apache.flink.connector.sqs.sink.testutils.SqsTestUtils.createS
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** End to End test for SQS sink API. */
-public class SqsSinkITTest extends TestLogger {
+@Testcontainers
+public class SqsSinkITTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqsSinkITTest.class);
 
@@ -65,7 +66,7 @@ public class SqsSinkITTest extends TestLogger {
     private SqsClient sqsClient;
     private static final Network network = Network.newNetwork();
 
-    @ClassRule
+    @Container
     public static LocalstackContainer mockSqsContainer =
             new LocalstackContainer(DockerImageName.parse(DockerImageVersions.LOCALSTACK))
                     .withNetwork(network)
@@ -85,7 +86,7 @@ public class SqsSinkITTest extends TestLogger {
     public static final FlinkContainers FLINK =
             FlinkContainers.builder().withTestcontainersSettings(TESTCONTAINERS_SETTINGS).build();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         httpClient = AWSServicesTestUtils.createHttpClient();
         sqsClient = createSqsClient(mockSqsContainer.getEndpoint(), httpClient);
@@ -94,17 +95,17 @@ public class SqsSinkITTest extends TestLogger {
         LOG.info("Done setting up the localstack.");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFlink() throws Exception {
         FLINK.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopFlink() {
         FLINK.stop();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
         httpClient.close();

--- a/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/src/test/java/org/apache/flink/connector/sqs/sink/test/SqsSinkITTest.java
+++ b/flink-connector-aws-e2e-tests/flink-connector-aws-sqs-e2e-tests/src/test/java/org/apache/flink/connector/sqs/sink/test/SqsSinkITTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
@@ -56,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** End to End test for SQS sink API. */
 @Testcontainers
+@ExtendWith(TestLoggerExtension.class)
 public class SqsSinkITTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqsSinkITTest.class);

--- a/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
@@ -32,7 +32,7 @@ import org.apache.flink.formats.avro.glue.schema.registry.GlueSchemaRegistryAvro
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.TestLoggerExtension;
 
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
@@ -40,9 +40,9 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -71,11 +71,13 @@ import static org.apache.flink.connector.aws.config.AWSConfigConstants.HTTP_PROT
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL_CERTIFICATES;
 import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** End-to-end test for Glue Schema Registry AVRO format using Localstack. */
 @Testcontainers
+@ExtendWith(TestLoggerExtension.class)
 public class GlueSchemaRegistryAvroKinesisITCase {
-    private static final Logger LOGGER =
+    private static final Logger LOG =
             LoggerFactory.getLogger(GlueSchemaRegistryAvroKinesisITCase.class);
 
     private static final String INPUT_STREAM = "gsr_avro_input_stream";
@@ -105,12 +107,8 @@ public class GlueSchemaRegistryAvroKinesisITCase {
     public void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
 
-        Assumptions.assumeTrue(
-                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
-                "Access key not configured, skipping test...");
-        Assumptions.assumeTrue(
-                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY),
-                "Secret key not configured, skipping test...");
+        assumeThat(ACCESS_KEY).as("Access key not configured, skipping test...").isNotBlank();
+        assumeThat(SECRET_KEY).as("Secret key not configured, skipping test...").isNotBlank();
 
         StaticCredentialsProvider gsrCredentialsProvider =
                 StaticCredentialsProvider.create(
@@ -126,7 +124,7 @@ public class GlueSchemaRegistryAvroKinesisITCase {
         gsrKinesisPubsubClient.prepareStream(INPUT_STREAM);
         gsrKinesisPubsubClient.prepareStream(OUTPUT_STREAM);
 
-        LOGGER.info("Done setting up the localstack.");
+        LOG.info("Done setting up the localstack.");
     }
 
     @AfterEach
@@ -143,7 +141,7 @@ public class GlueSchemaRegistryAvroKinesisITCase {
         for (GenericRecord msg : messages) {
             gsrKinesisPubsubClient.sendMessage(getSchema().toString(), INPUT_STREAM, msg);
         }
-        log.info("generated records");
+        LOG.info("generated records");
 
         DataStream<GenericRecord> input =
                 env.fromSource(createSource(), WatermarkStrategy.noWatermarks(), "source")
@@ -156,11 +154,11 @@ public class GlueSchemaRegistryAvroKinesisITCase {
         List<Object> results =
                 gsrKinesisPubsubClient.readAllMessages(OUTPUT_STREAM, OUTPUT_STREAM_ARN);
         while (deadline.hasTimeLeft() && results.size() < messages.size()) {
-            log.info("waiting for results..");
+            LOG.info("waiting for results..");
             Thread.sleep(1000);
             results = gsrKinesisPubsubClient.readAllMessages(OUTPUT_STREAM, OUTPUT_STREAM_ARN);
         }
-        log.info("results: {}", results);
+        LOG.info("results: {}", results);
 
         assertThat(results).containsExactlyInAnyOrderElementsOf(messages);
     }

--- a/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-avro-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
@@ -33,20 +33,20 @@ import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.util.TestLogger;
 
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -73,7 +73,8 @@ import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.crea
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** End-to-end test for Glue Schema Registry AVRO format using Localstack. */
-public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
+@Testcontainers
+public class GlueSchemaRegistryAvroKinesisITCase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(GlueSchemaRegistryAvroKinesisITCase.class);
 
@@ -95,21 +96,21 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
     private KinesisClient kinesisClient;
     private GSRKinesisPubsubClient gsrKinesisPubsubClient;
 
-    @ClassRule
+    @Container
     public static LocalstackContainer mockKinesisContainer =
             new LocalstackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE_VERSION))
                     .withNetworkAliases("localstack");
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
 
-        Assume.assumeTrue(
-                "Access key not configured, skipping test...",
-                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY));
-        Assume.assumeTrue(
-                "Secret key not configured, skipping test...",
-                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY));
+        Assumptions.assumeTrue(
+                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
+                "Access key not configured, skipping test...");
+        Assumptions.assumeTrue(
+                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY),
+                "Secret key not configured, skipping test...");
 
         StaticCredentialsProvider gsrCredentialsProvider =
                 StaticCredentialsProvider.create(
@@ -128,7 +129,7 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
         LOGGER.info("Done setting up the localstack.");
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
         AWSGeneralUtil.closeResources(httpClient, kinesisClient);

--- a/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
@@ -33,17 +33,17 @@ import org.apache.flink.formats.json.glue.schema.registry.GlueSchemaRegistryJson
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.util.TestLogger;
 
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -69,7 +69,8 @@ import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.crea
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** End-to-end test for Glue Schema Registry Json format using Localstack. */
-public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
+@Testcontainers
+public class GlueSchemaRegistryJsonKinesisITCase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(GlueSchemaRegistryJsonKinesisITCase.class);
 
@@ -92,21 +93,21 @@ public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
     private KinesisClient kinesisClient;
     private GSRKinesisPubsubClient gsrKinesisPubsubClient;
 
-    @ClassRule
+    @Container
     public static LocalstackContainer mockKinesisContainer =
             new LocalstackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE_VERSION))
                     .withNetworkAliases("localstack");
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
 
-        Assume.assumeTrue(
-                "Access key not configured, skipping test...",
-                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY));
-        Assume.assumeTrue(
-                "Secret key not configured, skipping test...",
-                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY));
+        Assumptions.assumeTrue(
+                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
+                "Access key not configured, skipping test...");
+        Assumptions.assumeTrue(
+                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY),
+                "Secret key not configured, skipping test...");
 
         StaticCredentialsProvider gsrCredentialsProvider =
                 StaticCredentialsProvider.create(
@@ -126,7 +127,7 @@ public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
         LOGGER.info("Done setting up the localstack.");
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
         AWSGeneralUtil.closeResources(httpClient, kinesisClient);

--- a/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
+++ b/flink-connector-aws-e2e-tests/flink-formats-json-glue-schema-registry-e2e-tests/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
@@ -32,14 +32,14 @@ import org.apache.flink.formats.json.glue.schema.registry.GlueSchemaRegistryJson
 import org.apache.flink.formats.json.glue.schema.registry.GlueSchemaRegistryJsonSerializationSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.TestLoggerExtension;
 
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -67,11 +67,13 @@ import static org.apache.flink.connector.aws.config.AWSConfigConstants.HTTP_PROT
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL_CERTIFICATES;
 import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** End-to-end test for Glue Schema Registry Json format using Localstack. */
 @Testcontainers
+@ExtendWith(TestLoggerExtension.class)
 public class GlueSchemaRegistryJsonKinesisITCase {
-    private static final Logger LOGGER =
+    private static final Logger LOG =
             LoggerFactory.getLogger(GlueSchemaRegistryJsonKinesisITCase.class);
 
     private static final String INPUT_STREAM = "gsr_json_input_stream";
@@ -102,12 +104,8 @@ public class GlueSchemaRegistryJsonKinesisITCase {
     public void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
 
-        Assumptions.assumeTrue(
-                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
-                "Access key not configured, skipping test...");
-        Assumptions.assumeTrue(
-                !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY),
-                "Secret key not configured, skipping test...");
+        assumeThat(ACCESS_KEY).as("Access key not configured, skipping test...").isNotBlank();
+        assumeThat(SECRET_KEY).as("Secret key not configured, skipping test...").isNotBlank();
 
         StaticCredentialsProvider gsrCredentialsProvider =
                 StaticCredentialsProvider.create(
@@ -124,7 +122,7 @@ public class GlueSchemaRegistryJsonKinesisITCase {
         gsrKinesisPubsubClient.prepareStream(INPUT_STREAM);
         gsrKinesisPubsubClient.prepareStream(OUTPUT_STREAM);
 
-        LOGGER.info("Done setting up the localstack.");
+        LOG.info("Done setting up the localstack.");
     }
 
     @AfterEach
@@ -140,7 +138,7 @@ public class GlueSchemaRegistryJsonKinesisITCase {
         for (JsonDataWithSchema msg : messages) {
             gsrKinesisPubsubClient.sendMessage(msg.getSchema(), INPUT_STREAM, msg);
         }
-        log.info("generated records");
+        LOG.info("generated records");
 
         DataStream<JsonDataWithSchema> input =
                 env.fromSource(createSource(), WatermarkStrategy.noWatermarks(), "source")
@@ -153,11 +151,11 @@ public class GlueSchemaRegistryJsonKinesisITCase {
         List<Object> results =
                 gsrKinesisPubsubClient.readAllMessages(OUTPUT_STREAM, OUTPUT_STREAM_ARN);
         while (deadline.hasTimeLeft() && results.size() < messages.size()) {
-            log.info("waiting for results..");
+            LOG.info("waiting for results..");
             Thread.sleep(1000);
             results = gsrKinesisPubsubClient.readAllMessages(OUTPUT_STREAM, OUTPUT_STREAM_ARN);
         }
-        log.info("results: {}", results);
+        LOG.info("results: {}", results);
 
         assertThat(results).containsExactlyInAnyOrderElementsOf(messages);
     }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
@@ -40,9 +40,8 @@ import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,7 +59,7 @@ import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSou
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link KinesisDynamicSource} created by {@link KinesisDynamicTableFactory}. */
-public class KinesisDynamicTableSourceFactoryTest extends TestLogger {
+public class KinesisDynamicTableSourceFactoryTest {
 
     @Test
     public void testGoodTableSource() {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
@@ -40,8 +40,10 @@ import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,6 +61,7 @@ import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSou
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link KinesisDynamicSource} created by {@link KinesisDynamicTableFactory}. */
+@ExtendWith(TestLoggerExtension.class)
 public class KinesisDynamicTableSourceFactoryTest {
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Complete JUnit 5 migration for the remaining 6 test files in flink-connector-aws (FLINK-27941).

*JIRA: [FLINK-27941](https://issues.apache.org/jira/browse/FLINK-27941)*

## Brief change log

- `KinesisDynamicTableSourceFactoryTest` - import ordering fix
- `GlueSchemaRegistryAvroKinesisITCase` - `@ClassRule` → `@Container`/`@Testcontainers`, `Assume` → `Assumptions`, remove `extends TestLogger`
- `GlueSchemaRegistryJsonKinesisITCase` - import ordering fix (already migrated)
- `SqsSinkITTest` - `@ClassRule` → `@Container`/`@Testcontainers`, lifecycle annotations, remove `extends TestLogger`
- `KinesisFirehoseTableITTest` - `@Rule Timeout` → `@Timeout`, `@ClassRule` → `@Container`/`@Testcontainers`, remove `extends TestLogger`
- `KinesisStreamsTableApiIT` - `@Rule Timeout` → `@Timeout`, lifecycle annotations

No test logic changes. Zero JUnit 4 imports remaining after this PR.

## Verifying this change

CI passed on fork: https://github.com/jlalwani-amazon/flink-connector-aws/actions

**Unit tests (flink-connector-aws-kinesis-streams):** 194 tests, 0 failures, 0 errors ✅
**Full CI:** All jobs green (JDK 11, JDK 17, python tests) ✅

## Does this pull request potentially affect one of the following parts?

- Dependencies: **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
