### PR TITLE
[FLINK-39810][Connectors/kinesis] Support upsert changelog streams in Kinesis SQL connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -29,6 +29,7 @@ under the License.
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Batch" >}}
 {{< label "Sink: Streaming Append Mode" >}}
+{{< label "Sink: Streaming Upsert Mode" >}}
 
 The Kinesis connector allows for reading data from and writing data into [Amazon Kinesis Data Streams (KDS)](https://aws.amazon.com/kinesis/data-streams/).
 
@@ -922,6 +923,41 @@ Reusing a consumer name will result in existing subscriptions being terminated.
 In the event that a job terminates without executing the shutdown hooks, stream consumers will remain active.
 In this situation the stream consumers will be gracefully reused when the application restarts.
 With the `NONE` and `EAGER` strategies, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
+
+### Upsert Mode (Changelog Streams)
+
+The Kinesis connector supports writing **upsert changelog streams** when a `PRIMARY KEY` is defined on the table. This enables writing the results of aggregations (`GROUP BY`), deduplication, and streaming joins directly to Kinesis Data Streams.
+
+When a primary key is present, the connector automatically:
+
+* Accepts `INSERT`, `UPDATE_AFTER`, and `DELETE` changelog events
+* Uses the primary key fields as the Kinesis partition key (ensuring records with the same key are routed to the same shard)
+* Writes an empty payload (tombstone) for `DELETE` and `UPDATE_BEFORE` events
+* Serializes the full row for `INSERT` and `UPDATE_AFTER` events
+
+```sql
+CREATE TABLE aggregated_orders (
+  user_id STRING,
+  order_count BIGINT,
+  total_amount DECIMAL(10, 2),
+  PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+  'connector' = 'kinesis',
+  'stream.arn' = 'arn:aws:kinesis:us-east-1:012345678901:stream/aggregated-orders',
+  'aws.region' = 'us-east-1',
+  'format' = 'json'
+);
+
+-- Write aggregation results to Kinesis
+INSERT INTO aggregated_orders
+SELECT user_id, COUNT(*), SUM(amount)
+FROM orders
+GROUP BY user_id;
+```
+
+{{< hint info >}}
+**Ordering considerations**: The Kinesis sink uses `PutRecords` with async batching. Records with the same partition key are routed to the same shard, where they are ordered by arrival time. With the default setting of multiple in-flight requests, two batches targeting the same shard may arrive out of order due to network jitter. For strict per-key ordering, set `'sink.requests.max-inflight' = '1'`. For most upsert use cases (materialized aggregations, deduplication), eventual consistency per key is sufficient since the downstream consumer materializes the latest value.
+{{< /hint >}}
 
 # Data Type Mapping
 

--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -29,6 +29,7 @@ under the License.
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Batch" >}}
 {{< label "Sink: Streaming Append Mode" >}}
+{{< label "Sink: Streaming Upsert Mode" >}}
 
 The Kinesis connector allows for reading data from and writing data into [Amazon Kinesis Data Streams (KDS)](https://aws.amazon.com/kinesis/data-streams/).
 
@@ -922,6 +923,48 @@ Reusing a consumer name will result in existing subscriptions being terminated.
 In the event that a job terminates without executing the shutdown hooks, stream consumers will remain active.
 In this situation the stream consumers will be gracefully reused when the application restarts.
 With the `NONE` and `EAGER` strategies, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
+
+### Upsert Mode (Changelog Streams)
+
+The Kinesis connector supports writing **upsert changelog streams** when a `PRIMARY KEY` is defined on the table. This enables writing the results of aggregations (`GROUP BY`), deduplication, and streaming joins over append-only inputs directly to Kinesis Data Streams.
+
+When a primary key is present, the connector automatically:
+
+* Accepts `INSERT` and `UPDATE_AFTER` changelog events, serializing the full row for both
+* Uses the primary key fields as the Kinesis partition key (ensuring records with the same key are routed to the same shard)
+* Restricts the writer to a single in-flight request (`sink.requests.max-inflight` = `1`) so that batches cannot overtake each other and per-key ordering is preserved
+
+`DELETE` events are **not supported**: Kinesis records have no key/value separation, so a delete event cannot carry the deleted key in a format-agnostic way. Queries that can produce `DELETE` events (for example CDC sources or Top-N queries) are rejected at planning time with a descriptive error.
+
+The following are incompatible with upsert mode and produce a validation error:
+
+* the `sink.partitioner` option (the partition key is always derived from the primary key)
+* the `sink.requests.max-inflight` option with a value other than `1`
+* a `PARTITIONED BY` clause
+
+```sql
+CREATE TABLE aggregated_orders (
+  user_id STRING,
+  order_count BIGINT,
+  total_amount DECIMAL(10, 2),
+  PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+  'connector' = 'kinesis',
+  'stream.arn' = 'arn:aws:kinesis:us-east-1:012345678901:stream/aggregated-orders',
+  'aws.region' = 'us-east-1',
+  'format' = 'json'
+);
+
+-- Write aggregation results to Kinesis
+INSERT INTO aggregated_orders
+SELECT user_id, COUNT(*), SUM(amount)
+FROM orders
+GROUP BY user_id;
+```
+
+{{< hint info >}}
+**Ordering considerations**: In upsert mode the connector limits each writer to a single in-flight request, so request batches cannot arrive out of order. Note that the Kinesis [PutRecords](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html) API does not guarantee ordering between records within the same request: if multiple updates for the same primary key land in one batch, they may receive out-of-order sequence numbers. Downstream consumers requiring strict per-key ordering should deduplicate on a version attribute carried in the row, or reduce the chance of same-key co-occurrence by tuning `sink.batch.max-size`.
+{{< /hint >}}
 
 # Data Type Mapping
 

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -29,6 +29,7 @@ under the License.
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Batch" >}}
 {{< label "Sink: Streaming Append Mode" >}}
+{{< label "Sink: Streaming Upsert Mode" >}}
 
 The Kinesis connector allows for reading data from and writing data into [Amazon Kinesis Data Streams (KDS)](https://aws.amazon.com/kinesis/data-streams/).
 
@@ -602,6 +603,41 @@ Valid values are:
 Records written into tables defining a `PARTITION BY` clause will always be partitioned based on a concatenated projection of the `PARTITION BY` fields.
 In this case, the `sink.partitioner` field cannot be used to modify this behavior (attempting to do this results in a configuration error).
 You can, however, use the `sink.partitioner-field-delimiter` option to set the delimiter of field values in the concatenated [PartitionKey](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#Streams-PutRecord-request-PartitionKey) string (an empty string is also a valid delimiter).
+{{< /hint >}}
+
+### Upsert Mode (Changelog Streams)
+
+The Kinesis connector supports writing **upsert changelog streams** when a `PRIMARY KEY` is defined on the table. This enables writing the results of aggregations (`GROUP BY`), deduplication, and streaming joins directly to Kinesis Data Streams.
+
+When a primary key is present, the connector automatically:
+
+* Accepts `INSERT`, `UPDATE_AFTER`, and `DELETE` changelog events
+* Uses the primary key fields as the Kinesis partition key (ensuring records with the same key are routed to the same shard)
+* Writes an empty payload (tombstone) for `DELETE` and `UPDATE_BEFORE` events
+* Serializes the full row for `INSERT` and `UPDATE_AFTER` events
+
+```sql
+CREATE TABLE aggregated_orders (
+  user_id STRING,
+  order_count BIGINT,
+  total_amount DECIMAL(10, 2),
+  PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+  'connector' = 'kinesis',
+  'stream.arn' = 'arn:aws:kinesis:us-east-1:012345678901:stream/aggregated-orders',
+  'aws.region' = 'us-east-1',
+  'format' = 'json'
+);
+
+-- Write aggregation results to Kinesis
+INSERT INTO aggregated_orders
+SELECT user_id, COUNT(*), SUM(amount)
+FROM orders
+GROUP BY user_id;
+```
+
+{{< hint info >}}
+**Ordering considerations**: The Kinesis sink uses `PutRecords` with async batching. Records with the same partition key are routed to the same shard, where they are ordered by arrival time. With the default setting of multiple in-flight requests, two batches targeting the same shard may arrive out of order due to network jitter. For strict per-key ordering, set `'sink.requests.max-inflight' = '1'`. For most upsert use cases (materialized aggregations, deduplication), eventual consistency per key is sufficient since the downstream consumer materializes the latest value.
 {{< /hint >}}
 
 # Data Type Mapping

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -29,6 +29,7 @@ under the License.
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Batch" >}}
 {{< label "Sink: Streaming Append Mode" >}}
+{{< label "Sink: Streaming Upsert Mode" >}}
 
 The Kinesis connector allows for reading data from and writing data into [Amazon Kinesis Data Streams (KDS)](https://aws.amazon.com/kinesis/data-streams/).
 
@@ -602,6 +603,48 @@ Valid values are:
 Records written into tables defining a `PARTITION BY` clause will always be partitioned based on a concatenated projection of the `PARTITION BY` fields.
 In this case, the `sink.partitioner` field cannot be used to modify this behavior (attempting to do this results in a configuration error).
 You can, however, use the `sink.partitioner-field-delimiter` option to set the delimiter of field values in the concatenated [PartitionKey](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#Streams-PutRecord-request-PartitionKey) string (an empty string is also a valid delimiter).
+{{< /hint >}}
+
+### Upsert Mode (Changelog Streams)
+
+The Kinesis connector supports writing **upsert changelog streams** when a `PRIMARY KEY` is defined on the table. This enables writing the results of aggregations (`GROUP BY`), deduplication, and streaming joins over append-only inputs directly to Kinesis Data Streams.
+
+When a primary key is present, the connector automatically:
+
+* Accepts `INSERT` and `UPDATE_AFTER` changelog events, serializing the full row for both
+* Uses the primary key fields as the Kinesis partition key (ensuring records with the same key are routed to the same shard)
+* Restricts the writer to a single in-flight request (`sink.requests.max-inflight` = `1`) so that batches cannot overtake each other and per-key ordering is preserved
+
+`DELETE` events are **not supported**: Kinesis records have no key/value separation, so a delete event cannot carry the deleted key in a format-agnostic way. Queries that can produce `DELETE` events (for example CDC sources or Top-N queries) are rejected at planning time with a descriptive error.
+
+The following are incompatible with upsert mode and produce a validation error:
+
+* the `sink.partitioner` option (the partition key is always derived from the primary key)
+* the `sink.requests.max-inflight` option with a value other than `1`
+* a `PARTITIONED BY` clause
+
+```sql
+CREATE TABLE aggregated_orders (
+  user_id STRING,
+  order_count BIGINT,
+  total_amount DECIMAL(10, 2),
+  PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+  'connector' = 'kinesis',
+  'stream.arn' = 'arn:aws:kinesis:us-east-1:012345678901:stream/aggregated-orders',
+  'aws.region' = 'us-east-1',
+  'format' = 'json'
+);
+
+-- Write aggregation results to Kinesis
+INSERT INTO aggregated_orders
+SELECT user_id, COUNT(*), SUM(amount)
+FROM orders
+GROUP BY user_id;
+```
+
+{{< hint info >}}
+**Ordering considerations**: In upsert mode the connector limits each writer to a single in-flight request, so request batches cannot arrive out of order. Note that the Kinesis [PutRecords](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html) API does not guarantee ordering between records within the same request: if multiple updates for the same primary key land in one batch, they may receive out-of-order sequence numbers. Downstream consumers requiring strict per-key ordering should deduplicate on a version attribute carried in the row, or reduce the chance of same-key co-occurrence by tuning `sink.batch.max-size`.
 {{< /hint >}}
 
 # Data Type Mapping

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/pom.xml
@@ -124,6 +124,14 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- SQL-path integration testing (upsert sink) -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSink.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSink.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
@@ -65,6 +66,9 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
 
     private final Boolean failOnError;
 
+    /** Whether this sink supports upsert mode (primary key is defined on the table). */
+    private final boolean upsertMode;
+
     public KinesisDynamicSink(
             @Nullable Integer maxBatchSize,
             @Nullable Integer maxInFlightRequests,
@@ -76,7 +80,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
             String streamArn,
             @Nullable Properties kinesisClientProperties,
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
-            PartitionKeyGenerator<RowData> partitioner) {
+            PartitionKeyGenerator<RowData> partitioner,
+            boolean upsertMode) {
         super(
                 maxBatchSize,
                 maxInFlightRequests,
@@ -94,10 +99,14 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         this.partitioner =
                 Preconditions.checkNotNull(
                         partitioner, "Kinesis partition key generator must not be null");
+        this.upsertMode = upsertMode;
     }
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        if (upsertMode) {
+            return ChangelogMode.upsert();
+        }
         return encodingFormat.getChangelogMode();
     }
 
@@ -106,9 +115,14 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         SerializationSchema<RowData> serializationSchema =
                 encodingFormat.createRuntimeEncoder(context, consumedDataType);
 
+        SerializationSchema<RowData> actualSchema =
+                upsertMode
+                        ? new UpsertSerializationSchemaWrapper(serializationSchema)
+                        : serializationSchema;
+
         KinesisStreamsSinkBuilder<RowData> builder =
                 KinesisStreamsSink.<RowData>builder()
-                        .setSerializationSchema(serializationSchema)
+                        .setSerializationSchema(actualSchema)
                         .setPartitionKeyGenerator(partitioner)
                         .setKinesisClientProperties(kinesisClientProperties)
                         .setStreamArn(streamArn);
@@ -132,7 +146,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 streamArn,
                 kinesisClientProperties,
                 encodingFormat,
-                partitioner);
+                partitioner,
+                upsertMode);
     }
 
     @Override
@@ -179,7 +194,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 && Objects.equals(kinesisClientProperties, that.kinesisClientProperties)
                 && Objects.equals(encodingFormat, that.encodingFormat)
                 && Objects.equals(partitioner, that.partitioner)
-                && Objects.equals(failOnError, that.failOnError);
+                && Objects.equals(failOnError, that.failOnError)
+                && upsertMode == that.upsertMode;
     }
 
     @Override
@@ -191,7 +207,41 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 kinesisClientProperties,
                 encodingFormat,
                 partitioner,
-                failOnError);
+                failOnError,
+                upsertMode);
+    }
+
+    /**
+     * Wraps a serialization schema to handle upsert semantics: writes the value for
+     * INSERT/UPDATE_AFTER and an empty payload for DELETE/UPDATE_BEFORE (tombstone).
+     */
+    @Internal
+    static class UpsertSerializationSchemaWrapper implements SerializationSchema<RowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final SerializationSchema<RowData> inner;
+
+        UpsertSerializationSchemaWrapper(SerializationSchema<RowData> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public void open(InitializationContext context) throws Exception {
+            inner.open(context);
+        }
+
+        @Override
+        public byte[] serialize(RowData element) {
+            RowKind kind = element.getRowKind();
+            if (kind == RowKind.DELETE || kind == RowKind.UPDATE_BEFORE) {
+                return new byte[0];
+            }
+            element.setRowKind(RowKind.INSERT);
+            byte[] bytes = inner.serialize(element);
+            element.setRowKind(kind);
+            return bytes;
+        }
     }
 
     /** Builder class for {@link KinesisDynamicSink}. */
@@ -206,6 +256,7 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         private EncodingFormat<SerializationSchema<RowData>> encodingFormat = null;
         private PartitionKeyGenerator<RowData> partitioner = null;
         private Boolean failOnError = null;
+        private boolean upsertMode = false;
 
         public KinesisDynamicTableSinkBuilder setConsumedDataType(DataType consumedDataType) {
             this.consumedDataType = consumedDataType;
@@ -245,6 +296,11 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
             return this;
         }
 
+        public KinesisDynamicTableSinkBuilder setUpsertMode(boolean upsertMode) {
+            this.upsertMode = upsertMode;
+            return this;
+        }
+
         @Override
         public KinesisDynamicSink build() {
             return new KinesisDynamicSink(
@@ -258,7 +314,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                     streamArn,
                     kinesisClientProperties,
                     encodingFormat,
-                    partitioner);
+                    partitioner,
+                    upsertMode);
         }
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSink.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSink.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
@@ -65,6 +66,9 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
 
     private final Boolean failOnError;
 
+    /** Whether this sink supports upsert mode (primary key is defined on the table). */
+    private final boolean upsertMode;
+
     public KinesisDynamicSink(
             @Nullable Integer maxBatchSize,
             @Nullable Integer maxInFlightRequests,
@@ -76,7 +80,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
             String streamArn,
             @Nullable Properties kinesisClientProperties,
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
-            PartitionKeyGenerator<RowData> partitioner) {
+            PartitionKeyGenerator<RowData> partitioner,
+            boolean upsertMode) {
         super(
                 maxBatchSize,
                 maxInFlightRequests,
@@ -94,10 +99,26 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         this.partitioner =
                 Preconditions.checkNotNull(
                         partitioner, "Kinesis partition key generator must not be null");
+        this.upsertMode = upsertMode;
+        Preconditions.checkArgument(
+                !upsertMode || maxInFlightRequests == null || maxInFlightRequests == 1,
+                "Upsert mode requires maxInFlightRequests = 1 to preserve per-key ordering, but was %s.",
+                maxInFlightRequests);
     }
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        if (upsertMode) {
+            // DELETE is intentionally not supported: Kinesis records have no key/value
+            // separation, so a delete event cannot carry the deleted key in a
+            // format-agnostic way. Queries that can produce DELETE events (e.g. CDC
+            // sources, Top-N queries) are rejected during planning instead of writing
+            // tombstones that downstream consumers cannot interpret.
+            return ChangelogMode.newBuilder()
+                    .addContainedKind(RowKind.INSERT)
+                    .addContainedKind(RowKind.UPDATE_AFTER)
+                    .build();
+        }
         return encodingFormat.getChangelogMode();
     }
 
@@ -106,9 +127,14 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         SerializationSchema<RowData> serializationSchema =
                 encodingFormat.createRuntimeEncoder(context, consumedDataType);
 
+        SerializationSchema<RowData> actualSchema =
+                upsertMode
+                        ? new UpsertSerializationSchemaWrapper(serializationSchema)
+                        : serializationSchema;
+
         KinesisStreamsSinkBuilder<RowData> builder =
                 KinesisStreamsSink.<RowData>builder()
-                        .setSerializationSchema(serializationSchema)
+                        .setSerializationSchema(actualSchema)
                         .setPartitionKeyGenerator(partitioner)
                         .setKinesisClientProperties(kinesisClientProperties)
                         .setStreamArn(streamArn);
@@ -132,7 +158,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 streamArn,
                 kinesisClientProperties,
                 encodingFormat,
-                partitioner);
+                partitioner,
+                upsertMode);
     }
 
     @Override
@@ -179,7 +206,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 && Objects.equals(kinesisClientProperties, that.kinesisClientProperties)
                 && Objects.equals(encodingFormat, that.encodingFormat)
                 && Objects.equals(partitioner, that.partitioner)
-                && Objects.equals(failOnError, that.failOnError);
+                && Objects.equals(failOnError, that.failOnError)
+                && upsertMode == that.upsertMode;
     }
 
     @Override
@@ -191,7 +219,59 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                 kinesisClientProperties,
                 encodingFormat,
                 partitioner,
-                failOnError);
+                failOnError,
+                upsertMode);
+    }
+
+    /**
+     * Wraps a serialization schema for upsert mode: rewrites the {@link RowKind} of {@code
+     * UPDATE_AFTER} rows to {@code INSERT} before delegating to the wrapped schema, so that
+     * insert-only formats (e.g. json, csv) can encode the row. {@code DELETE} and {@code
+     * UPDATE_BEFORE} rows are rejected defensively; the planner already excludes them because
+     * {@link KinesisDynamicSink#getChangelogMode(ChangelogMode)} does not advertise them in upsert
+     * mode.
+     */
+    @Internal
+    static class UpsertSerializationSchemaWrapper implements SerializationSchema<RowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final SerializationSchema<RowData> inner;
+
+        UpsertSerializationSchemaWrapper(SerializationSchema<RowData> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public void open(InitializationContext context) throws Exception {
+            inner.open(context);
+        }
+
+        @Override
+        public byte[] serialize(RowData element) {
+            RowKind kind = element.getRowKind();
+            if (kind == RowKind.DELETE || kind == RowKind.UPDATE_BEFORE) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "The Kinesis sink in upsert mode does not support %s records. "
+                                        + "Queries producing DELETE or UPDATE_BEFORE events should "
+                                        + "have been rejected during planning; receiving one here "
+                                        + "indicates a planner/connector inconsistency.",
+                                kind));
+            }
+            if (kind == RowKind.INSERT) {
+                return inner.serialize(element);
+            }
+            // Normalize UPDATE_AFTER to INSERT for insert-only formats. Restore the
+            // original RowKind even if serialization fails, since RowData instances may
+            // be reused.
+            element.setRowKind(RowKind.INSERT);
+            try {
+                return inner.serialize(element);
+            } finally {
+                element.setRowKind(kind);
+            }
+        }
     }
 
     /** Builder class for {@link KinesisDynamicSink}. */
@@ -206,6 +286,7 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
         private EncodingFormat<SerializationSchema<RowData>> encodingFormat = null;
         private PartitionKeyGenerator<RowData> partitioner = null;
         private Boolean failOnError = null;
+        private boolean upsertMode = false;
 
         public KinesisDynamicTableSinkBuilder setConsumedDataType(DataType consumedDataType) {
             this.consumedDataType = consumedDataType;
@@ -245,6 +326,11 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
             return this;
         }
 
+        public KinesisDynamicTableSinkBuilder setUpsertMode(boolean upsertMode) {
+            this.upsertMode = upsertMode;
+            return this;
+        }
+
         @Override
         public KinesisDynamicSink build() {
             return new KinesisDynamicSink(
@@ -258,7 +344,8 @@ public class KinesisDynamicSink extends AsyncDynamicTableSink<PutRecordsRequestE
                     streamArn,
                     kinesisClientProperties,
                     encodingFormat,
-                    partitioner);
+                    partitioner,
+                    upsertMode);
         }
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableFactory.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableFactory.java
@@ -38,7 +38,9 @@ import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -92,6 +94,19 @@ public class KinesisDynamicTableFactory extends AsyncDynamicTableSinkFactory
         addAsyncOptionsToBuilder(properties, builder);
         Optional.ofNullable((Boolean) properties.get(SINK_FAIL_ON_ERROR.key()))
                 .ifPresent(builder::setFailOnError);
+
+        int[] primaryKeyIndexes = context.getPrimaryKeyIndexes();
+        if (primaryKeyIndexes != null && primaryKeyIndexes.length > 0) {
+            builder.setUpsertMode(true);
+            RowType rowType = (RowType) factoryContext.getPhysicalDataType().getLogicalType();
+            List<String> primaryKeyFields = new ArrayList<>();
+            for (int idx : primaryKeyIndexes) {
+                primaryKeyFields.add(rowType.getFieldNames().get(idx));
+            }
+            builder.setPartitioner(
+                    new RowDataFieldsKinesisPartitionKeyGenerator(rowType, primaryKeyFields));
+        }
+
         return builder.build();
     }
 

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableFactory.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableFactory.java
@@ -38,11 +38,15 @@ import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.flink.connector.base.table.AsyncSinkConnectorOptions.MAX_IN_FLIGHT_REQUESTS;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.AWS_REGION;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.SINK_FAIL_ON_ERROR;
 import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.SINK_PARTITIONER;
@@ -92,7 +96,52 @@ public class KinesisDynamicTableFactory extends AsyncDynamicTableSinkFactory
         addAsyncOptionsToBuilder(properties, builder);
         Optional.ofNullable((Boolean) properties.get(SINK_FAIL_ON_ERROR.key()))
                 .ifPresent(builder::setFailOnError);
+
+        int[] primaryKeyIndexes = context.getPrimaryKeyIndexes();
+        if (primaryKeyIndexes.length > 0) {
+            validateUpsertMode(
+                    context.getCatalogTable().getOptions(), factoryContext.isPartitioned());
+            builder.setUpsertMode(true);
+            // Upsert semantics require per-key ordering: batches must not overtake each
+            // other, so allow at most one in-flight request per writer.
+            builder.setMaxInFlightRequests(1);
+            RowType rowType = (RowType) factoryContext.getPhysicalDataType().getLogicalType();
+            List<String> primaryKeyFields = new ArrayList<>();
+            for (int idx : primaryKeyIndexes) {
+                primaryKeyFields.add(rowType.getFieldNames().get(idx));
+            }
+            builder.setPartitioner(
+                    new RowDataFieldsKinesisPartitionKeyGenerator(rowType, primaryKeyFields));
+        }
+
         return builder.build();
+    }
+
+    private static void validateUpsertMode(Map<String, String> tableOptions, boolean partitioned) {
+        if (partitioned) {
+            throw new ValidationException(
+                    "Cannot define a PARTITIONED BY clause for a table defined with a PRIMARY KEY. "
+                            + "In upsert mode the partition key is derived from the primary key fields.");
+        }
+        if (tableOptions.containsKey(SINK_PARTITIONER.key())) {
+            throw new ValidationException(
+                    String.format(
+                            "Cannot set %s option for a table defined with a PRIMARY KEY. "
+                                    + "In upsert mode the partition key is derived from the primary "
+                                    + "key fields so that changelog records for the same key are "
+                                    + "routed to the same shard.",
+                            SINK_PARTITIONER.key()));
+        }
+        String maxInFlightRequests = tableOptions.get(MAX_IN_FLIGHT_REQUESTS.key());
+        if (maxInFlightRequests != null && !"1".equals(maxInFlightRequests.trim())) {
+            throw new ValidationException(
+                    String.format(
+                            "Invalid option %s = '%s' for a table defined with a PRIMARY KEY. "
+                                    + "Upsert semantics require per-key ordering, which the Kinesis "
+                                    + "sink only provides with a single in-flight request per "
+                                    + "writer. Remove the option or set it to 1.",
+                            MAX_IN_FLIGHT_REQUESTS.key(), maxInFlightRequests));
+        }
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSinkFactoryTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSinkFactoryTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
@@ -33,11 +35,13 @@ import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -281,11 +285,123 @@ class KinesisDynamicTableSinkFactoryTest {
                 .withMessageContaining("Could not find and instantiate partitioner class 'abc'");
     }
 
+    @Test
+    void testGoodTableSinkForUpsertTableWithPrimaryKey() {
+        ResolvedSchema sinkSchema = defaultSinkSchemaWithPrimaryKey();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions = defaultTableOptions().build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        KinesisDynamicSink actualSink =
+                (KinesisDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        // Construct expected DynamicTableSink using factory under test
+        KinesisDynamicSink expectedSink =
+                new KinesisDynamicSink.KinesisDynamicTableSinkBuilder()
+                        .setMaxInFlightRequests(1)
+                        .setConsumedDataType(physicalDataType)
+                        .setStreamArn(TestUtil.STREAM_ARN)
+                        .setKinesisClientProperties(defaultProducerProperties())
+                        .setEncodingFormat(new TestFormatFactory.EncodingFormatMock(","))
+                        .setPartitioner(
+                                new RowDataFieldsKinesisPartitionKeyGenerator(
+                                        (RowType) physicalDataType.getLogicalType(),
+                                        Collections.singletonList("name")))
+                        .setUpsertMode(true)
+                        .build();
+        Assertions.assertThat(actualSink).isEqualTo(expectedSink);
+
+        // upsert mode accepts INSERT and UPDATE_AFTER only; DELETE-producing queries
+        // must be rejected during planning
+        ChangelogMode changelogMode = actualSink.getChangelogMode(ChangelogMode.all());
+        Assertions.assertThat(changelogMode.contains(RowKind.INSERT)).isTrue();
+        Assertions.assertThat(changelogMode.contains(RowKind.UPDATE_AFTER)).isTrue();
+        Assertions.assertThat(changelogMode.contains(RowKind.DELETE)).isFalse();
+        Assertions.assertThat(changelogMode.contains(RowKind.UPDATE_BEFORE)).isFalse();
+
+        // verify the produced sink
+        DynamicTableSink.SinkRuntimeProvider sinkFunctionProvider =
+                actualSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+        Sink<RowData> sinkFunction = ((SinkV2Provider) sinkFunctionProvider).createSink();
+        Assertions.assertThat(sinkFunction).isInstanceOf(KinesisStreamsSink.class);
+    }
+
+    @Test
+    void testGoodTableSinkForUpsertTableWithExplicitSingleInFlightRequest() {
+        ResolvedSchema sinkSchema = defaultSinkSchemaWithPrimaryKey();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption(MAX_IN_FLIGHT_REQUESTS.key(), "1").build();
+
+        // explicitly setting max in-flight requests to 1 is consistent with upsert mode
+        KinesisDynamicSink actualSink =
+                (KinesisDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        Assertions.assertThat(
+                        actualSink.getChangelogMode(ChangelogMode.all()).contains(RowKind.DELETE))
+                .isFalse();
+    }
+
+    @Test
+    void testBadTableSinkForExplicitPartitionerWithPrimaryKey() {
+        ResolvedSchema sinkSchema = defaultSinkSchemaWithPrimaryKey();
+        Map<String, String> sinkOptions =
+                defaultTableOptions()
+                        .withTableOption(KinesisConnectorOptions.SINK_PARTITIONER, "random")
+                        .build();
+
+        Assertions.assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> createTableSink(sinkSchema, sinkOptions))
+                .havingCause()
+                .withMessageContaining(
+                        String.format(
+                                "Cannot set %s option for a table defined with a PRIMARY KEY",
+                                KinesisConnectorOptions.SINK_PARTITIONER.key()));
+    }
+
+    @Test
+    void testBadTableSinkForMaxInFlightRequestsWithPrimaryKey() {
+        ResolvedSchema sinkSchema = defaultSinkSchemaWithPrimaryKey();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption(MAX_IN_FLIGHT_REQUESTS.key(), "5").build();
+
+        Assertions.assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> createTableSink(sinkSchema, sinkOptions))
+                .havingCause()
+                .withMessageContaining("Upsert semantics require per-key ordering");
+    }
+
+    @Test
+    void testBadTableSinkForPartitionedTableWithPrimaryKey() {
+        ResolvedSchema sinkSchema = defaultSinkSchemaWithPrimaryKey();
+        Map<String, String> sinkOptions = defaultTableOptions().build();
+
+        Assertions.assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(
+                        () ->
+                                createTableSink(
+                                        sinkSchema,
+                                        Collections.singletonList("curr_id"),
+                                        sinkOptions))
+                .havingCause()
+                .withMessageContaining(
+                        "Cannot define a PARTITIONED BY clause for a table defined with a PRIMARY KEY");
+    }
+
     private ResolvedSchema defaultSinkSchema() {
         return ResolvedSchema.of(
                 Column.physical("name", DataTypes.STRING()),
                 Column.physical("curr_id", DataTypes.BIGINT()),
                 Column.physical("time", DataTypes.TIMESTAMP(3)));
+    }
+
+    private ResolvedSchema defaultSinkSchemaWithPrimaryKey() {
+        return new ResolvedSchema(
+                Arrays.asList(
+                        Column.physical("name", DataTypes.STRING().notNull()),
+                        Column.physical("curr_id", DataTypes.BIGINT()),
+                        Column.physical("time", DataTypes.TIMESTAMP(3))),
+                Collections.emptyList(),
+                UniqueConstraint.primaryKey("PK_name", Collections.singletonList("name")));
     }
 
     private TableOptionsBuilder defaultTableOptionsWithSinkOptions() {

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertSinkSerializationTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertSinkSerializationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.table;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the upsert serialization behavior in {@link KinesisDynamicSink}. */
+class KinesisUpsertSinkSerializationTest {
+
+    @Test
+    void testUpsertSchemaWritesValueForInsert() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.INSERT);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotNull();
+        assertThat(result.length).isGreaterThan(0);
+    }
+
+    @Test
+    void testUpsertSchemaWritesValueForUpdateAfter() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 99L);
+        row.setRowKind(RowKind.UPDATE_AFTER);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotNull();
+        assertThat(result.length).isGreaterThan(0);
+    }
+
+    @Test
+    void testUpsertSchemaWritesTombstoneForDelete() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.DELETE);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testUpsertSchemaWritesTombstoneForUpdateBefore() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.UPDATE_BEFORE);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testUpsertSchemaPreservesOriginalRowKind() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.UPDATE_AFTER);
+
+        wrapper.serialize(row);
+        assertThat(row.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
+    }
+
+    @Test
+    void testKinesisSinkChangelogModeWithPrimaryKey() {
+        org.apache.flink.table.connector.ChangelogMode mode =
+                org.apache.flink.table.connector.ChangelogMode.upsert();
+
+        assertThat(mode.contains(RowKind.INSERT)).isTrue();
+        assertThat(mode.contains(RowKind.UPDATE_AFTER)).isTrue();
+        assertThat(mode.contains(RowKind.DELETE)).isTrue();
+    }
+
+    private static class TestSerializationSchema implements SerializationSchema<RowData> {
+        @Override
+        public byte[] serialize(RowData element) {
+            return "serialized".getBytes(StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertSinkSerializationTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertSinkSerializationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.table;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the upsert serialization behavior in {@link KinesisDynamicSink}. */
+class KinesisUpsertSinkSerializationTest {
+
+    @Test
+    void testUpsertSchemaWritesValueForInsert() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.INSERT);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotEmpty();
+        assertThat(inner.observedKinds).containsExactly(RowKind.INSERT);
+    }
+
+    @Test
+    void testUpsertSchemaNormalizesUpdateAfterToInsert() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 99L);
+        row.setRowKind(RowKind.UPDATE_AFTER);
+
+        byte[] result = wrapper.serialize(row);
+        assertThat(result).isNotEmpty();
+        // the wrapped (insert-only) format must see an INSERT row
+        assertThat(inner.observedKinds).containsExactly(RowKind.INSERT);
+        // the caller-visible RowKind must be restored after serialization
+        assertThat(row.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
+    }
+
+    @Test
+    void testUpsertSchemaRejectsDelete() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.DELETE);
+
+        assertThatThrownBy(() -> wrapper.serialize(row))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("DELETE");
+        assertThat(inner.observedKinds).isEmpty();
+    }
+
+    @Test
+    void testUpsertSchemaRejectsUpdateBefore() {
+        TestSerializationSchema inner = new TestSerializationSchema();
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(inner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.UPDATE_BEFORE);
+
+        assertThatThrownBy(() -> wrapper.serialize(row))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("UPDATE_BEFORE");
+        assertThat(inner.observedKinds).isEmpty();
+    }
+
+    @Test
+    void testUpsertSchemaRestoresRowKindWhenSerializationFails() {
+        SerializationSchema<RowData> throwingInner =
+                element -> {
+                    throw new RuntimeException("serialization failure");
+                };
+        KinesisDynamicSink.UpsertSerializationSchemaWrapper wrapper =
+                new KinesisDynamicSink.UpsertSerializationSchemaWrapper(throwingInner);
+
+        GenericRowData row = GenericRowData.of(StringData.fromString("key1"), 42L);
+        row.setRowKind(RowKind.UPDATE_AFTER);
+
+        assertThatThrownBy(() -> wrapper.serialize(row))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("serialization failure");
+        // RowData instances may be reused: the RowKind must be restored even on failure
+        assertThat(row.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
+    }
+
+    private static class TestSerializationSchema implements SerializationSchema<RowData> {
+
+        private final List<RowKind> observedKinds = new ArrayList<>();
+
+        @Override
+        public byte[] serialize(RowData element) {
+            observedKinds.add(element.getRowKind());
+            return "serialized".getBytes(StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertTableSinkITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisUpsertTableSinkITCase.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.table;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
+import org.apache.flink.connector.aws.testutils.LocalstackContainer;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+import software.amazon.awssdk.services.kinesis.model.StreamStatus;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SQL-path integration test for the Kinesis sink in upsert mode ({@code PRIMARY KEY} defined on the
+ * table). Verifies end-to-end against a Localstack Kinesis stream that:
+ *
+ * <ul>
+ *   <li>an upsert changelog produced by a {@code GROUP BY} query is accepted and written, with the
+ *       latest value per key readable from the stream,
+ *   <li>the Kinesis partition key of every written record is derived from the primary key fields,
+ *   <li>a delete-producing query (Top-N) is rejected at planning time, since the sink does not
+ *       advertise {@code DELETE} in its changelog mode.
+ * </ul>
+ */
+@Testcontainers
+@ExtendWith(MiniClusterExtension.class)
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+class KinesisUpsertTableSinkITCase {
+
+    private static final String LOCALSTACK_DOCKER_IMAGE_VERSION = "localstack/localstack:3.7.2";
+    private static final String STREAM_NAME = "upsert_orders";
+    private static final String STREAM_ARN =
+            "arn:aws:kinesis:ap-southeast-1:000000000000:stream/" + STREAM_NAME;
+    private static final String DEFAULT_FIRST_SHARD_NAME = "shardId-000000000000";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Container
+    private static final LocalstackContainer LOCALSTACK =
+            new LocalstackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE_VERSION))
+                    .withNetwork(Network.newNetwork())
+                    .withNetworkAliases("localstack");
+
+    private SdkHttpClient httpClient;
+    private KinesisClient kinesisClient;
+    private StreamTableEnvironment tEnv;
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+        httpClient = AWSServicesTestUtils.createHttpClient();
+        kinesisClient =
+                AWSServicesTestUtils.createAwsSyncClient(
+                        LOCALSTACK.getEndpoint(), httpClient, KinesisClient.builder());
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        tEnv = StreamTableEnvironment.create(env, EnvironmentSettings.newInstance().build());
+        tEnv.executeSql(createUpsertSinkTableStmt());
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        AWSGeneralUtil.closeResources(httpClient, kinesisClient);
+    }
+
+    @Test
+    void testUpsertSinkWritesLatestValuePerKeyWithPrimaryKeyPartitioning() throws Exception {
+        prepareStream(STREAM_NAME);
+
+        // GROUP BY over an insert-only VALUES source produces an upsert changelog:
+        // INSERT for the first row of a key, UPDATE_AFTER for subsequent rows.
+        tEnv.executeSql(
+                        "INSERT INTO upsert_orders "
+                                + "SELECT user_id, COUNT(*), SUM(amount) "
+                                + "FROM (VALUES ('alice', 5), ('alice', 7), ('bob', 3)) "
+                                + "    AS orders (user_id, amount) "
+                                + "GROUP BY user_id")
+                .await();
+
+        List<Record> records = readAllRecordsFromStream(3);
+
+        // every changelog event is written as a full row: alice I+UA, bob I
+        assertThat(records).hasSize(3);
+
+        // the Kinesis partition key must be derived from the primary key fields
+        for (Record record : records) {
+            JsonNode row = OBJECT_MAPPER.readTree(record.data().asByteArray());
+            assertThat(record.partitionKey()).isEqualTo(row.get("user_id").asText());
+        }
+
+        // a consumer materializing the stream (last record per key wins) must
+        // converge to the final aggregate values
+        Map<String, JsonNode> materialized = new HashMap<>();
+        for (Record record : records) {
+            JsonNode row = OBJECT_MAPPER.readTree(record.data().asByteArray());
+            materialized.put(row.get("user_id").asText(), row);
+        }
+        assertThat(materialized).containsOnlyKeys("alice", "bob");
+        assertThat(materialized.get("alice").get("order_count").asLong()).isEqualTo(2L);
+        assertThat(materialized.get("alice").get("total_amount").asLong()).isEqualTo(12L);
+        assertThat(materialized.get("bob").get("order_count").asLong()).isEqualTo(1L);
+        assertThat(materialized.get("bob").get("total_amount").asLong()).isEqualTo(3L);
+    }
+
+    @Test
+    void testUpsertSinkRejectsDeleteProducingQueryDuringPlanning() {
+        // A Top-N query produces DELETE events when rows are displaced from the top-N.
+        // The sink does not advertise DELETE in upsert mode, so planning must fail --
+        // no job is submitted and no connection to Kinesis is made.
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                        "INSERT INTO upsert_orders "
+                                                + "SELECT user_id, order_count, total_amount FROM ("
+                                                + "  SELECT user_id, amount AS order_count, "
+                                                + "         amount AS total_amount, "
+                                                + "         ROW_NUMBER() OVER ("
+                                                + "             ORDER BY amount DESC) AS row_num "
+                                                + "  FROM (VALUES ('alice', CAST(5 AS BIGINT)), "
+                                                + "               ('bob', CAST(3 AS BIGINT))) "
+                                                + "      AS orders (user_id, amount)"
+                                                + ") WHERE row_num <= 1"))
+                .hasMessageContaining("doesn't support consuming delete changes");
+    }
+
+    private String createUpsertSinkTableStmt() {
+        return "CREATE TABLE upsert_orders ("
+                + "  user_id STRING,"
+                + "  order_count BIGINT,"
+                + "  total_amount BIGINT,"
+                + "  PRIMARY KEY (user_id) NOT ENFORCED"
+                + ") WITH ("
+                + "  'connector' = 'kinesis',"
+                + ("  'stream.arn' = '" + STREAM_ARN + "',")
+                + "  'aws.region' = 'us-east-1',"
+                + ("  'aws.endpoint' = '" + LOCALSTACK.getEndpoint() + "',")
+                + "  'aws.credentials.provider' = 'BASIC',"
+                + "  'aws.credentials.basic.accesskeyid' = 'access-key',"
+                + "  'aws.credentials.basic.secretkey' = 'secret-key',"
+                + "  'aws.trust.all.certificates' = 'true',"
+                + "  'aws.http.protocol.version' = 'HTTP1_1',"
+                + "  'format' = 'json'"
+                + ")";
+    }
+
+    private void prepareStream(String streamName) throws Exception {
+        kinesisClient.createStream(
+                CreateStreamRequest.builder().streamName(streamName).shardCount(1).build());
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        while (!streamExists(streamName)) {
+            if (deadline.isOverdue()) {
+                throw new RuntimeException("Failed to create stream within time");
+            }
+            Thread.sleep(500);
+        }
+    }
+
+    private boolean streamExists(final String streamName) {
+        try {
+            return kinesisClient
+                            .describeStream(
+                                    DescribeStreamRequest.builder().streamName(streamName).build())
+                            .streamDescription()
+                            .streamStatus()
+                    == StreamStatus.ACTIVE;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private List<Record> readAllRecordsFromStream(int expectedMinimumCount)
+            throws IOException, InterruptedException {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+        List<Record> records;
+        do {
+            Thread.sleep(1000);
+            String shardIterator =
+                    kinesisClient
+                            .getShardIterator(
+                                    GetShardIteratorRequest.builder()
+                                            .shardId(DEFAULT_FIRST_SHARD_NAME)
+                                            .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+                                            .streamName(STREAM_NAME)
+                                            .build())
+                            .shardIterator();
+            records =
+                    kinesisClient
+                            .getRecords(
+                                    GetRecordsRequest.builder()
+                                            .shardIterator(shardIterator)
+                                            .build())
+                            .records();
+        } while (deadline.hasTimeLeft() && records.size() < expectedMinimumCount);
+        return records;
+    }
+}


### PR DESCRIPTION
## Purpose of the change

Adds upsert changelog stream support to the Kinesis SQL connector. When a `PRIMARY KEY` is defined on the table, the sink accepts the results of aggregations (`GROUP BY`), deduplication, and streaming joins over append-only inputs, writing the latest row per key to Kinesis Data Streams.

## Design decisions

- **A mode on the existing `kinesis` connector, not a separate `upsert-kinesis` connector.** `upsert-kafka` is a separate connector because compacted topics give it distinct semantics on *both* sides: the source reads a compacted topic as a changelog (null value = DELETE tombstone), and the sink writes tombstones that log compaction actually applies. Kinesis has neither compaction nor key-based retention, so there is no materialized latest-per-key view for an upsert *source* to read — the capability is inherently sink-only. A separate connector identifier would duplicate every source/sink option for the sake of one sink behavior; instead, the presence of a `PRIMARY KEY` activates upsert mode on the existing factory (the same signal `upsert-kafka` requires), and everything incompatible with it fails validation explicitly.
- **Changelog mode is `{INSERT, UPDATE_AFTER}` — DELETE is intentionally not supported.** Kinesis records have no key/value separation, so a delete event cannot carry the deleted key in a format-agnostic way (an empty-payload tombstone is unusable by consumers and breaks JSON deserialization). Delete-producing queries (CDC sources, Top-N) are rejected at planning time with a descriptive planner error instead. A `sink.delete-strategy` option can be added later if a sound tombstone contract is found.
- **Per-key ordering is enforced, not documented away.** Upsert consumers materialize the last record per key, so out-of-order updates cause permanently stale state. In upsert mode the connector forces `sink.requests.max-inflight = 1` so request batches cannot overtake each other; an explicit conflicting value fails validation. Residual limitation (documented): the Kinesis `PutRecords` API does not guarantee ordering *within* one request, so two updates for the same key in a single batch may be sequenced out of order. A key-deduplicating flush buffer (analogous to upsert-kafka's `sink.buffer-flush.*`) is a natural follow-up that would close this and restore throughput.
- **No silent behavior changes.** The primary key drives the partition key; a conflicting explicit `sink.partitioner`, a `PARTITIONED BY` clause, or `sink.requests.max-inflight != 1` all fail with a `ValidationException` rather than being silently overridden.

## Changes

- **KinesisDynamicSink**: `upsertMode` flag; restricted `ChangelogMode`; `UpsertSerializationSchemaWrapper` normalizes `UPDATE_AFTER` to `INSERT` for insert-only formats (RowKind restored via try/finally; DELETE/UPDATE_BEFORE rejected defensively); constructor precondition on `maxInFlightRequests`.
- **KinesisDynamicTableFactory**: detects the primary key, enables upsert mode, derives the partition key from PK fields, forces max in-flight to 1, and validates incompatible options.
- **Tests**: wrapper unit tests (normalization, RowKind restore incl. on serializer failure, DELETE/UPDATE_BEFORE rejection) and factory tests (PK wiring incl. expected-sink equality and changelog-mode restriction, plus all three validation failures).
- **Docs** (EN + ZH): upsert section rewritten to match — supported events, delete rejection rationale, ordering guarantees and the intra-batch caveat.

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests for `UpsertSerializationSchemaWrapper` (INSERT pass-through, UPDATE_AFTER normalization + RowKind restore, restore-on-exception, DELETE/UPDATE_BEFORE rejection)
- Added factory tests: PK table produces the expected sink (PK partition key, upsert mode, max-inflight 1), changelog mode excludes DELETE/UPDATE_BEFORE, and `sink.partitioner` / `sink.requests.max-inflight != 1` / `PARTITIONED BY` each fail validation
- Added a SQL-path integration test (`KinesisUpsertTableSinkITCase`, Localstack Kinesis): a `GROUP BY` upsert changelog is written end-to-end with primary-key-derived partition keys and the latest value per key is materializable from the stream; a delete-producing Top-N query fails at planning time with `doesn't support consuming delete changes` (also empirically confirming that `GROUP BY` over insert-only input is not inferred to produce DELETE)
- Full `flink-connector-aws-kinesis-streams` module suite passes, spotless, checkstyle and dependency-convergence clean

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [x] Serializers have been changed
- [x] New feature has been introduced
  - If yes, how is this documented? (docs)


