### PR TITLE
[FLINK-39540][Connectors/Kinesis][5.1] Addressed bugs for EFO subscriptions when they are completed

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -109,7 +109,7 @@ public class FanOutKinesisShardSubscription {
                 consumerArn);
         if (shardSubscriber != null
                 && shardSubscriber.getSubscriptionState() == SubscriptionState.SUBSCRIBED) {
-            LOG.warn("Skipping activation of subscription since it is already active.");
+            LOG.warn("Skipping activation of subscription since it is active & subscribed.");
             return;
         }
 
@@ -243,23 +243,29 @@ public class FanOutKinesisShardSubscription {
 
         switch (state) {
             case NOT_STARTED:
-                LOG.debug(
-                        "Subscription to shard {} for consumer {} is not yet active. Skipping.",
-                        shardId,
-                        consumerArn);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Subscription to shard {} for consumer {} is not yet active. Skipping.",
+                            shardId,
+                            consumerArn);
+                }
                 return null;
             case COMPLETED:
                 if (shardSubscriber.isShardEndReached()) {
-                    LOG.info(
-                            "Subscription reached SHARD_END for shard {} for consumer {}.",
-                            shardId,
-                            consumerArn);
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info(
+                                "Subscription reached SHARD_END for shard {} for consumer {}.",
+                                shardId,
+                                consumerArn);
+                    }
                     return null;
                 }
-                LOG.info(
-                        "Subscription expired to shard {} for consumer {}. Restarting.",
-                        shardId,
-                        consumerArn);
+                if (LOG.isInfoEnabled()) {
+                    LOG.info(
+                            "Subscription expired to shard {} for consumer {}. Restarting.",
+                            shardId,
+                            consumerArn);
+                }
                 activateSubscription();
                 return null;
             case SUBSCRIBED:
@@ -309,7 +315,7 @@ public class FanOutKinesisShardSubscription {
 
         public void cancel() {
             if (this.subscriptionState.get() == SubscriptionState.COMPLETED) {
-                LOG.warn("Trying to cancel inactive subscription. Ignoring.");
+                LOG.warn("Subscription is already completed. Ignoring request to cancel.");
                 return;
             }
 
@@ -345,6 +351,10 @@ public class FanOutKinesisShardSubscription {
                                 eventQueue.put(event);
 
                                 if (event.continuationSequenceNumber() == null) {
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug("continuationSequenceNumber is null. " +
+                                                "Reached ShardEnd for shard: {}", shardId);
+                                    }
                                     isShardEnd.set(true);
                                     return;
                                 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscription.java
@@ -80,7 +80,6 @@ public class FanOutKinesisShardSubscription {
     // Queue is meant for eager retrieval of records from the Kinesis stream. We will always have 2
     // record batches available on next read.
     private final BlockingQueue<SubscribeToShardEvent> eventQueue = new LinkedBlockingQueue<>(2);
-    private final AtomicBoolean subscriptionActive = new AtomicBoolean(false);
     private final AtomicReference<Throwable> subscriptionException = new AtomicReference<>();
 
     // Store the current starting position for this subscription. Will be updated each time new
@@ -108,7 +107,8 @@ public class FanOutKinesisShardSubscription {
                 shardId,
                 startingPosition,
                 consumerArn);
-        if (subscriptionActive.get()) {
+        if (shardSubscriber != null
+                && shardSubscriber.getSubscriptionState() == SubscriptionState.SUBSCRIBED) {
             LOG.warn("Skipping activation of subscription since it is already active.");
             return;
         }
@@ -166,9 +166,9 @@ public class FanOutKinesisShardSubscription {
                                     shardId,
                                     startingPosition,
                                     consumerArn);
-                            subscriptionActive.set(true);
                             // Request first batch of records.
                             shardSubscriber.requestRecords();
+
                         } else {
                             String errorMessage =
                                     "Timeout when subscribing to shard "
@@ -236,16 +236,37 @@ public class FanOutKinesisShardSubscription {
             throw new KinesisStreamsSourceException(
                     "Subscription encountered unrecoverable exception.", throwable);
         }
+        final SubscriptionState state =
+                Optional.ofNullable(shardSubscriber)
+                        .map(FanOutShardSubscriber::getSubscriptionState)
+                        .orElse(SubscriptionState.NOT_STARTED);
 
-        if (!subscriptionActive.get()) {
-            LOG.debug(
-                    "Subscription to shard {} for consumer {} is not yet active. Skipping.",
-                    shardId,
-                    consumerArn);
-            return null;
+        switch (state) {
+            case NOT_STARTED:
+                LOG.debug(
+                        "Subscription to shard {} for consumer {} is not yet active. Skipping.",
+                        shardId,
+                        consumerArn);
+                return null;
+            case COMPLETED:
+                if (shardSubscriber.isShardEndReached()) {
+                    LOG.info(
+                            "Subscription reached SHARD_END for shard {} for consumer {}.",
+                            shardId,
+                            consumerArn);
+                    return null;
+                }
+                LOG.info(
+                        "Subscription expired to shard {} for consumer {}. Restarting.",
+                        shardId,
+                        consumerArn);
+                activateSubscription();
+                return null;
+            case SUBSCRIBED:
+                return eventQueue.poll();
+            default:
+                throw new IllegalStateException("Unknown subscription state: " + state);
         }
-
-        return eventQueue.poll();
     }
 
     /**
@@ -254,11 +275,32 @@ public class FanOutKinesisShardSubscription {
      */
     private class FanOutShardSubscriber implements Subscriber<SubscribeToShardEventStream> {
         private final CountDownLatch subscriptionLatch;
-
         private Subscription subscription;
+
+        private final AtomicReference<SubscriptionState> subscriptionState =
+                new AtomicReference<>(SubscriptionState.NOT_STARTED);
+        private final AtomicBoolean isShardEnd = new AtomicBoolean(false);
 
         private FanOutShardSubscriber(CountDownLatch subscriptionLatch) {
             this.subscriptionLatch = subscriptionLatch;
+        }
+
+        /**
+         * Fetch the state that the subscriber is in.
+         *
+         * @return Subscription state for the subscriber.
+         */
+        public SubscriptionState getSubscriptionState() {
+            return subscriptionState.get();
+        }
+
+        /**
+         * Boolean whether this subscriber has reached the end of a shard.
+         *
+         * @return True if ShardEnd. false otherwise.
+         */
+        public boolean isShardEndReached() {
+            return isShardEnd.get();
         }
 
         public void requestRecords() {
@@ -266,14 +308,15 @@ public class FanOutKinesisShardSubscription {
         }
 
         public void cancel() {
-            if (!subscriptionActive.get()) {
+            if (this.subscriptionState.get() == SubscriptionState.COMPLETED) {
                 LOG.warn("Trying to cancel inactive subscription. Ignoring.");
                 return;
             }
-            subscriptionActive.set(false);
+
             if (subscription != null) {
                 subscription.cancel();
             }
+            this.subscriptionState.set(SubscriptionState.COMPLETED);
         }
 
         @Override
@@ -284,6 +327,7 @@ public class FanOutKinesisShardSubscription {
                     startingPosition,
                     consumerArn);
             this.subscription = subscription;
+            this.subscriptionState.set(SubscriptionState.SUBSCRIBED);
             subscriptionLatch.countDown();
         }
 
@@ -299,6 +343,11 @@ public class FanOutKinesisShardSubscription {
                                         event.getClass().getSimpleName(),
                                         event);
                                 eventQueue.put(event);
+
+                                if (event.continuationSequenceNumber() == null) {
+                                    isShardEnd.set(true);
+                                    return;
+                                }
 
                                 // Update the starting position in case we have to recreate the
                                 // subscription
@@ -330,8 +379,14 @@ public class FanOutKinesisShardSubscription {
         @Override
         public void onComplete() {
             LOG.info("Subscription complete - {} ({})", shardId, consumerArn);
-            cancel();
-            activateSubscription();
+            this.subscriptionState.set(SubscriptionState.COMPLETED);
         }
+    }
+
+    /** States that the {@code FanOutShardSubscriber} may be in. */
+    private enum SubscriptionState {
+        NOT_STARTED,
+        SUBSCRIBED,
+        COMPLETED
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/source/reader/fanout/FanOutKinesisShardSubscriptionTest.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.source.reader.fanout;
+
+import org.apache.flink.connector.kinesis.source.exception.KinesisStreamsSourceException;
+import org.apache.flink.connector.kinesis.source.proxy.AsyncStreamProxy;
+import org.apache.flink.connector.kinesis.source.split.StartingPosition;
+import org.apache.flink.connector.kinesis.source.util.FakeKinesisFanOutBehaviorsFactory;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponse;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.CONSUMER_ARN;
+import static org.apache.flink.connector.kinesis.source.util.TestUtil.generateShardId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link FanOutKinesisShardSubscription}. */
+class FanOutKinesisShardSubscriptionTest {
+
+    private static final String TEST_SHARD_ID = generateShardId(1);
+    private static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    void testNextEventReturnsNullBeforeActivation() {
+        AsyncStreamProxy proxy = FakeKinesisFanOutBehaviorsFactory.boundedShard().build();
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        assertThat(subscription.nextEvent()).isNull();
+    }
+
+    @Test
+    void testResourceNotFoundExceptionThrown() {
+        AsyncStreamProxy proxy =
+                FakeKinesisFanOutBehaviorsFactory.resourceNotFoundWhenObtainingSubscription();
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+
+        // Poll until exception surfaces
+        assertThatThrownBy(
+                        () -> {
+                            for (int i = 0; i < 200; i++) {
+                                subscription.nextEvent();
+                                Thread.sleep(50);
+                            }
+                        })
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void testUnrecoverableExceptionWrappedInSourceException() throws Exception {
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        responseHandler.exceptionOccurred(
+                                new IllegalStateException("unrecoverable"));
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+
+        assertThatThrownBy(
+                        () -> {
+                            for (int i = 0; i < 200; i++) {
+                                subscription.nextEvent();
+                                Thread.sleep(50);
+                            }
+                        })
+                .isInstanceOf(KinesisStreamsSourceException.class)
+                .hasMessageContaining("unrecoverable");
+    }
+
+    @Test
+    void testSubscriptionTimeoutTerminatesSubscription() throws Exception {
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        return new CompletableFuture<>();
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        Duration.ofMillis(200));
+
+        subscription.activateSubscription();
+
+        // Wait for timeout to trigger, then poll - should recover
+        Thread.sleep(500);
+        SubscribeToShardEvent event = subscription.nextEvent();
+        assertThat(event).isNull();
+    }
+
+    @Test
+    void testExpiredSubscriptionResubscribes() throws Exception {
+        AtomicInteger subscribeCount = new AtomicInteger(0);
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        subscribeCount.incrementAndGet();
+                        return CompletableFuture.supplyAsync(
+                                () -> {
+                                    responseHandler.responseReceived(
+                                            SubscribeToShardResponse.builder().build());
+                                    responseHandler.onEventStream(
+                                            subscriber -> {
+                                                subscriber.onSubscribe(
+                                                        new Subscription() {
+                                                            @Override
+                                                            public void request(long n) {
+                                                                // Complete without sending any
+                                                                // events (simulates 5-min expiry)
+                                                                subscriber.onComplete();
+                                                            }
+
+                                                            @Override
+                                                            public void cancel() {}
+                                                        });
+                                            });
+                                    return null;
+                                });
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+        Thread.sleep(500);
+
+        // nextEvent() should detect COMPLETED without shard-end and trigger resubscription
+        subscription.nextEvent();
+        Thread.sleep(500);
+
+        assertThat(subscribeCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void testShardEndDoesNotResubscribe() throws Exception {
+        AtomicInteger subscribeCount = new AtomicInteger(0);
+        AsyncStreamProxy proxy =
+                new AsyncStreamProxy() {
+                    @Override
+                    public CompletableFuture<Void> subscribeToShard(
+                            String consumerArn,
+                            String shardId,
+                            StartingPosition startingPosition,
+                            SubscribeToShardResponseHandler responseHandler) {
+                        subscribeCount.incrementAndGet();
+                        return CompletableFuture.supplyAsync(
+                                () -> {
+                                    responseHandler.responseReceived(
+                                            SubscribeToShardResponse.builder().build());
+                                    responseHandler.onEventStream(
+                                            subscriber -> {
+                                                subscriber.onSubscribe(
+                                                        new Subscription() {
+                                                            private boolean sent = false;
+
+                                                            @Override
+                                                            public void request(long n) {
+                                                                if (!sent) {
+                                                                    sent = true;
+                                                                    // Send event with null
+                                                                    // continuation (shard end)
+                                                                    subscriber.onNext(
+                                                                            SubscribeToShardEvent
+                                                                                    .builder()
+                                                                                    .millisBehindLatest(
+                                                                                            0L)
+                                                                                    .continuationSequenceNumber(
+                                                                                            null)
+                                                                                    .build());
+                                                                } else {
+                                                                    subscriber.onComplete();
+                                                                }
+                                                            }
+
+                                                            @Override
+                                                            public void cancel() {}
+                                                        });
+                                            });
+                                    return null;
+                                });
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        FanOutKinesisShardSubscription subscription =
+                new FanOutKinesisShardSubscription(
+                        proxy,
+                        CONSUMER_ARN,
+                        TEST_SHARD_ID,
+                        StartingPosition.fromStart(),
+                        SUBSCRIPTION_TIMEOUT);
+
+        subscription.activateSubscription();
+        Thread.sleep(500);
+
+        // Drain the shard-end event from the queue
+        subscription.nextEvent();
+        Thread.sleep(500);
+
+        // Should not have resubscribed — shard has ended
+        assertThat(subscribeCount.get()).isEqualTo(1);
+        assertThat(subscription.nextEvent()).isNull();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink AWS Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number. 
    Generally, [component] should be the connector you are working on.
    For example: "[FLINK-XXXX][Connectors/Kinesis] XXXX" if you are working on the Kinesis connector or "[FLINK-XXXX][Connectors/AWS] XXXX" if you are working on components shared among all the connectors.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
## Purpose of the change
- https://issues.apache.org/jira/browse/FLINK-39540

Address a bug in the Kinesis Flink Connector that would cause Enhanced Fan Out (EFO) customers to continously experience ``IllegalArgumentException`` when their stream is resharded. This occurs due to the subscription being restarted when it should be completed and cleaned up.

Example of error:
```
aws-java-sdk-NettyEventLoop-2-2] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Subscription complete - shardId-000000003081 (arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121)
[aws-java-sdk-NettyEventLoop-2-2] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Activating subscription to shard shardId-000000003081 with starting position StartingPosition{shardIteratorType=AFTER_SEQUENCE_NUMBER, startingMarker=null} for consumer arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121.
[aws-java-sdk-NettyEventLoop-2-2] ERROR software.amazon.awssdk.utils.async.FlatteningSubscriber - Unexpected exception encountered that violates the reactive streams specification. Attempting to terminate gracefully.
java.lang.IllegalArgumentException: Invalid StartingPosition. When ShardIteratorType is AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER, startingMarker must be a String.
        at org.apache.flink.util.Preconditions.checkArgument(Preconditions.java:138)
        at org.apache.flink.connector.kinesis.source.split.StartingPositionUtil.toSdkStartingPosition(StartingPositionUtil.java:65)
        at org.apache.flink.connector.kinesis.source.proxy.KinesisAsyncStreamProxy.subscribeToShard(KinesisAsyncStreamProxy.java:56)
        at org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription.activateSubscription(FanOutKinesisShardSubscription.java:137)
        at org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription$FanOutShardSubscriber.onComplete(FanOutKinesisShardSubscription.java:334)
        at software.amazon.awssdk.utils.async.DelegatingSubscriber.onComplete(DelegatingSubscriber.java:47)
        at software.amazon.awssdk.utils.async.EventListeningSubscriber.onComplete(EventListeningSubscriber.java:66)
        at software.amazon.awssdk.utils.async.DelegatingSubscriber.onComplete(DelegatingSubscriber.java:47)
        at software.amazon.awssdk.utils.async.EventListeningSubscriber.onComplete(EventListeningSubscriber.java:66)
        at software.amazon.awssdk.utils.async.DelegatingSubscriber.onComplete(DelegatingSubscriber.java:47)
        at software.amazon.awssdk.utils.async.EventListeningSubscriber.onComplete(EventListeningSubscriber.java:66)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.handleOnCompleteState(FlatteningSubscriber.java:229)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.handleStateUpdate(FlatteningSubscriber.java:169)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.onComplete(FlatteningSubscriber.java:129)
        at software.amazon.awssdk.utils.internal.MappingSubscriber.onComplete(MappingSubscriber.java:63)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.handleOnCompleteState(FlatteningSubscriber.java:229)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.handleStateUpdate(FlatteningSubscriber.java:169)
        at software.amazon.awssdk.utils.async.FlatteningSubscriber.onComplete(FlatteningSubscriber.java:129)
        at software.amazon.awssdk.utils.internal.MappingSubscriber.onComplete(MappingSubscriber.java:63)
        at software.amazon.awssdk.core.internal.metrics.BytesReadTrackingPublisher$BytesReadTracker.onComplete(BytesReadTrackingPublisher.java:74)
        at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$DataCountingPublisher$1.onComplete(ResponseHandler.java:519)
        at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.runAndLogError(ResponseHandler.java:254)
        at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.access$600(ResponseHandler.java:77)
        at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onComplete(ResponseHandler.java:375)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.complete(HandlerPublisher.java:447)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.handlerRemoved(HandlerPublisher.java:435)
        at io.netty.channel.AbstractChannelHandlerContext.callHandlerRemoved(AbstractChannelHandlerContext.java:1138)
        at io.netty.channel.DefaultChannelPipeline.callHandlerRemoved0(DefaultChannelPipeline.java:636)
        at io.netty.channel.DefaultChannelPipeline.remove(DefaultChannelPipeline.java:476)
        at io.netty.channel.DefaultChannelPipeline.remove(DefaultChannelPipeline.java:422)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.removeHandlerIfActive(HttpStreamsHandler.java:370)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.handleReadHttpContent(HttpStreamsHandler.java:232)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:203)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:173)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
        at software.amazon.awssdk.http.nio.netty.internal.http2.Http2ToHttpInboundAdapter.onDataRead(Http2ToHttpInboundAdapter.java:87)
        at software.amazon.awssdk.http.nio.netty.internal.http2.Http2ToHttpInboundAdapter.channelRead0(Http2ToHttpInboundAdapter.java:49)
        at software.amazon.awssdk.http.nio.netty.internal.http2.Http2ToHttpInboundAdapter.channelRead0(Http2ToHttpInboundAdapter.java:42)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
        at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
        at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doBeginRead(AbstractHttp2StreamChannel.java:882)
        at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.beginRead(AbstractHttp2StreamChannel.java:845)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.read(DefaultChannelPipeline.java:1359)
        at io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:845)
        at io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
        at software.amazon.awssdk.http.nio.netty.internal.http2.FlushOnReadHandler.read(FlushOnReadHandler.java:40)
        at io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:849)
        at io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.requestDemand(HandlerPublisher.java:130)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler$1.requestDemand(HttpStreamsHandler.java:195)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.receivedDemand(HandlerPublisher.java:304)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.access$200(HandlerPublisher.java:61)
        at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher$ChannelSubscription$1.run(HandlerPublisher.java:495)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Verifying this change
- *Manually verified by running the Kinesis connector on a local Flink cluster.*

After making the change, i 1. re-ran my flink application, 2. resharded my stream. Afterwards verified that subscriptions were being shut down and restarted without issues:

reshard
```
[Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.SourceReaderBase - Finished reading split(s) [shardId-000000003079]
[Source Data Fetcher for Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher - Finished reading from splits [shardId-000000003079]
[Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.SourceReaderBase - Finished reading split(s) [shardId-000000003080]
[Source Data Fetcher for Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher - Finished reading from splits [shardId-000000003080]
[Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager - Closing splitFetcher 0 because it is idle.
[Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher - Shutting down split fetcher 0
[SourceCoordinator-Source: Kinesis source] INFO org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumerator - Assigning shard shardId-000000003081 from stream arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream to subtask 0.
[Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.SourceReaderBase - Adding split(s) to reader: [KinesisShardSplit{streamArn='arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream', shardId='shardId-000000003081', startingPosition=StartingPosition{shardIteratorType=TRIM_HORIZON, startingMarker=null}, parentShardIds=[shardId-000000003079,shardId-000000003080], startingHashKey='0', endingHashKey='340282366920938463463374607431768211455', finished=false}]
[Source Data Fetcher for Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher - Split fetcher 0 exited.
[Source Data Fetcher for Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher - Starting split fetcher 1
[Source Data Fetcher for Source: Kinesis source -> (Sink: Print to Std. Out, Kinesis sink: Writer) (1/1)#0] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Activating subscription to shard shardId-000000003081 with starting position StartingPosition{shardIteratorType=TRIM_HORIZON, startingMarker=null} for consumer arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121.
[aws-java-sdk-NettyEventLoop-2-10] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Successfully subscribed to shard shardId-000000003081 at StartingPosition{shardIteratorType=TRIM_HORIZON, startingMarker=null} using consumer arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121.
[ForkJoinPool.commonPool-worker-4] INFO org.apache.flink.connector.kinesis.source.reader.fanout.FanOutKinesisShardSubscription - Successfully subscribed to shard shardId-000000003081 with starting position StartingPosition{shardIteratorType=TRIM_HORIZON, startingMarker=null} for consumer arn:aws:kinesis:us-east-1:890385144326:stream/test-source-stream/consumer/my-flink-efo-consumer:1774401121.
```


## Significant changes
N/A - Not a significant change
