### PR TITLE
[FLINK-39813][Connectors/Kinesis] Add lineage support to Kinesis Streams connector

### DIFF
--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisDatasetFacet.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisDatasetFacet.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+import java.util.Objects;
+
+/**
+ * Dataset facet containing Kinesis-specific metadata for lineage reporting.
+ *
+ * <p>Includes the stream ARN, region, and stream name for full identification.
+ */
+@PublicEvolving
+public class KinesisDatasetFacet implements LineageDatasetFacet {
+
+    public static final String KINESIS_FACET_NAME = "kinesis";
+
+    private final String streamArn;
+    private final String streamName;
+    private final String region;
+
+    public KinesisDatasetFacet(String streamArn, String streamName, String region) {
+        this.streamArn = streamArn;
+        this.streamName = streamName;
+        this.region = region;
+    }
+
+    public String getStreamArn() {
+        return streamArn;
+    }
+
+    public String getStreamName() {
+        return streamName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    @Override
+    public String name() {
+        return KINESIS_FACET_NAME;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KinesisDatasetFacet that = (KinesisDatasetFacet) o;
+        return Objects.equals(streamArn, that.streamArn)
+                && Objects.equals(streamName, that.streamName)
+                && Objects.equals(region, that.region);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(streamArn, streamName, region);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisDatasetFacet.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisDatasetFacet.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Dataset facet containing Kinesis-specific metadata for lineage reporting.
+ *
+ * <p>Includes the stream ARN, region, and stream name for full identification. The ARN and region
+ * may be {@code null} when the sink was configured with only a stream name.
+ */
+@PublicEvolving
+public class KinesisDatasetFacet implements LineageDatasetFacet {
+
+    public static final String KINESIS_FACET_NAME = "kinesis";
+
+    @Nullable private final String streamArn;
+    private final String streamName;
+    @Nullable private final String region;
+
+    public KinesisDatasetFacet(
+            @Nullable String streamArn, String streamName, @Nullable String region) {
+        this.streamArn = streamArn;
+        this.streamName = streamName;
+        this.region = region;
+    }
+
+    @Nullable
+    public String getStreamArn() {
+        return streamArn;
+    }
+
+    public String getStreamName() {
+        return streamName;
+    }
+
+    @Nullable
+    public String getRegion() {
+        return region;
+    }
+
+    @Override
+    public String name() {
+        return KINESIS_FACET_NAME;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KinesisDatasetFacet that = (KinesisDatasetFacet) o;
+        return Objects.equals(streamArn, that.streamArn)
+                && Objects.equals(streamName, that.streamName)
+                && Objects.equals(region, that.region);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(streamArn, streamName, region);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageUtil.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageUtil.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
+import org.apache.flink.streaming.api.lineage.DefaultLineageVertex;
+import org.apache.flink.streaming.api.lineage.DefaultSourceLineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import software.amazon.awssdk.arns.Arn;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utility class for constructing lineage datasets and vertices for Kinesis Streams. */
+@Internal
+public class KinesisLineageUtil {
+
+    /** Constructs the namespace for a Kinesis stream from its ARN. */
+    public static String namespaceOf(String streamArn) {
+        // Use the ARN prefix up to the resource as namespace
+        // e.g., arn:aws:kinesis:us-west-2:123456789012:stream
+        Arn arn = Arn.fromString(streamArn);
+        return String.format(
+                "arn:%s:kinesis:%s:%s:stream",
+                arn.partition(), arn.region().orElse(""), arn.accountId().orElse(""));
+    }
+
+    /** Extracts the stream name from a Kinesis stream ARN. */
+    public static String streamNameOf(String streamArn) {
+        Arn arn = Arn.fromString(streamArn);
+        return arn.resource().resource();
+    }
+
+    public static LineageDataset datasetOf(String streamArn) {
+        return new DefaultLineageDataset(
+                streamNameOf(streamArn), namespaceOf(streamArn), Collections.emptyMap());
+    }
+
+    public static LineageDataset datasetOf(
+            String streamArn, Map<String, LineageDatasetFacet> facets) {
+        return new DefaultLineageDataset(streamNameOf(streamArn), namespaceOf(streamArn), facets);
+    }
+
+    public static LineageDataset datasetOf(
+            String streamArn, KinesisDatasetFacet kinesisDatasetFacet) {
+        Map<String, LineageDatasetFacet> facets = new HashMap<>();
+        facets.put(KinesisDatasetFacet.KINESIS_FACET_NAME, kinesisDatasetFacet);
+        return new DefaultLineageDataset(streamNameOf(streamArn), namespaceOf(streamArn), facets);
+    }
+
+    public static LineageDataset datasetOf(
+            String streamArn,
+            KinesisDatasetFacet kinesisDatasetFacet,
+            TypeDatasetFacet typeDatasetFacet) {
+        Map<String, LineageDatasetFacet> facets = new HashMap<>();
+        facets.put(KinesisDatasetFacet.KINESIS_FACET_NAME, kinesisDatasetFacet);
+        facets.put(TypeDatasetFacet.TYPE_FACET_NAME, typeDatasetFacet);
+        return new DefaultLineageDataset(streamNameOf(streamArn), namespaceOf(streamArn), facets);
+    }
+
+    public static SourceLineageVertex sourceLineageVertexOf(Collection<LineageDataset> datasets) {
+        DefaultSourceLineageVertex vertex =
+                new DefaultSourceLineageVertex(
+                        org.apache.flink.api.connector.source.Boundedness.CONTINUOUS_UNBOUNDED);
+        datasets.forEach(vertex::addDataset);
+        return vertex;
+    }
+
+    public static LineageVertex sinkLineageVertexOf(Collection<LineageDataset> datasets) {
+        DefaultLineageVertex vertex = new DefaultLineageVertex();
+        datasets.forEach(vertex::addLineageDataset);
+        return vertex;
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageUtil.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageUtil.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.aws.config.AWSConfigConstants;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
+import org.apache.flink.streaming.api.lineage.DefaultLineageVertex;
+import org.apache.flink.streaming.api.lineage.DefaultSourceLineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import software.amazon.awssdk.arns.Arn;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Utility class for constructing lineage datasets and vertices for Kinesis Streams.
+ *
+ * <p>Dataset identity follows the OpenLineage naming convention for ARN-identified AWS resources
+ * (matching the AWS Glue precedent): the namespace is {@code
+ * arn:{partition}:kinesis:{region}:{account}} and the dataset name carries the resource type,
+ * {@code stream/{streamName}}.
+ */
+@Internal
+public class KinesisLineageUtil {
+
+    private static final String DATASET_NAME_PREFIX = "stream/";
+    private static final String FALLBACK_NAMESPACE = "arn:aws:kinesis";
+
+    private KinesisLineageUtil() {}
+
+    /**
+     * Constructs the dataset namespace for a Kinesis stream from its ARN, e.g. {@code
+     * arn:aws:kinesis:us-east-1:123456789012}.
+     */
+    public static String namespaceOf(String streamArn) {
+        Arn arn = Arn.fromString(streamArn);
+        return String.format(
+                "arn:%s:kinesis:%s:%s",
+                arn.partition(), arn.region().orElse(""), arn.accountId().orElse(""));
+    }
+
+    /**
+     * Constructs a best-effort dataset namespace when only the stream name is known, using the
+     * region from the client properties when available (e.g. {@code arn:aws:kinesis:eu-west-1})
+     * so that datasets stay under the same scheme as ARN-derived namespaces.
+     */
+    public static String namespaceOf(@Nullable Properties clientProperties) {
+        String region =
+                clientProperties == null
+                        ? null
+                        : clientProperties.getProperty(AWSConfigConstants.AWS_REGION);
+        return region == null ? FALLBACK_NAMESPACE : FALLBACK_NAMESPACE + ":" + region;
+    }
+
+    /** Constructs the dataset name for a Kinesis stream, e.g. {@code stream/my-stream}. */
+    public static String nameOf(String streamName) {
+        return DATASET_NAME_PREFIX + streamName;
+    }
+
+    /** Extracts the stream name from a Kinesis stream ARN. */
+    public static String streamNameOf(String streamArn) {
+        return Arn.fromString(streamArn).resource().resource();
+    }
+
+    /** Builds the lineage dataset for a stream identified by its ARN, without type facet. */
+    public static LineageDataset datasetOf(String streamArn) {
+        return datasetOf(streamArn, null);
+    }
+
+    /**
+     * Builds the lineage dataset for a stream identified by its ARN, attaching the Kinesis facet
+     * and, when available, the type facet carrying the record schema.
+     */
+    public static LineageDataset datasetOf(
+            String streamArn, @Nullable TypeInformation<?> typeInformation) {
+        Arn arn = Arn.fromString(streamArn);
+        String streamName = arn.resource().resource();
+        Map<String, LineageDatasetFacet> facets = new HashMap<>();
+        facets.put(
+                KinesisDatasetFacet.KINESIS_FACET_NAME,
+                new KinesisDatasetFacet(streamArn, streamName, arn.region().orElse(null)));
+        if (typeInformation != null) {
+            facets.put(TypeDatasetFacet.TYPE_FACET_NAME, new TypeDatasetFacet(typeInformation));
+        }
+        return new DefaultLineageDataset(nameOf(streamName), namespaceOf(streamArn), facets);
+    }
+
+    /**
+     * Builds the lineage dataset for a stream known only by name (no ARN), deriving the namespace
+     * region from the client properties when present.
+     */
+    public static LineageDataset datasetOfStreamName(
+            String streamName, @Nullable Properties clientProperties) {
+        String region =
+                clientProperties == null
+                        ? null
+                        : clientProperties.getProperty(AWSConfigConstants.AWS_REGION);
+        Map<String, LineageDatasetFacet> facets = new HashMap<>();
+        facets.put(
+                KinesisDatasetFacet.KINESIS_FACET_NAME,
+                new KinesisDatasetFacet(null, streamName, region));
+        return new DefaultLineageDataset(
+                nameOf(streamName), namespaceOf(clientProperties), facets);
+    }
+
+    /** Wraps datasets in a source lineage vertex. */
+    public static SourceLineageVertex sourceLineageVertexOf(Collection<LineageDataset> datasets) {
+        DefaultSourceLineageVertex vertex =
+                new DefaultSourceLineageVertex(Boundedness.CONTINUOUS_UNBOUNDED);
+        datasets.forEach(vertex::addDataset);
+        return vertex;
+    }
+
+    /** Wraps datasets in a sink lineage vertex. */
+    public static LineageVertex sinkLineageVertexOf(Collection<LineageDataset> datasets) {
+        DefaultLineageVertex vertex = new DefaultLineageVertex();
+        datasets.forEach(vertex::addLineageDataset);
+        return vertex;
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/TypeDatasetFacet.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/lineage/TypeDatasetFacet.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+import java.util.Objects;
+
+/**
+ * Dataset facet containing type/schema information for lineage reporting.
+ *
+ * <p>Wraps the Flink {@link TypeInformation} which contains column names and types when available
+ * (e.g., from RowType schemas).
+ */
+@PublicEvolving
+public class TypeDatasetFacet implements LineageDatasetFacet {
+
+    public static final String TYPE_FACET_NAME = "type";
+
+    private final TypeInformation<?> typeInformation;
+
+    public TypeDatasetFacet(TypeInformation<?> typeInformation) {
+        this.typeInformation = typeInformation;
+    }
+
+    public TypeInformation<?> getTypeInformation() {
+        return typeInformation;
+    }
+
+    @Override
+    public String name() {
+        return TYPE_FACET_NAME;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TypeDatasetFacet that = (TypeDatasetFacet) o;
+        return Objects.equals(typeInformation, that.typeInformation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(typeInformation);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSink.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSink.java
@@ -67,7 +67,8 @@ import java.util.Properties;
  * @param <InputT> Type of the elements handled by this sink
  */
 @PublicEvolving
-public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecordsRequestEntry> {
+public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecordsRequestEntry>
+        implements org.apache.flink.streaming.api.lineage.LineageVertexProvider {
 
     private final boolean failOnError;
     private final String streamName;
@@ -173,5 +174,25 @@ public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecords
                 streamArn,
                 kinesisClientProperties,
                 recoveredState);
+    }
+
+    // ---- Lineage support ----
+
+    @Override
+    public org.apache.flink.streaming.api.lineage.LineageVertex getLineageVertex() {
+        if (streamArn != null) {
+            return org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil
+                    .sinkLineageVertexOf(
+                            java.util.Collections.singletonList(
+                                    org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil
+                                            .datasetOf(streamArn)));
+        }
+        // Fallback when only streamName is provided (no ARN)
+        return org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil.sinkLineageVertexOf(
+                java.util.Collections.singletonList(
+                        new org.apache.flink.streaming.api.lineage.DefaultLineageDataset(
+                                streamName,
+                                "kinesis://unknown-region",
+                                java.util.Collections.emptyMap())));
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSink.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSink.java
@@ -24,7 +24,11 @@ import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.arns.Arn;
@@ -67,7 +71,8 @@ import java.util.Properties;
  * @param <InputT> Type of the elements handled by this sink
  */
 @PublicEvolving
-public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecordsRequestEntry> {
+public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecordsRequestEntry>
+        implements LineageVertexProvider {
 
     private final boolean failOnError;
     private final String streamName;
@@ -173,5 +178,20 @@ public class KinesisStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRecords
                 streamArn,
                 kinesisClientProperties,
                 recoveredState);
+    }
+
+    // ---- Lineage support ----
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        final LineageDataset dataset;
+        if (streamArn != null) {
+            dataset = KinesisLineageUtil.datasetOf(streamArn);
+        } else {
+            // Only the stream name is known; derive the namespace region from the client
+            // properties so the dataset stays under the same namespace scheme.
+            dataset = KinesisLineageUtil.datasetOfStreamName(streamName, kinesisClientProperties);
+        }
+        return KinesisLineageUtil.sinkLineageVertexOf(Collections.singletonList(dataset));
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -105,7 +105,8 @@ import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConf
  */
 @Experimental
 public class KinesisStreamsSource<T>
-        implements Source<T, KinesisShardSplit, KinesisStreamsSourceEnumeratorState> {
+        implements Source<T, KinesisShardSplit, KinesisStreamsSourceEnumeratorState>,
+                org.apache.flink.streaming.api.lineage.LineageVertexProvider {
 
     private final String streamArn;
     private final Configuration sourceConfig;
@@ -353,5 +354,15 @@ public class KinesisStreamsSource<T>
                 .circuitBreakerEnabled(false)
                 .retryOnExceptionOrCauseInstanceOf(LimitExceededException.class)
                 .maxAttempts(maxAttempts);
+    }
+
+    // ---- Lineage support ----
+
+    @Override
+    public org.apache.flink.streaming.api.lineage.SourceLineageVertex getLineageVertex() {
+        return org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil.sourceLineageVertexOf(
+                java.util.Collections.singletonList(
+                        org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil.datasetOf(
+                                streamArn)));
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/source/KinesisStreamsSource.java
@@ -33,6 +33,7 @@ import org.apache.flink.connector.aws.util.AWSClientUtil;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.kinesis.lineage.KinesisLineageUtil;
 import org.apache.flink.connector.kinesis.sink.KinesisStreamsConfigConstants;
 import org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions;
 import org.apache.flink.connector.kinesis.source.enumerator.KinesisShardAssigner;
@@ -54,6 +55,8 @@ import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
 import org.apache.flink.connector.kinesis.source.split.KinesisShardSplitSerializer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.UserCodeClassLoader;
 
@@ -74,6 +77,7 @@ import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -105,7 +109,8 @@ import static org.apache.flink.connector.kinesis.source.config.KinesisSourceConf
  */
 @Experimental
 public class KinesisStreamsSource<T>
-        implements Source<T, KinesisShardSplit, KinesisStreamsSourceEnumeratorState> {
+        implements Source<T, KinesisShardSplit, KinesisStreamsSourceEnumeratorState>,
+                LineageVertexProvider {
 
     private final String streamArn;
     private final Configuration sourceConfig;
@@ -353,5 +358,15 @@ public class KinesisStreamsSource<T>
                 .circuitBreakerEnabled(false)
                 .retryOnExceptionOrCauseInstanceOf(LimitExceededException.class)
                 .maxAttempts(maxAttempts);
+    }
+
+    // ---- Lineage support ----
+
+    @Override
+    public SourceLineageVertex getLineageVertex() {
+        return KinesisLineageUtil.sourceLineageVertexOf(
+                Collections.singletonList(
+                        KinesisLineageUtil.datasetOf(
+                                streamArn, deserializationSchema.getProducedType())));
     }
 }

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSource.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/table/KinesisDynamicSource.java
@@ -19,18 +19,14 @@
 package org.apache.flink.connector.kinesis.table;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
@@ -125,27 +121,17 @@ public class KinesisDynamicSource implements ScanTableSource, SupportsReadingMet
         DeserializationSchema<RowData> deserializationSchema =
                 decodingFormat.createRuntimeDecoder(scanContext, physicalDataType);
 
-        return new DataStreamScanProvider() {
-            @Override
-            public DataStream<RowData> produceDataStream(
-                    ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+        KinesisStreamsSource<RowData> kdsSource =
+                KinesisStreamsSource.<RowData>builder()
+                        .setStreamArn(streamArn)
+                        .setSourceConfig(sourceConfig)
+                        .setDeserializationSchema(deserializationSchema)
+                        .build();
 
-                KinesisStreamsSource<RowData> kdsSource =
-                        KinesisStreamsSource.<RowData>builder()
-                                .setStreamArn(streamArn)
-                                .setSourceConfig(sourceConfig)
-                                .setDeserializationSchema(deserializationSchema)
-                                .build();
-
-                return execEnv.fromSource(
-                        kdsSource, WatermarkStrategy.noWatermarks(), "Kinesis source");
-            }
-
-            @Override
-            public boolean isBounded() {
-                return false;
-            }
-        };
+        // SourceProvider (rather than DataStreamScanProvider) lets the planner extract the
+        // source's lineage: CommonExecTableSourceScan only consults LineageVertexProvider in
+        // its SourceProvider branch.
+        return SourceProvider.of(kdsSource);
     }
 
     @Override

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for Kinesis Streams lineage support. */
+class KinesisLineageTest {
+
+    private static final String TEST_STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:123456789012:stream/my-test-stream";
+
+    @Test
+    void testSourceLineageVertex() {
+        KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .build();
+
+        assertThat(source).isInstanceOf(LineageVertexProvider.class);
+
+        LineageVertex vertex = ((LineageVertexProvider) source).getLineageVertex();
+        assertThat(vertex).isNotNull();
+
+        List<LineageDataset> datasets = vertex.datasets();
+        assertThat(datasets).hasSize(1);
+
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.name()).isEqualTo("my-test-stream");
+        assertThat(dataset.namespace()).isEqualTo("arn:aws:kinesis:us-east-1:123456789012:stream");
+    }
+
+    @Test
+    void testSourceLineageDatasetHasEmptyFacets() {
+        KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .build();
+
+        LineageVertex vertex = ((LineageVertexProvider) source).getLineageVertex();
+        LineageDataset dataset = vertex.datasets().get(0);
+
+        // Facets are added by the table planner / OL module, not the connector
+        assertThat(dataset.facets()).isEmpty();
+    }
+
+    @Test
+    void testSinkLineageVertexWithArn() {
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> "key")
+                        .build();
+
+        assertThat(sink).isInstanceOf(LineageVertexProvider.class);
+
+        LineageVertex vertex = ((LineageVertexProvider) sink).getLineageVertex();
+        assertThat(vertex).isNotNull();
+
+        List<LineageDataset> datasets = vertex.datasets();
+        assertThat(datasets).hasSize(1);
+
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.name()).isEqualTo("my-test-stream");
+        assertThat(dataset.namespace()).isEqualTo("arn:aws:kinesis:us-east-1:123456789012:stream");
+    }
+
+    @Test
+    void testSinkLineageVertexWithNameOnly() {
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamName("name-only-stream")
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> "key")
+                        .build();
+
+        LineageVertex vertex = ((LineageVertexProvider) sink).getLineageVertex();
+        List<LineageDataset> datasets = vertex.datasets();
+
+        assertThat(datasets).hasSize(1);
+        assertThat(datasets.get(0).name()).isEqualTo("name-only-stream");
+        assertThat(datasets.get(0).namespace()).isEqualTo("kinesis://unknown-region");
+    }
+
+    @Test
+    void testLineageUtilNamespaceExtraction() {
+        String namespace = KinesisLineageUtil.namespaceOf(TEST_STREAM_ARN);
+        assertThat(namespace).isEqualTo("arn:aws:kinesis:us-east-1:123456789012:stream");
+    }
+
+    @Test
+    void testLineageUtilStreamNameExtraction() {
+        String streamName = KinesisLineageUtil.streamNameOf(TEST_STREAM_ARN);
+        assertThat(streamName).isEqualTo("my-test-stream");
+    }
+
+    @Test
+    void testLineageUtilDifferentRegions() {
+        String euArn = "arn:aws:kinesis:eu-west-1:999888777666:stream/orders";
+        assertThat(KinesisLineageUtil.namespaceOf(euArn))
+                .isEqualTo("arn:aws:kinesis:eu-west-1:999888777666:stream");
+        assertThat(KinesisLineageUtil.streamNameOf(euArn)).isEqualTo("orders");
+    }
+
+    @Test
+    void testKinesisDatasetFacetEquality() {
+        KinesisDatasetFacet facet1 = new KinesisDatasetFacet(TEST_STREAM_ARN, "stream", "us-east-1");
+        KinesisDatasetFacet facet2 = new KinesisDatasetFacet(TEST_STREAM_ARN, "stream", "us-east-1");
+        KinesisDatasetFacet facet3 =
+                new KinesisDatasetFacet(TEST_STREAM_ARN, "other", "us-west-2");
+
+        assertThat(facet1).isEqualTo(facet2);
+        assertThat(facet1).isNotEqualTo(facet3);
+        assertThat(facet1.name()).isEqualTo(KinesisDatasetFacet.KINESIS_FACET_NAME);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisLineageTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.connector.aws.config.AWSConfigConstants;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for Kinesis Streams lineage support. */
+class KinesisLineageTest {
+
+    private static final String TEST_STREAM_ARN =
+            "arn:aws:kinesis:us-east-1:123456789012:stream/my-test-stream";
+
+    @Test
+    void testSourceLineageVertex() {
+        KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .build();
+
+        assertThat(source).isInstanceOf(LineageVertexProvider.class);
+
+        LineageVertex vertex = ((LineageVertexProvider) source).getLineageVertex();
+        assertThat(vertex).isNotNull();
+
+        List<LineageDataset> datasets = vertex.datasets();
+        assertThat(datasets).hasSize(1);
+
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.name()).isEqualTo("stream/my-test-stream");
+        assertThat(dataset.namespace()).isEqualTo("arn:aws:kinesis:us-east-1:123456789012");
+    }
+
+    @Test
+    void testSourceLineageDatasetFacets() {
+        KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .build();
+
+        LineageVertex vertex = ((LineageVertexProvider) source).getLineageVertex();
+        LineageDataset dataset = vertex.datasets().get(0);
+
+        assertThat(dataset.facets())
+                .containsKeys(
+                        KinesisDatasetFacet.KINESIS_FACET_NAME, TypeDatasetFacet.TYPE_FACET_NAME);
+
+        KinesisDatasetFacet kinesisFacet =
+                (KinesisDatasetFacet) dataset.facets().get(KinesisDatasetFacet.KINESIS_FACET_NAME);
+        assertThat(kinesisFacet.getStreamArn()).isEqualTo(TEST_STREAM_ARN);
+        assertThat(kinesisFacet.getStreamName()).isEqualTo("my-test-stream");
+        assertThat(kinesisFacet.getRegion()).isEqualTo("us-east-1");
+
+        TypeDatasetFacet typeFacet =
+                (TypeDatasetFacet) dataset.facets().get(TypeDatasetFacet.TYPE_FACET_NAME);
+        assertThat(typeFacet.getTypeInformation()).isEqualTo(Types.STRING);
+    }
+
+    @Test
+    void testSinkLineageVertexWithArn() {
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamArn(TEST_STREAM_ARN)
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> "key")
+                        .build();
+
+        assertThat(sink).isInstanceOf(LineageVertexProvider.class);
+
+        LineageVertex vertex = ((LineageVertexProvider) sink).getLineageVertex();
+        assertThat(vertex).isNotNull();
+
+        List<LineageDataset> datasets = vertex.datasets();
+        assertThat(datasets).hasSize(1);
+
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.name()).isEqualTo("stream/my-test-stream");
+        assertThat(dataset.namespace()).isEqualTo("arn:aws:kinesis:us-east-1:123456789012");
+        assertThat(dataset.facets()).containsKey(KinesisDatasetFacet.KINESIS_FACET_NAME);
+    }
+
+    @Test
+    void testSinkLineageVertexWithNameAndRegion() {
+        Properties clientProperties = new Properties();
+        clientProperties.setProperty(AWSConfigConstants.AWS_REGION, "eu-west-1");
+
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamName("name-only-stream")
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> "key")
+                        .setKinesisClientProperties(clientProperties)
+                        .build();
+
+        LineageVertex vertex = ((LineageVertexProvider) sink).getLineageVertex();
+        List<LineageDataset> datasets = vertex.datasets();
+
+        assertThat(datasets).hasSize(1);
+        assertThat(datasets.get(0).name()).isEqualTo("stream/name-only-stream");
+        assertThat(datasets.get(0).namespace()).isEqualTo("arn:aws:kinesis:eu-west-1");
+
+        KinesisDatasetFacet kinesisFacet =
+                (KinesisDatasetFacet)
+                        datasets.get(0).facets().get(KinesisDatasetFacet.KINESIS_FACET_NAME);
+        assertThat(kinesisFacet.getStreamArn()).isNull();
+        assertThat(kinesisFacet.getStreamName()).isEqualTo("name-only-stream");
+        assertThat(kinesisFacet.getRegion()).isEqualTo("eu-west-1");
+    }
+
+    @Test
+    void testSinkLineageVertexWithNameOnly() {
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamName("name-only-stream")
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> "key")
+                        .build();
+
+        LineageVertex vertex = ((LineageVertexProvider) sink).getLineageVertex();
+        List<LineageDataset> datasets = vertex.datasets();
+
+        assertThat(datasets).hasSize(1);
+        assertThat(datasets.get(0).name()).isEqualTo("stream/name-only-stream");
+        assertThat(datasets.get(0).namespace()).isEqualTo("arn:aws:kinesis");
+    }
+
+    @Test
+    void testLineageUtilNamespaceExtraction() {
+        String namespace = KinesisLineageUtil.namespaceOf(TEST_STREAM_ARN);
+        assertThat(namespace).isEqualTo("arn:aws:kinesis:us-east-1:123456789012");
+    }
+
+    @Test
+    void testLineageUtilStreamNameExtraction() {
+        String streamName = KinesisLineageUtil.streamNameOf(TEST_STREAM_ARN);
+        assertThat(streamName).isEqualTo("my-test-stream");
+    }
+
+    @Test
+    void testLineageUtilDifferentRegions() {
+        String euArn = "arn:aws:kinesis:eu-west-1:999888777666:stream/orders";
+        assertThat(KinesisLineageUtil.namespaceOf(euArn))
+                .isEqualTo("arn:aws:kinesis:eu-west-1:999888777666");
+        assertThat(KinesisLineageUtil.streamNameOf(euArn)).isEqualTo("orders");
+        assertThat(KinesisLineageUtil.nameOf("orders")).isEqualTo("stream/orders");
+    }
+
+    @Test
+    void testKinesisDatasetFacetEquality() {
+        KinesisDatasetFacet facet1 =
+                new KinesisDatasetFacet(TEST_STREAM_ARN, "stream", "us-east-1");
+        KinesisDatasetFacet facet2 =
+                new KinesisDatasetFacet(TEST_STREAM_ARN, "stream", "us-east-1");
+        KinesisDatasetFacet facet3 = new KinesisDatasetFacet(TEST_STREAM_ARN, "other", "us-west-2");
+
+        assertThat(facet1).isEqualTo(facet2);
+        assertThat(facet1).isNotEqualTo(facet3);
+        assertThat(facet1.name()).isEqualTo(KinesisDatasetFacet.KINESIS_FACET_NAME);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisStreamsLineageITCase.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/lineage/KinesisStreamsLineageITCase.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
+import org.apache.flink.connector.aws.testutils.LocalstackContainer;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobStatusChangedEvent;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerFactory;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
+import org.apache.flink.streaming.runtime.execution.JobCreatedEvent;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ENDPOINT;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_REGION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.HTTP_PROTOCOL_VERSION;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL_CERTIFICATES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test verifying that jobs using the Kinesis source/sink expose lineage through the
+ * FLIP-314 {@link JobCreatedEvent}, for both the DataStream API and SQL.
+ */
+@Testcontainers
+class KinesisStreamsLineageITCase {
+
+    private static final String LOCALSTACK_DOCKER_IMAGE_VERSION = "localstack/localstack:3.7.2";
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final Region TEST_REGION = Region.AP_SOUTHEAST_1;
+    private static final String EXPECTED_NAMESPACE =
+            String.format("arn:aws:kinesis:%s:%s", TEST_REGION, ACCOUNT_ID);
+
+    // The listener must be registered in the cluster configuration: MiniClusterExecutor creates
+    // JobStatusChangedListeners from MiniCluster.getConfiguration(), not the per-job config.
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(clusterConfiguration())
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    private static Configuration clusterConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                DeploymentOptions.JOB_STATUS_CHANGED_LISTENERS,
+                Collections.singletonList(CapturingLineageListenerFactory.class.getName()));
+        return configuration;
+    }
+
+    @Container
+    private static final LocalstackContainer MOCK_KINESIS_CONTAINER =
+            new LocalstackContainer(DockerImageName.parse(LOCALSTACK_DOCKER_IMAGE_VERSION));
+
+    private SdkHttpClient httpClient;
+    private KinesisClient kinesisClient;
+
+    /** Captures lineage graphs from {@link JobCreatedEvent}s. */
+    public static class CapturingLineageListenerFactory implements JobStatusChangedListenerFactory {
+
+        private static final List<LineageGraph> CAPTURED_GRAPHS = new CopyOnWriteArrayList<>();
+
+        @Override
+        public JobStatusChangedListener createListener(Context context) {
+            return (JobStatusChangedEvent event) -> {
+                if (event instanceof JobCreatedEvent) {
+                    CAPTURED_GRAPHS.add(((JobCreatedEvent) event).lineageGraph());
+                }
+            };
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+        CapturingLineageListenerFactory.CAPTURED_GRAPHS.clear();
+
+        httpClient = AWSServicesTestUtils.createHttpClient();
+        kinesisClient =
+                AWSServicesTestUtils.createAwsSyncClient(
+                        MOCK_KINESIS_CONTAINER.getEndpoint(), httpClient, KinesisClient.builder());
+    }
+
+    @AfterEach
+    void teardown() {
+        System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        AWSGeneralUtil.closeResources(httpClient, kinesisClient);
+    }
+
+    @Test
+    void testDataStreamJobExposesKinesisLineage() throws Exception {
+        String sourceStream = "lineage-ds-source-stream";
+        String sinkStream = "lineage-ds-sink-stream";
+        createStream(sourceStream);
+        createStream(sinkStream);
+
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        KinesisStreamsSource<String> source =
+                KinesisStreamsSource.<String>builder()
+                        .setStreamArn(streamArn(sourceStream))
+                        .setSourceConfig(sourceConfiguration())
+                        .setDeserializationSchema(new SimpleStringSchema())
+                        .build();
+
+        KinesisStreamsSink<String> sink =
+                KinesisStreamsSink.<String>builder()
+                        .setStreamArn(streamArn(sinkStream))
+                        .setSerializationSchema(new SimpleStringSchema())
+                        .setPartitionKeyGenerator(element -> String.valueOf(element.hashCode()))
+                        .setKinesisClientProperties(clientProperties())
+                        .build();
+
+        env.fromSource(
+                        source,
+                        WatermarkStrategy.noWatermarks(),
+                        "kinesis-source",
+                        TypeInformation.of(String.class))
+                .sinkTo(sink);
+
+        JobClient jobClient = env.executeAsync("lineage-datastream-job");
+        try {
+            LineageGraph graph = awaitLineageGraph();
+
+            assertThat(graph.sources()).hasSize(1);
+            LineageDataset sourceDataset = graph.sources().get(0).datasets().get(0);
+            assertThat(sourceDataset.name()).isEqualTo("stream/" + sourceStream);
+            assertThat(sourceDataset.namespace()).isEqualTo(EXPECTED_NAMESPACE);
+            assertThat(sourceDataset.facets())
+                    .containsKeys(
+                            KinesisDatasetFacet.KINESIS_FACET_NAME,
+                            TypeDatasetFacet.TYPE_FACET_NAME);
+
+            assertThat(graph.sinks()).hasSize(1);
+            LineageDataset sinkDataset = graph.sinks().get(0).datasets().get(0);
+            assertThat(sinkDataset.name()).isEqualTo("stream/" + sinkStream);
+            assertThat(sinkDataset.namespace()).isEqualTo(EXPECTED_NAMESPACE);
+            assertThat(sinkDataset.facets()).containsKey(KinesisDatasetFacet.KINESIS_FACET_NAME);
+        } finally {
+            cancelSilently(jobClient);
+        }
+    }
+
+    @Test
+    void testSqlJobExposesKinesisLineage() throws Exception {
+        String sourceStream = "lineage-sql-source-stream";
+        String sinkStream = "lineage-sql-sink-stream";
+        createStream(sourceStream);
+        createStream(sinkStream);
+
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+        tableEnv.executeSql(kinesisTableDdl("source_table", sourceStream));
+        tableEnv.executeSql(kinesisTableDdl("sink_table", sinkStream));
+
+        Optional<JobClient> jobClient =
+                tableEnv.executeSql("INSERT INTO sink_table SELECT * FROM source_table")
+                        .getJobClient();
+        try {
+            LineageGraph graph = awaitLineageGraph();
+
+            // The SQL planner emits catalog-identity dataset names, but merges the physical
+            // source's/sink's connector lineage (namespace + facets) into the datasets. The
+            // source side requires the connector to expose a SourceProvider: the planner only
+            // consults LineageVertexProvider in its SourceProvider branch.
+            assertThat(graph.sources()).hasSize(1);
+            LineageDataset sourceDataset = graph.sources().get(0).datasets().get(0);
+            assertThat(sourceDataset.namespace()).isEqualTo(EXPECTED_NAMESPACE);
+            assertThat(sourceDataset.facets()).containsKey(KinesisDatasetFacet.KINESIS_FACET_NAME);
+            KinesisDatasetFacet sourceFacet =
+                    (KinesisDatasetFacet)
+                            sourceDataset.facets().get(KinesisDatasetFacet.KINESIS_FACET_NAME);
+            assertThat(sourceFacet.getStreamArn()).isEqualTo(streamArn(sourceStream));
+            assertThat(sourceFacet.getStreamName()).isEqualTo(sourceStream);
+
+            assertThat(graph.sinks()).hasSize(1);
+            LineageDataset sinkDataset = graph.sinks().get(0).datasets().get(0);
+            assertThat(sinkDataset.namespace()).isEqualTo(EXPECTED_NAMESPACE);
+            assertThat(sinkDataset.facets()).containsKey(KinesisDatasetFacet.KINESIS_FACET_NAME);
+            KinesisDatasetFacet sinkFacet =
+                    (KinesisDatasetFacet)
+                            sinkDataset.facets().get(KinesisDatasetFacet.KINESIS_FACET_NAME);
+            assertThat(sinkFacet.getStreamArn()).isEqualTo(streamArn(sinkStream));
+            assertThat(sinkFacet.getStreamName()).isEqualTo(sinkStream);
+        } finally {
+            jobClient.ifPresent(this::cancelSilently);
+        }
+    }
+
+    private void cancelSilently(JobClient client) {
+        try {
+            client.cancel().get();
+        } catch (Exception e) {
+            // The job may have already terminated; lineage is captured at submission time.
+        }
+    }
+
+    private Configuration sourceConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.setString(AWS_ENDPOINT, MOCK_KINESIS_CONTAINER.getEndpoint());
+        configuration.setString(AWS_ACCESS_KEY_ID, "accessKeyId");
+        configuration.setString(AWS_SECRET_ACCESS_KEY, "secretAccessKey");
+        configuration.setString(AWS_REGION, TEST_REGION.toString());
+        configuration.setString(TRUST_ALL_CERTIFICATES, "true");
+        configuration.setString(HTTP_PROTOCOL_VERSION, "HTTP1_1");
+        return configuration;
+    }
+
+    private Properties clientProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(AWS_ENDPOINT, MOCK_KINESIS_CONTAINER.getEndpoint());
+        properties.setProperty(AWS_ACCESS_KEY_ID, "accessKeyId");
+        properties.setProperty(AWS_SECRET_ACCESS_KEY, "secretAccessKey");
+        properties.setProperty(AWS_REGION, TEST_REGION.toString());
+        properties.setProperty(TRUST_ALL_CERTIFICATES, "true");
+        properties.setProperty(HTTP_PROTOCOL_VERSION, "HTTP1_1");
+        return properties;
+    }
+
+    private String kinesisTableDdl(String tableName, String streamName) {
+        return String.format(
+                "CREATE TABLE %s (payload STRING) WITH ("
+                        + "'connector' = 'kinesis',"
+                        + "'stream.arn' = '%s',"
+                        + "'aws.region' = '%s',"
+                        + "'aws.endpoint' = '%s',"
+                        + "'aws.credentials.provider' = 'BASIC',"
+                        + "'aws.credentials.basic.accesskeyid' = 'accessKeyId',"
+                        + "'aws.credentials.basic.secretkey' = 'secretAccessKey',"
+                        + "'aws.trust.all.certificates' = 'true',"
+                        + "'format' = 'raw')",
+                tableName, streamArn(streamName), TEST_REGION, MOCK_KINESIS_CONTAINER.getEndpoint());
+    }
+
+    private String streamArn(String streamName) {
+        return String.format(
+                "arn:aws:kinesis:%s:%s:stream/%s", TEST_REGION, ACCOUNT_ID, streamName);
+    }
+
+    private void createStream(String streamName) throws Exception {
+        kinesisClient.createStream(
+                CreateStreamRequest.builder().streamName(streamName).shardCount(1).build());
+
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+        while (!kinesisClient
+                .describeStream(builder -> builder.streamName(streamName))
+                .streamDescription()
+                .streamStatusAsString()
+                .equals("ACTIVE")) {
+            if (deadline.isOverdue()) {
+                throw new AssertionError("Stream " + streamName + " did not become ACTIVE");
+            }
+            Thread.sleep(200);
+        }
+    }
+
+    private LineageGraph awaitLineageGraph() throws InterruptedException {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+        while (CapturingLineageListenerFactory.CAPTURED_GRAPHS.isEmpty()) {
+            if (deadline.isOverdue()) {
+                throw new AssertionError("No JobCreatedEvent lineage graph captured");
+            }
+            Thread.sleep(100);
+        }
+        return CapturingLineageListenerFactory.CAPTURED_GRAPHS.get(
+                CapturingLineageListenerFactory.CAPTURED_GRAPHS.size() - 1);
+    }
+}

--- a/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
+++ b/flink-connector-aws/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSourceFactoryTest.java
@@ -18,23 +18,17 @@
 
 package org.apache.flink.connector.kinesis.table;
 
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.connector.aws.config.AWSConfigOptions;
 import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
 import org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions;
-import org.apache.flink.connector.kinesis.source.enumerator.KinesisStreamsSourceEnumeratorState;
-import org.apache.flink.connector.kinesis.source.split.KinesisShardSplit;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.WatermarkSpec;
-import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
-import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
 import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
@@ -48,7 +42,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -191,24 +184,10 @@ public class KinesisDynamicTableSourceFactoryTest extends TestLogger {
 
     private KinesisStreamsSource<?> assertKinesisStreamsSource(
             ScanTableSource.ScanRuntimeProvider provider) {
-        assertThat(provider).isInstanceOf(DataStreamScanProvider.class);
-        final DataStreamScanProvider dataStreamScanProvider = (DataStreamScanProvider) provider;
-        final Transformation<RowData> transformation =
-                dataStreamScanProvider
-                        .produceDataStream(
-                                n -> Optional.empty(),
-                                StreamExecutionEnvironment.createLocalEnvironment())
-                        .getTransformation();
-        assertThat(transformation).isInstanceOf(SourceTransformation.class);
-        SourceTransformation<RowData, KinesisShardSplit, KinesisStreamsSourceEnumeratorState>
-                sourceTransformation =
-                        (SourceTransformation<
-                                        RowData,
-                                        KinesisShardSplit,
-                                        KinesisStreamsSourceEnumeratorState>)
-                                transformation;
-        assertThat(sourceTransformation.getSource()).isInstanceOf(KinesisStreamsSource.class);
-        return (KinesisStreamsSource<?>) sourceTransformation.getSource();
+        assertThat(provider).isInstanceOf(SourceProvider.class);
+        final SourceProvider sourceProvider = (SourceProvider) provider;
+        assertThat(sourceProvider.createSource()).isInstanceOf(KinesisStreamsSource.class);
+        return (KinesisStreamsSource<?>) sourceProvider.createSource();
     }
 
     private DataType getProducedType(ResolvedSchema schema, RowMetadata... requestedMetadata) {


### PR DESCRIPTION
## Purpose of the change

Implements `LineageVertexProvider` (FLIP-314) on `KinesisStreamsSource` and `KinesisStreamsSink` to enable native lineage extraction in Flink 2.x, e.g. for consumption by the OpenLineage Flink 2.x integration.

This covers both API surfaces:
- **DataStream API**: the source/sink implement `LineageVertexProvider` directly — full dataset identity (namespace, name, facets) surfaces in the `JobCreatedEvent` lineage graph (integration-verified).
- **SQL / Table API**: `KinesisDynamicSource#getScanRuntimeProvider` now returns `SourceProvider.of(kinesisSource)` instead of an anonymous `DataStreamScanProvider`. The planner (`CommonExecTableSourceScan`) only extracts connector lineage in its `SourceProvider` branch, so this switch is what makes SQL scan lineage work; the previous anonymous provider added no behavior beyond what `SourceProvider` gives (no watermark pushdown, no provider-context uid). `KinesisDynamicSink` already wraps the physical sink via `SinkV2Provider`. With both, SQL scan and sink datasets carry the connector namespace and Kinesis facet, with planner-supplied catalog-identity names (integration-verified).

New classes in `org.apache.flink.connector.kinesis.lineage`:
- `KinesisLineageUtil` — dataset namespace/name construction and vertex assembly.
- `KinesisDatasetFacet` — stream ARN, stream name, region metadata (attached to every dataset).
- `TypeDatasetFacet` — record schema via `TypeInformation` (attached on the source, obtained from the deserialization schema).

### Dataset naming

Follows the OpenLineage naming convention for ARN-identified AWS resources (matching the existing AWS Glue precedent — namespace is the ARN prefix, resource type goes in the name):

- namespace: `arn:{partition}:kinesis:{region}:{account}`
- name: `stream/{streamName}`

When the sink is configured with only a stream name (no ARN), the namespace falls back to `arn:aws:kinesis:{region}` (region taken from the client properties' `aws.region`), staying under the same scheme so datasets from both configuration styles correlate.

## Verifying this change

This change added tests and can be verified as follows:

- Added `KinesisLineageTest` (9 unit tests) covering: source vertex dataset identity and facets (Kinesis facet + type facet), sink vertex with ARN, sink fallback with name+region and name-only, namespace/name extraction for multiple regions, and facet equality.
- Added `KinesisStreamsLineageITCase` (Localstack + MiniCluster, 2 tests): submits a real DataStream job and a real SQL `INSERT INTO ... SELECT` job against Localstack Kinesis with a `JobStatusChangedListener` registered, and asserts the FLIP-314 `JobCreatedEvent` lineage graph carries the expected Kinesis dataset identity and facets end-to-end — on both the DataStream path (namespace, `stream/{name}`, kinesis + type facets) and the SQL path (namespace + kinesis facet on scan and sink datasets).
- Updated `KinesisDynamicTableSourceFactoryTest` for the `SourceProvider` switch.
- `mvn test` (module, 226 existing tests + new), `spotless:check`, and `checkstyle:check` pass.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*

- [ ] Dependencies have been added or upgraded
- [x] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented) — JavaDocs
